### PR TITLE
removed html partial from hero figcaption

### DIFF
--- a/layouts/partials/header/hero.html
+++ b/layouts/partials/header/hero.html
@@ -69,7 +69,7 @@
                 aria-label="{{- i18n "commons.lightbox.link.title" -}}">
             </a>
           {{ end }}
-          {{ with partial "GetTextFromHTML" .image.credit }}
+          {{ with .image.credit }}
             <figcaption tabindex="0">
               <div class="credit-content">
                 {{ partial "PrepareHTML" . }}


### PR DESCRIPTION
Dans le hero, les crédits n'affichent plus les liens vers les personnes/entités créditées, à cause de l'appel de `partial "GetTextFromHTML"`.

J'ai retrouvé la trace du commit à partir duquel on utilise ça, mais j'ai du mal à comprendre la raison de l'ajout du partial : [
fix mobile figcaption](https://github.com/osunyorg/theme/commit/9aaa0cabc80fbf3278a664e4cea987fbaab4c80c) (à moins qu'on ait décidé de ne pas afficher les liens ?)

@alexisben tu te souviens ?