### PR TITLE
remove list reset on li error

### DIFF
--- a/assets/sass/_theme/utils/sidebar.sass
+++ b/assets/sass/_theme/utils/sidebar.sass
@@ -97,7 +97,6 @@
         @include link(var(--color-accent))
         text-align: right
     .terms
-        @include list-reset
         margin: 0
         li
             display: inline-block


### PR DESCRIPTION
## Type

- [x] Bug

## Description

Corrige l'erreur de l'application du mixin list-reset sur une balise ```<li>``` 

## Niveau d'incidence

- [x] Incidence faible 😌

## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)

https://www.francoisnemeta.fr/films/2023-10-24-in-bed-with-michel-gondry/

## Screenshots

Un effet de bord force un padding-left 0 sur un li alors qu'il n'a pas de padding par défaut (ça sert à rien, mais ça complique l'application de padding sur le premier li du post-infos) 


<img width="428" alt="image" src="https://github.com/osunyorg/theme/assets/4630530/36e04fee-d8a3-432e-a3be-127bdc664645">


