### PR TITLE
Links block

### DIFF
--- a/assets/sass/_theme/blocks/links.sass
+++ b/assets/sass/_theme/blocks/links.sass
@@ -4,32 +4,33 @@
         @include grid(2, md)
         align-items: flex-start
     li
+        @include icon(link-blank, after, true)
         background-color: $block-lien-card-background
         display: flex
         flex-direction: column-reverse
         justify-content: flex-end
         min-height: pxToRem(130)
         position: relative
+        &::after
+            position: absolute
+            bottom: space(4)
+            right: space(4)
         .link-content
             padding: space(4)
+            line-height: 100%
         a
             @include stretched-link(before)
-            &::after
-                position: absolute
-                bottom: space(4)
-                right: space(4)
+            text-decoration: none
         p
             @include small
-            margin-top: space()
-        figure
+            margin-top: space(3)
+        .media
+            aspect-ratio: 16/9
             position: relative
             img
+                display: block
                 aspect-ratio: 16/9
                 object-fit: cover
-            figcaption
-                text-align: right
-                padding-left: space(4)
-                padding-right: space(4)
     @include in-page-without-sidebar
         .top
             display: flex

--- a/assets/sass/_theme/blocks/links.sass
+++ b/assets/sass/_theme/blocks/links.sass
@@ -22,9 +22,14 @@
             @include small
             margin-top: space()
         figure
+            position: relative
             img
                 aspect-ratio: 16/9
                 object-fit: cover
+            figcaption
+                text-align: right
+                padding-left: space(4)
+                padding-right: space(4)
     @include in-page-without-sidebar
         .top
             display: flex

--- a/assets/sass/_theme/blocks/links.sass
+++ b/assets/sass/_theme/blocks/links.sass
@@ -1,0 +1,42 @@
+.block-links
+    ul
+        @include list-reset
+        @include grid(2, md)
+        align-items: flex-start
+    li
+        background-color: $block-lien-card-background
+        display: flex
+        flex-direction: column-reverse
+        justify-content: flex-end
+        min-height: pxToRem(130)
+        position: relative
+        .link-content
+            padding: space(4)
+        a
+            @include stretched-link(before)
+            &::after
+                position: absolute
+                bottom: space(4)
+                right: space(4)
+        p
+            @include small
+            margin-top: space()
+        figure
+            img
+                aspect-ratio: 16/9
+                object-fit: cover
+    @include in-page-without-sidebar
+        .top
+            display: flex
+            gap: var(--grid-gutter)
+            .block-title
+                width: columns(4)
+            .description
+                flex: 1
+                margin-top: 0
+        ul
+            @include grid(3, md)
+    @include media-breakpoint-down(desktop)
+        ul
+            li + li
+                margin-top: $spacing-3

--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -103,3 +103,6 @@ $block-image-max-height-without-sidebar: none !default
 
 // Block video
 $block-video-background: var(--color-background-alt) !default
+
+// Block liens
+$block-lien-card-background: var(--color-background-alt) !default

--- a/assets/sass/_theme/hugo-osuny.sass
+++ b/assets/sass/_theme/hugo-osuny.sass
@@ -53,6 +53,7 @@
 @import blocks/image
 @import blocks/key_figures
 @import blocks/license
+@import blocks/links
 @import blocks/organizations
 @import blocks/pages
 @import blocks/persons

--- a/config.yaml
+++ b/config.yaml
@@ -168,6 +168,10 @@ params:
         mobile:   480x850
         tablet:   768x1360
         desktop:  1920x1920
+      links:
+        mobile:   350
+        tablet:   400
+        desktop:  750
       organizations:
         mobile:   164
         tablet:   216

--- a/layouts/partials/blocks/templates/links.html
+++ b/layouts/partials/blocks/templates/links.html
@@ -34,7 +34,7 @@
                     (dict
                       "image"    .image
                       "alt"      .alt
-                      "sizes"    site.Params.image_sizes.blocks.features
+                      "sizes"    site.Params.image_sizes.blocks.links
                   ) -}}
                   {{- if .credit -}}
                     <figcaption>

--- a/layouts/partials/blocks/templates/links.html
+++ b/layouts/partials/blocks/templates/links.html
@@ -1,0 +1,52 @@
+{{- $block := .block -}}
+{{- $block_class := partial "GetBlockClass" .block -}}
+
+{{- with .block.data -}}
+  <div class="{{ $block_class }}">
+    <div class="container">
+      <div class="block-content">
+        {{ partial "blocks/top.html" (dict
+          "title" $block.title
+          "heading_level" $block.ranks.self
+          "description" .description
+        )}}
+        
+        <ul class="links">
+          {{- range .links }}
+            <li>
+              <div class="link-content">
+                {{- $title := partial "PrepareHTML" .title -}}
+                {{- $url := .url -}}
+                <a href="{{ .url }}"
+                  {{ if .target_blank }}
+                    title="{{ i18n "commons.link.blank_aria" (dict "Title" $title) }}"
+                    target="_blank"
+                  {{ else }}
+                    title="{{ $title }}"
+                  {{ end }}
+                  >{{- $title -}}
+                </a>
+                <p>{{ .description | safeHTML }}</p>
+              </div>
+              {{- if .image -}}
+                <figure>
+                  {{- partial "commons/image.html"
+                    (dict
+                      "image"    .image
+                      "alt"      .alt
+                      "sizes"    site.Params.image_sizes.blocks.features
+                  ) -}}
+                  {{- if .credit -}}
+                    <figcaption>
+                      {{ partial "PrepareHTML" .credit }}
+                    </figcaption>
+                  {{- end -}}
+                </figure>
+              {{- end -}}
+            </li>
+          {{ end -}}
+        </ul>
+      </div>
+    </div>
+  </div>
+{{- end -}}

--- a/layouts/partials/blocks/templates/links.html
+++ b/layouts/partials/blocks/templates/links.html
@@ -13,35 +13,23 @@
         
         <ul class="links">
           {{- range .links }}
-            <li>
+            <li itemscope itemtype="https://schema.org/WebPage">
               <div class="link-content">
                 {{- $title := partial "PrepareHTML" .title -}}
                 {{- $url := .url -}}
-                <a href="{{ .url }}"
-                  {{ if .target_blank }}
-                    title="{{ i18n "commons.link.blank_aria" (dict "Title" $title) }}"
-                    target="_blank"
-                  {{ else }}
-                    title="{{ $title }}"
-                  {{ end }}
-                  >{{- $title -}}
-                </a>
+                <link itemprop="url" href="{{ .url }}">
+                <a itemprop="relatedLink" href="{{ .url }}" title="{{ $title }}"><span itemprop="name">{{- $title -}}</span></a>
                 <p>{{ .description | safeHTML }}</p>
               </div>
               {{- if .image -}}
-                <figure>
+                <div class="media">
                   {{- partial "commons/image.html"
                     (dict
                       "image"    .image
                       "alt"      .alt
                       "sizes"    site.Params.image_sizes.blocks.links
                   ) -}}
-                  {{- if .credit -}}
-                    <figcaption>
-                      {{ partial "PrepareHTML" .credit }}
-                    </figcaption>
-                  {{- end -}}
-                </figure>
+                </div>
               {{- end -}}
             </li>
           {{ end -}}


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout du bloc "liens" au thème. 

Reste à faire : 
- [x] Les crédits des images
- [ ] Valider l'alignement des blocs lorsqu'il n'y a pas tout le temps des images (cf. screens plus bas)

Je me suis fondée sur plusieurs autres blocs pour établir le schéma de données, n'hésitez pas à me dire s'il peut être amélioré : 

```
- kind: block
    template: links
    title: >-
      Le bloc de liens
      
    ranks:
      self: false
    data:
      description: >-
        <p>Quelques liens pour tester</p>

      links:
        
      - title: >-
          Espace Numérique de Travail

        description: >-
          Espace Numérique de Travail des Personnels (ENTP) Université Bordeaux Montaigne

        url: >-
          https://support.osuny.org/

        target_blank: true

        alt: >-
          
        credit: >-
          
        
      - title: >-
          Messagerie

        description: >-
          Webmail de l’Université

        url: >-
          https://www.noesya.coop/

        target_blank: true

        image:
          id: "99fb2adb-d07e-435f-870e-0723cdebe899"
          file: "99fb2adb-d07e-435f-870e-0723cdebe899"

        alt: >-
          
        credit: >-
          <p>Daniel Faro<br>Death to stock</p>

      - title: >-
          Mon compte IUT

        description: >-
          
        url: >-
          https://support.osuny.org/

        target_blank: true

        alt: >-
          
        credit: >-
```

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

[FIGMA](https://www.figma.com/design/tQh3oLfNwSt8aoVDuUjQt0/Th%C3%A8me-Osuny?node-id=11867%3A217&t=sPcVe5lnfdGIRRki-1) | Nécessité pour EPV qui nous a relancé sur le sujet

## URL de test sur example.osuny.org

N/A il faut pour le moment copier le schéma ci-dessus et le mettre dans une page d'example.

## URL de test du site (optionnel)

N/A

## Screenshots

### À discuter

@arnaudlevy je veux bien ton avis pour l'alignement des blocs, s'il te plaît, j'ai du mal à arbitrer entre deux situations (ou +, je n'ai pas fait d'autres tests) concernant le cas où on a un lien sans image suivi d'un lien avec image : 

**Une première possibilité :**

<img width="1470" alt="Capture d’écran 2024-05-17 à 11 07 39" src="https://github.com/osunyorg/theme/assets/91660674/f1cbb79b-2b0a-438c-9dd5-9e3a478c07b7">

**Une autre :**

<img width="1470" alt="Capture d’écran 2024-05-17 à 11 07 30" src="https://github.com/osunyorg/theme/assets/91660674/44eee552-4d1b-477a-bdf7-a117e79525cd">

Je rajouterai des captures d'écran quand le crédit sera bien intégré.