### PR TITLE
Block links hover

### DIFF
--- a/assets/sass/_theme/blocks/links.sass
+++ b/assets/sass/_theme/blocks/links.sass
@@ -4,23 +4,24 @@
         @include grid(2, md)
         align-items: flex-start
     li
-        @include icon(link-blank, after, true)
         background-color: $block-lien-card-background
+        color: $block-lien-card-color
         display: flex
         flex-direction: column-reverse
         justify-content: flex-end
-        min-height: pxToRem(130)
         position: relative
-        &::after
-            position: absolute
-            bottom: space(4)
-            right: space(4)
+        transition: background 0.3s ease
         .link-content
-            padding: space(4)
             line-height: 100%
+            min-height: pxToRem(130)
+            padding: space(4)
         a
             @include stretched-link(before)
             text-decoration: none
+            &::after
+                bottom: space(4)
+                position: absolute
+                right: space(4)
         p
             @include small
             margin-top: space(3)
@@ -31,6 +32,10 @@
                 display: block
                 aspect-ratio: 16/9
                 object-fit: cover
+        &:hover
+            background-color: $block-lien-card-hover-background
+            &, a
+                color: $block-lien-card-hover-color
     @include in-page-without-sidebar
         .top
             display: flex

--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -107,5 +107,5 @@ $block-video-background: var(--color-background-alt) !default
 // Block liens
 $block-lien-card-background: var(--color-background-alt) !default
 $block-lien-card-color: var(--color-text) !default
-$block-lien-card-hover-background: var(--color-accent)
+$block-lien-card-hover-background: var(--color-accent) !default
 $block-lien-card-hover-color: var(--color-background) !default

--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -106,3 +106,6 @@ $block-video-background: var(--color-background-alt) !default
 
 // Block liens
 $block-lien-card-background: var(--color-background-alt) !default
+$block-lien-card-color: var(--color-text) !default
+$block-lien-card-hover-background: var(--color-accent)
+$block-lien-card-hover-color: var(--color-background) !default


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Ajout d'un effet au hover des liens (avec nouvelles variables) + fix l'icon du target blank

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

Fix #420

## URL de test du site (optionnel)

`http://localhost:1313/fr/blocks/blocks-techniques/liens/`

## Screenshots

<img width="942" alt="Capture d’écran 2024-05-17 à 19 10 03" src="https://github.com/osunyorg/theme/assets/91660674/ea0aa268-172a-456d-8904-c07aae2bd34a">

<img width="966" alt="Capture d’écran 2024-05-17 à 19 10 22" src="https://github.com/osunyorg/theme/assets/91660674/b4e45b70-5590-4ed1-be4b-8148e9484c8c">
