### PR TITLE
Refonte du bloc contact

### DIFF
--- a/assets/sass/_theme/blocks/contact.sass
+++ b/assets/sass/_theme/blocks/contact.sass
@@ -67,9 +67,8 @@
         ul
             span
                 width: columns(2)
-                &:first-child
+                &:first-child,
+                &:last-child
                     width: columns(3)
                 &:last-child
                     text-align: right
-                    margin-left: columns(1)
-                    flex: 1

--- a/assets/sass/_theme/blocks/contact.sass
+++ b/assets/sass/_theme/blocks/contact.sass
@@ -15,8 +15,16 @@
             @include h4
         a
             @extend %underline-on-hover
-        + ul
+        .contact-types
+            margin-top: $spacing-3
+            @include media-breakpoint-down(desktop)
+                > div + div
+                    margin-top: $spacing-3
+        + span
+            display: block
             margin-top: $spacing-4
+            + ul
+                margin-top: $spacing-1
     ul
         @include list-reset
         li
@@ -36,13 +44,7 @@
                     &:nth-child(n+2)
                         text-align: right
             @include media-breakpoint-up(desktop)
-                justify-content: space-between
-                span
-                    width: 25%
-                    &:first-child
-                        width: 50%
-                span + span
-                    text-align: right
+                gap: var(--grid-gutter)
     time + time
         @include icon(arrow-right, before)
             display: inline-block
@@ -52,12 +54,21 @@
         .top
             margin-bottom: $spacing-4
         .informations
-            display: flex
-            margin-top: 0
-            address
+            .contact-types
+                @include grid(3)
+        ul
+            span
                 width: columns(4)
-                margin-top: 0
-            ul
-                margin-top: 0
-                width: columns(8)
-                margin-left: var(--grid-gutter)
+
+    @include in-page-with-sidebar
+        .contact-types
+            @include grid(2)
+            row-gap: $spacing-3
+        ul
+            span
+                width: columns(2)
+                &:first-child
+                    width: columns(3)
+                &:last-child
+                    text-align: right
+                    margin-left: columns(1)

--- a/assets/sass/_theme/blocks/contact.sass
+++ b/assets/sass/_theme/blocks/contact.sass
@@ -15,7 +15,7 @@
             @include h4
         a
             @extend %underline-on-hover
-        .contact-types
+        .contacts
             margin-top: $spacing-3
             @include media-breakpoint-down(desktop)
                 > div + div
@@ -54,14 +54,14 @@
         .top
             margin-bottom: $spacing-4
         .informations
-            .contact-types
+            .contacts
                 @include grid(3)
         ul
             span
                 width: columns(4)
 
     @include in-page-with-sidebar
-        .contact-types
+        .contacts
             @include grid(2)
             row-gap: $spacing-3
         ul

--- a/assets/sass/_theme/blocks/contact.sass
+++ b/assets/sass/_theme/blocks/contact.sass
@@ -72,3 +72,4 @@
                 &:last-child
                     text-align: right
                     margin-left: columns(1)
+                    flex: 1

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -90,7 +90,9 @@ commons:
     email: Email
     phone: Phone
     phone_professional: Professional phone
-    website: Site web
+    website: Website
+    web: Web
+    schedule: Hours
   credit: A low impact website crafted with <a href="https://www.osuny.org/" title="Osuny - extern link" target="_blank" rel="noreferrer">Osuny</a>
   date: Date
   download:

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -92,7 +92,7 @@ commons:
     phone_professional: Téléphone professionnel
     website: Site web
     web: Web
-    schedule: Horaires d'ouverture
+    schedule: Horaires
   credit: Un site éco-conçu produit avec <a href="https://www.osuny.org/" title="Osuny - lien externe" target="_blank" rel="noreferrer">Osuny</a>
   date: Date
   download:

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -91,6 +91,8 @@ commons:
     phone: Téléphone
     phone_professional: Téléphone professionnel
     website: Site web
+    web: Web
+    schedule: Horaires d'ouverture
   credit: Un site éco-conçu produit avec <a href="https://www.osuny.org/" title="Osuny - lien externe" target="_blank" rel="noreferrer">Osuny</a>
   date: Date
   download:

--- a/layouts/partials/blocks/templates/contact.html
+++ b/layouts/partials/blocks/templates/contact.html
@@ -19,7 +19,7 @@
             {{ with .information }}
               {{ partial "PrepareHTML" . }}
             {{ end }}
-            <div class="contact-types">
+            <div class="contacts">
               {{ with .address }}
                 {{ if or .address .city .zipcode .country }}
                   <div itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">

--- a/layouts/partials/blocks/templates/contact.html
+++ b/layouts/partials/blocks/templates/contact.html
@@ -25,25 +25,25 @@
                   <div itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
                     <p class="meta">{{- i18n "commons.contact.address" -}}</p>
                     {{ if .address }}
-                    <span itemprop="streetAddress">
-                      {{ partial "PrepareHTML" .address }},
-                    </span>
+                      <span itemprop="streetAddress">
+                        {{ partial "PrepareHTML" .address }},
+                      </span>
+                      <br>
                     {{ end }}
-                    <br>
                     {{ if .city }}
-                    <span itemprop="addressLocality">
-                      {{ partial "PrepareHTML" .city }}
-                    </span>
+                      <span itemprop="addressLocality">
+                        {{ partial "PrepareHTML" .city }}
+                      </span>
                     {{ end }}
                     {{ if .zipcode }}
-                    <span itemprop="postalCode">
-                      {{ partial "PrepareHTML" .zipcode }}
-                    </span>
+                      <span itemprop="postalCode">
+                        {{ partial "PrepareHTML" .zipcode }}
+                      </span>
                     {{ end }}
                     {{ if .country }}
-                    <span itemprop="addressCountry">
-                      {{ partial "PrepareHTML" .country }}
-                    </span>
+                      <span itemprop="addressCountry">
+                        {{ partial "PrepareHTML" .country }}
+                      </span>
                     {{ end }}
                   </div>
                 {{ end }}
@@ -51,11 +51,11 @@
               {{ if or .url .emails }}
                 <div>
                   <p class="meta">{{- i18n "commons.contact.web" -}}</p>
-                  {{ with .url }}
-                    <p><a href="{{ . }}" target="_blank" rel="noreferrer">{{ . }}</a></p>
-                  {{ end }}
                   {{ range .emails }}
                     <p><a itemprop="email" href="mailto:{{ . }}">{{ . }}</a></p>
+                  {{ end }}
+                  {{ with .url }}
+                    <p><a href="{{ . }}" target="_blank" rel="noreferrer">{{ . }}</a></p>
                   {{ end }}
                 </div>
               {{ end }}

--- a/layouts/partials/blocks/templates/contact.html
+++ b/layouts/partials/blocks/templates/contact.html
@@ -19,45 +19,59 @@
             {{ with .information }}
               {{ partial "PrepareHTML" . }}
             {{ end }}
-            {{ with .address }}
-              {{ if or .address .city .zipcode .country }}
-                <div itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
-                  {{ if .address }}
-                  <span itemprop="streetAddress">
-                    {{ partial "PrepareHTML" .address }},
-                  </span>
+            <div class="contact-types">
+              {{ with .address }}
+                {{ if or .address .city .zipcode .country }}
+                  <div itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
+                    <p class="meta">{{- i18n "commons.contact.address" -}}</p>
+                    {{ if .address }}
+                    <span itemprop="streetAddress">
+                      {{ partial "PrepareHTML" .address }},
+                    </span>
+                    {{ end }}
+                    <br>
+                    {{ if .city }}
+                    <span itemprop="addressLocality">
+                      {{ partial "PrepareHTML" .city }}
+                    </span>
+                    {{ end }}
+                    {{ if .zipcode }}
+                    <span itemprop="postalCode">
+                      {{ partial "PrepareHTML" .zipcode }}
+                    </span>
+                    {{ end }}
+                    {{ if .country }}
+                    <span itemprop="addressCountry">
+                      {{ partial "PrepareHTML" .country }}
+                    </span>
+                    {{ end }}
+                  </div>
+                {{ end }}
+              {{ end }}
+              {{ if or .url .emails }}
+                <div>
+                  <p class="meta">{{- i18n "commons.contact.web" -}}</p>
+                  {{ with .url }}
+                    <p><a href="{{ . }}" target="_blank" rel="noreferrer">{{ . }}</a></p>
                   {{ end }}
-                  <br>
-                  {{ if .city }}
-                  <span itemprop="addressLocality">
-                    {{ partial "PrepareHTML" .city }}
-                  </span>
-                  {{ end }}
-                  {{ if .zipcode }}
-                  <span itemprop="postalCode">
-                    {{ partial "PrepareHTML" .zipcode }}
-                  </span>
-                  {{ end }}
-                  {{ if .country }}
-                  <span itemprop="addressCountry">
-                    {{ partial "PrepareHTML" .country }}
-                  </span>
+                  {{ range .emails }}
+                    <p><a itemprop="email" href="mailto:{{ . }}">{{ . }}</a></p>
                   {{ end }}
                 </div>
               {{ end }}
-            {{ end }}
-            {{ with .url }}
-              <p><a href="{{ . }}" target="_blank" rel="noreferrer">{{ . }}</a></p>
-            {{ end }}
-            {{ range .phone_numbers }}
-              <p><a itemprop="telephone" href="tel:{{ . }}">{{ . }}</a></p>
-            {{ end }}
-            {{ range .emails }}
-              <p><a itemprop="email" href="mailto:{{ . }}">{{ . }}</a></p>
-            {{ end }}
+              {{ with .phone_numbers}}
+                <div>
+                  <p class="meta">{{- i18n "commons.contact.phone" -}}</p>
+                  {{ range . }}
+                    <p><a itemprop="telephone" href="tel:{{ . }}">{{ . }}</a></p>
+                  {{ end }}
+                </div>
+              {{ end }}
+            </div>
           </address>
   
           {{ if .timetable}}
+            <span class="meta">{{- i18n "commons.contact.schedule" -}}</span>
             <ul>
                 {{ range .timetable }}
                   {{ if or

--- a/layouts/partials/blocks/templates/contact.html
+++ b/layouts/partials/blocks/templates/contact.html
@@ -59,7 +59,7 @@
                   {{ end }}
                 </div>
               {{ end }}
-              {{ with .phone_numbers}}
+              {{ with .phone_numbers }}
                 <div>
                   <p class="meta">{{- i18n "commons.contact.phone" -}}</p>
                   {{ range . }}


### PR DESCRIPTION
- Ajout d'une div `.contacts` englobant les 3 types de champs (adresse, web et téléphone) pour ajouter une `grid(3)` en pleine page et `grid(2)` en partielle
- Ajout de traductions pour le champ "horaires d'ouverture" (à revoir ou non) et pour celui "web" -> nouveau `span` dans le dom, avant le tableau (`ul`)
- Le tableau prend toute la largeur en pleine page -> gestion de la taille des colonnes avec columns(n)

TO DO : 
- [x] Si traduction fr validée, ajout de celle en

Version mobile : 

![Capture d’écran 2024-04-22 à 12 39 14](https://github.com/osunyorg/theme/assets/91660674/b6a575f0-0ee3-466f-a83e-9acb050c5d9b)
