### PR TITLE
Ajout des événements aux formations

### DIFF
--- a/assets/sass/_theme/sections/programs.sass
+++ b/assets/sass/_theme/sections/programs.sass
@@ -155,7 +155,8 @@ ol.programs
             a
             p
                 @include small
-    .related-posts
+    .related-posts,
+    .related-events
         .category-link
             display: block
             text-decoration: none
@@ -163,3 +164,22 @@ ol.programs
             @include hover-translate-icon
             @include media-breakpoint-down(desktop)
                 margin-bottom: $spacing-3
+    .block-events--list
+        @extend .events--list
+        // TODO : REFACTO
+        @include media-breakpoint-up(desktop)
+            .event
+                @include grid(8)
+                &-content
+                    order: 1
+                    grid-column: 6 span
+                    margin-top: $spacing-1
+                &-time
+                    display: inline
+                    &::before
+                        content: ' — '
+                .media
+                    grid-column: 2 span
+    .block-events--grid
+        .grid
+            @extend .events--grid

--- a/config.yaml
+++ b/config.yaml
@@ -107,6 +107,8 @@ params:
   programs:
     related_posts:
       quantity: 4
+    related_events:
+      quantity: 4
   volumes:
     default_image: false
 

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -180,6 +180,8 @@ events:
     day: Jour de fin
     hour: Heure de fin
   unique_day: Date
+  see_all_in_program: Voir tous les événements de la formation
+  title: Événements
 formats:
   pdf: Adobe Portable Document Format
   jpg: JPEG image
@@ -294,7 +296,8 @@ programs:
     essential: Essentiel
     pedagogy: Pédagogie
     presentation: Présentation
-    related: Actualités
+    related_posts: Actualités
+    related_events: Événements
     results: Après la formation
   type:
     apprenticeship: Apprentissage

--- a/layouts/partials/posts/block-posts-layout.html
+++ b/layouts/partials/posts/block-posts-layout.html
@@ -1,13 +1,25 @@
-{{ $layout := site.Params.posts.index.layout | default "list" }}
-<div class="block-posts block-posts--{{- $layout -}}">
+{{ $type := .type }}
+{{ $singularizedType := $type | singularize }}
+{{ $elements := .elements}}
+{{ $layout := index site.Params ($type | index) | default "list" }}
+{{ $layout = $layout.index.layout }}
+
+<div class="block-{{ $type }} block-{{ $type }}--{{- $layout -}}">
   <div class="container">
     <div class="block-content">
       <div class="{{ $layout }}">
-        {{ range .posts }}
-          {{ partial "posts/post.html" (dict 
-            "post" .
-            "heading" "h3"
-            ) }}
+        {{ $partials := dict 
+            "posts" "posts/post.html" 
+            "events" "events/event.html" 
+        }}
+        {{ range .elements }}
+          {{ $currentElement := . }}
+          {{ with index $partials $type }}
+            {{ partial . (dict 
+              $singularizedType $currentElement
+              "heading" "h3"
+            )}}
+          {{ end }}
         {{ end }}
       </div>
     </div>

--- a/layouts/partials/programs/related.html
+++ b/layouts/partials/programs/related.html
@@ -1,18 +1,24 @@
-{{ if .Pages }}
-<section class="related-posts" id="{{ urlize (i18n "programs.toc.related") }}">
+{{ $type := .type }}
+
+{{ if .context.Pages }}
+<section class="related-{{ $type }}" id="{{ urlize (i18n (printf "programs.toc.related_%s" $type)) }}">
   <div class="container">
     <div class="content">
-      <h2 id="page-posts">{{ i18n "posts.title" }}</h2>
+      <h2 id="page-{{ $type }}">{{ i18n (printf "%s.title" $type) }}</h2>
       <a href="{{ .Permalink }}" class="category-link">
         {{ $category_name := safeHTML .Title | truncate 30 }}
-        {{ i18n "posts.see_all_in_program" (dict "Title" $category_name) }}
+        {{ i18n (printf "%s.see_all_in_program" $type) (dict "Title" $category_name) }}
       </a>
 
-      {{/*  Related posts  */}}
-      {{ $posts := first site.Params.programs.related_posts.quantity .Pages }}
-      {{ if gt (len $posts) 0 }}
+      {{/*  Related posts and events  */}}
+      {{$quantity := (index site.Params.programs (printf "related_%s" $type) | default 0).quantity}}
+      {{ $elements := first $quantity .context.Pages }}
+      {{ if gt (len $elements) 0 }}
         <div class="blocks">
-          {{ partial "posts/block-posts-layout.html" (dict "posts" $posts ) }}
+          {{ partial "posts/block-posts-layout.html" (dict
+            "elements" $elements
+            "type" $type
+          ) }}
         </div>
       {{ end }}
     </div>

--- a/layouts/partials/programs/single.html
+++ b/layouts/partials/programs/single.html
@@ -35,8 +35,17 @@
   {{- partial "programs/admission.html" . -}}
   {{- partial "programs/certification.html" . -}}
 
-  {{- $category := site.GetPage (printf "/posts_categories/%s" .Params.related_category ) -}}
-  {{- partial "programs/related.html" $category -}}
+  {{- $posts_category := site.GetPage (printf "/posts_categories/%s" .Params.related_category ) -}}
+  {{ partial "programs/related.html" (dict
+    "context" $posts_category
+    "type" "posts"
+  ) }}
+
+  {{- $events_category := site.GetPage (printf "/events_categories/%s" .Params.related_category ) -}}
+  {{ partial "programs/related.html" (dict
+    "context" $events_category
+    "type" "events"
+  ) }}
 
   {{- partial "hooks/before-program-end.html" . -}}
 </div>

--- a/layouts/partials/programs/single.html
+++ b/layouts/partials/programs/single.html
@@ -35,16 +35,18 @@
   {{- partial "programs/admission.html" . -}}
   {{- partial "programs/certification.html" . -}}
 
-  {{- $posts_category := site.GetPage (printf "/posts_categories/%s" .Params.related_category ) -}}
-  {{ partial "programs/related.html" (dict
-    "context" $posts_category
-    "type" "posts"
-  ) }}
-
+  {{/*  {{ TODO : REFACTO }}  */}}
+  
   {{- $events_category := site.GetPage (printf "/events_categories/%s" .Params.related_category ) -}}
   {{ partial "programs/related.html" (dict
     "context" $events_category
     "type" "events"
+  ) }}
+
+  {{- $posts_category := site.GetPage (printf "/posts_categories/%s" .Params.related_category ) -}}
+  {{ partial "programs/related.html" (dict
+    "context" $posts_category
+    "type" "posts"
   ) }}
 
   {{- partial "hooks/before-program-end.html" . -}}

--- a/layouts/partials/programs/toc.html
+++ b/layouts/partials/programs/toc.html
@@ -19,8 +19,10 @@
 {{ $roles := .context.Params.roles }}
 {{ $contacts := partial "GetTextFromHTML" .context.Params.contacts }}
 
-{{ $category := site.GetPage (printf "/posts_categories/%s" .context.Params.related_category ) }}
-{{ $related_posts := $category.Pages }}
+{{ $posts_category := site.GetPage (printf "/posts_categories/%s" .context.Params.related_category ) }}
+{{ $related_posts := $posts_category.Pages }}
+{{ $events_category := site.GetPage (printf "/events_categories/%s" .context.Params.related_category ) }}
+{{ $related_events := $events_category.Pages }}
 
 {{/* nav-link required for toggle active class */}}
 <nav class="toc" id="nav-toc" aria-label="{{ i18n "commons.toc" }}">
@@ -110,7 +112,12 @@
     {{- end -}}
     {{- if gt (len $related_posts) 0 -}}
       <li>
-        <a href="#{{ urlize (i18n "programs.toc.related") }}">{{ i18n "programs.toc.related" }}</a>
+        <a href="#{{ urlize (i18n "programs.toc.related_posts") }}">{{ i18n "programs.toc.related_posts" }}</a>
+      </li>
+    {{- end -}}
+    {{- if gt (len $related_events) 0 -}}
+      <li>
+        <a href="#{{ urlize (i18n "programs.toc.related_events") }}">{{ i18n "programs.toc.related_events" }}</a>
       </li>
     {{- end -}}
   </ol>


### PR DESCRIPTION
- Utilisation des partials related et block-posts-layout pour ne pas dupliquer de code
- Ajout de config aux programs : 
```
programs:
    related_posts:
      quantity: 4
    related_events:
      quantity: 4
```

TODO : 
- [ ] refacto du css de programs (duplication de code -> d'abord besoin de validation du html & de la méthode)
- [ ] renommer le partial "block-posts-layout" (qui sert maintenant à la fois aux events et aux posts -> related-block-layout ?)
- [ ] ajouter les traductions en anglais (d'abord les valider en fr)

Le résultat : 
![Capture d’écran 2024-04-22 à 10 47 39](https://github.com/osunyorg/theme/assets/91660674/2b78d6cc-171f-4ae0-9079-9c42c9bb0a2e)

NB : Tout comme pour les posts, le layout du bloc passe en grid si grid est set dans les paramètres de l'index des events