### PR TITLE
Fix categories display in event page

### DIFF
--- a/assets/sass/_theme/sections/events.sass
+++ b/assets/sass/_theme/sections/events.sass
@@ -55,8 +55,9 @@
             &::before
                 padding-right: 0.3rem
     .events-categories
-        display: flex
-        gap: $spacing-1
+        li
+            display: inline-block
+            margin-right: $spacing-1
         a
             @include link(var(--color-accent))
     .events-actions


### PR DESCRIPTION
Dans la page d'un événement, avec des catégories au nom long, on avait cet affichage : 
![Capture d’écran 2024-04-22 à 11 09 40](https://github.com/osunyorg/theme/assets/91660674/d494732e-d8b0-443c-aa3b-bf68d2a2b1d0)

Et en mobile : 
![Capture d’écran 2024-04-22 à 11 10 21](https://github.com/osunyorg/theme/assets/91660674/f5e6622b-19f7-4b5a-b6ac-7078f5c4734e)

Ça vient du fait que `.events-categories` a un `display: flex` sans `flex-wrap`.

Soit on ajoute le flex-wrap, qui permet de chasser toute la catégorie lorsqu'elle est trop longue : 
![Capture d’écran 2024-04-22 à 11 09 50](https://github.com/osunyorg/theme/assets/91660674/1a50a344-2b03-45ad-83ad-8fdc5370a4c7)

Soit on ajoute un `display: inline` sur la catégorie pour qu'elles se suivent toutes comme ceci : 
![Capture d’écran 2024-04-22 à 11 15 35](https://github.com/osunyorg/theme/assets/91660674/098caba5-3e2e-42bc-a7b6-5259c78df423)
