### PR TITLE
Problème d'affichage du statut des événements

### DIFF
--- a/assets/sass/_theme/sections/events.sass
+++ b/assets/sass/_theme/sections/events.sass
@@ -170,7 +170,7 @@
                     @include grid(10, desktop, 0)
                     order: 1
                     grid-column: 1 / 11
-                    > .event-title, > hgroup, .event-description, .event-categories
+                    > .event-title, > hgroup, .event-description, .event-categories, .event-status
                         grid-column: 5 / 11
                     > .event-dates
                         grid-column: 0 / 5


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

En pleine largeur, les événements en liste voient leur statut revenir à la ligne. En liste pleine largeur on donne à `.content` une `grid(10, desktop)`, et le contenu textuel hors date, à l'intérieur, est placé sur cette grille comme ceci : 
```
> .event-title, > hgroup, .event-description, .event-categories
    grid-column: 5 / 11
``` 
J'ai donc ajouté `.event-status` à cette liste !

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

Issue #407 

## URL de test sur example.osuny.org

`/fr/blocks/blocs-de-liste/agenda-1/#agenda-liste` (pleine largeur)


## URL de test du site (optionnel)

Homepage de [Osuny-www](https://github.com/osunyorg/osuny-www)

## Screenshots

Le problème :
![Capture d’écran 2024-05-03 à 10 18 52](https://github.com/osunyorg/theme/assets/91660674/80d416b5-b832-4988-92d2-e89b71532583)

Avec grid : 
![Capture d’écran 2024-05-03 à 10 18 09](https://github.com/osunyorg/theme/assets/91660674/a6d85cac-f26b-48b8-bfdf-929d392f3ccc)
