### PR TITLE
Ajouter les options de config au bloc des actualités liées à une formation

### DIFF
--- a/layouts/partials/posts/block-posts-layout.html
+++ b/layouts/partials/posts/block-posts-layout.html
@@ -6,6 +6,7 @@
         {{ range .posts }}
           {{ partial "posts/post.html" (dict 
             "post" .
+            "options" .Site.Params.posts.index.options
             "heading" "h3"
             ) }}
         {{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Justin nous a rapporté que les actualités des posts ne contiennent plus que le titre, ce qui est un effet de bord des options du bloc ! Pour remédier à ça, j'ai utilisé les options déterminées en config :

```
posts:
    ...
    index:
      ...
      options:
        hide_image: false
        hide_summary: false
        hide_category: false
        hide_author: false
        hide_date: false
```

En passant le paramètre dans l'appel du partial "post" : `"options" .Site.Params.posts.index.options`, comme ça on est iso entre l'index et ce bloc-là !

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

IUT Bordeaux Montaigne : issue [#97](https://github.com/osunyorg/bordeauxmontaigne-iut/issues/97)

## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)

Sur l'IUT : `/formation/offre-de-formation/metiers-du-livre-et-du-patrimoine/#actualites`
Sur example : `/fr/offre-de-formation/animation-sociale-et-socioculturelle#actualites`

## Screenshots

#### Le problème : 
<img width="1470" alt="Capture d’écran 2024-05-14 à 10 14 17" src="https://github.com/osunyorg/theme/assets/91660674/fd4ffb10-b601-4156-bac5-cf06e99b1326">

#### La solution : 
<img width="1470" alt="Capture d’écran 2024-05-14 à 10 14 44" src="https://github.com/osunyorg/theme/assets/91660674/bc86ec62-e4a4-49fe-bf64-b549172568ab">

### Sur example même situation : 
<img width="1470" alt="Capture d’écran 2024-05-14 à 10 16 03" src="https://github.com/osunyorg/theme/assets/91660674/d5ed514d-bfd2-44bb-bf3d-69b629b77440">

