### PR TITLE
Update version.yml

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Commit & Push
         uses: Andro999b/push@v1.3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.OSUNY_BOT_GITHUB_TOKEN }}
           branch: main
           force: true
           message: 'Write version to file'


### PR DESCRIPTION
La branche `main` étant protégée, on ne peut pas push le nouveau `osuny-version` avec le token de la GitHub Action. On utilise celui d'osuny-bot

Pourquoi on ne peut pas autoriser GitHub Action :
=> https://github.com/orgs/community/discussions/25305