### PR TITLE
Problème d'affichage du bloc lien en format tablette

### DIFF
--- a/assets/sass/_theme/blocks/links.sass
+++ b/assets/sass/_theme/blocks/links.sass
@@ -47,7 +47,7 @@
                 margin-top: 0
         ul
             @include grid(3, md)
-    @include media-breakpoint-down(desktop)
+    @include media-breakpoint-down(md)
         ul
             li + li
                 margin-top: $spacing-3


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Petit fix du bloc lien, le breakpoint n'était pas le bon !

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

#422 

## URL de test sur example.osuny.org

`https://example.osuny.org/fr/blocks/blocks-techniques/liens/`

## URL de test du site (optionnel)

`https://www.iut.u-bordeaux-montaigne.fr/intranet/`

## Screenshots

### Tablette : 
<img width="762" alt="Capture d’écran 2024-05-21 à 10 20 37" src="https://github.com/osunyorg/theme/assets/91660674/8645e51b-7a88-4280-9084-d1294d28b12b">

### Mobile : 
<img width="368" alt="Capture d’écran 2024-05-21 à 10 20 26" src="https://github.com/osunyorg/theme/assets/91660674/32f1621f-01ae-4ab0-a527-8ece3cf62429">


