### PR TITLE
Fix event dates spacings

### DIFF
--- a/assets/sass/_theme/sections/events.sass
+++ b/assets/sass/_theme/sections/events.sass
@@ -90,6 +90,8 @@
     &-time
         span + span
             @include icon(arrow-right, before)
+                margin-left: space()
+                margin-right: space()
     .media
         &:empty
             display: none
@@ -101,6 +103,9 @@
             &::before
                 content: ' |'
                 margin-right: $spacing-1
+    @include media-breakpoint-up(desktop)
+        &-time
+            display: flex
 .events
     &--list
         .event

--- a/assets/sass/_theme/sections/events.sass
+++ b/assets/sass/_theme/sections/events.sass
@@ -99,7 +99,8 @@
         &-time
             display: inline-flex
             &::before
-                content: '|'
+                content: ' |'
+                margin-left: space()
                 margin-right: $spacing-1
 .events
     &--list

--- a/assets/sass/_theme/sections/events.sass
+++ b/assets/sass/_theme/sections/events.sass
@@ -100,7 +100,6 @@
             display: inline-flex
             &::before
                 content: ' |'
-                margin-left: space()
                 margin-right: $spacing-1
 .events
     &--list

--- a/layouts/partials/events/event.html
+++ b/layouts/partials/events/event.html
@@ -35,7 +35,7 @@
                 <span>{{ .Params.dates.from.hour }}</span>
               {{ end -}}
               {{- if .Params.dates.to.hour }}
-                 <span> {{ .Params.dates.to.hour }}</span>
+                <span>{{ .Params.dates.to.hour }}</span>
               {{ end -}}
             </div>
           {{ end -}}

--- a/layouts/partials/events/event.html
+++ b/layouts/partials/events/event.html
@@ -32,10 +32,10 @@
           {{- if (or .Params.dates.from.hour .Params.dates.to.hour) }}
             <div class="event-time">
               {{- if .Params.dates.from.hour }}
-                <span>{{ .Params.dates.from.hour }}</span> 
+                <span>{{ .Params.dates.from.hour }}</span>
               {{ end -}}
               {{- if .Params.dates.to.hour }}
-                <span> {{ .Params.dates.to.hour }}</span>
+                 <span> {{ .Params.dates.to.hour }}</span>
               {{ end -}}
             </div>
           {{ end -}}

--- a/layouts/partials/events/event.html
+++ b/layouts/partials/events/event.html
@@ -32,7 +32,7 @@
           {{- if (or .Params.dates.from.hour .Params.dates.to.hour) }}
             <div class="event-time">
               {{- if .Params.dates.from.hour }}
-                <span>{{ .Params.dates.from.hour }}</span>
+                <span>{{ .Params.dates.from.hour }}</span> 
               {{ end -}}
               {{- if .Params.dates.to.hour }}
                 <span> {{ .Params.dates.to.hour }}</span>


### PR DESCRIPTION
Le `|` n'est pas assez espacé par rapport au texte à sa gauche (pb signalé par Arnaud pour Osuny-www (`/agenda/`), visible aussi sur Sufficiency Lab (homepage) :

![Capture d’écran 2024-05-02 à 17 18 40](https://github.com/osunyorg/theme/assets/91660674/ce517e43-3739-4389-932d-e5d617e4d2d0)

J'ai donc ajouté un espace insécable comme ceci : `content: ' |'`

Ce qui donne ça : 

![Capture d’écran 2024-05-02 à 17 18 27](https://github.com/osunyorg/theme/assets/91660674/23abff93-34ef-478f-b4dd-4d2655309762)