### PR TITLE
Réparation du lien en haut du bloc événements

### DIFF
--- a/layouts/partials/blocks/templates/agenda.html
+++ b/layouts/partials/blocks/templates/agenda.html
@@ -10,7 +10,7 @@
     <div class="container">
       <div class="block-content">
         {{ $events_page := site.GetPage "/events" }}
-        {{ $link := $events_page.Permalink }}
+        {{ $link := .title_link }}
 
         {{ if .category }}
           {{ $term := site.GetPage (printf "/events_categories%s" .category) }}


### PR DESCRIPTION
## Type

- [x] Bug

## Description

On n'utilisait pas l'info du static pour récupérer le lien en haut du bloc des événement et celui-ci renvoyait donc toujours vers l'index "agenda", même lorsqu'on avait affaire à des archives.

J'ai remplacé `{{ $link := $events_page.Permalink }}` par la donnée du static : `{{ $link := .title_link }}`.

## Niveau d'incidence

- [X] Incidence faible 😌

## Référence (ticket et/ou figma)

N/A

## URL de test sur example.osuny.org

`/fr/blocks/blocs-de-liste/agenda-1/#agenda-grand-categorie`

## URL de test du site (optionnel)

Page d'accueil de En Commun Association ([repo](https://github.com/osunyorg/encommuns-l-association))