### PR TITLE
Bloc de liste des publications

### DIFF
--- a/assets/sass/_theme/blocks/publications.sass
+++ b/assets/sass/_theme/blocks/publications.sass
@@ -1,0 +1,11 @@
+.block-publications
+    @include in-page-without-sidebar
+        .block-content
+            @include grid(2, desktop)
+            .publications
+                margin-top: 0
+                .publication:first-of-type
+                    padding-top: 0
+            .description
+                @include h2
+                margin-top: $spacing-4

--- a/assets/sass/_theme/hugo-osuny.sass
+++ b/assets/sass/_theme/hugo-osuny.sass
@@ -60,6 +60,7 @@
 @import blocks/posts
 @import blocks/projects
 @import blocks/programs
+@import blocks/publications
 @import blocks/sitemap
 @import blocks/sound
 @import blocks/summary

--- a/assets/sass/_theme/sections/publications.sass
+++ b/assets/sass/_theme/sections/publications.sass
@@ -20,19 +20,28 @@
     @include icon-block(arrow-right, before)
         position: absolute
         right: 0px
+        top: 50%
+        transform: translateY(-50%)
     a
         text-decoration: none
-    .publication-title
-        a
-            @include stretched-link(after)
-            &:hover
-                color: var(--color-accent)
-    .publication-meta
-        @include small
-        color: var(--color-text-alt)
-        margin-top: $spacing-1
-        a
+    .publication-content
+        display: flex
+        flex-direction: column
+        .publication-authors
+            order: -1
+            margin-bottom: space()
+        .publication-title
+            a
+                @include stretched-link(after)
+        .publication-meta
+            @include small
             color: var(--color-text-alt)
+            margin-top: $spacing-1
+            a
+                color: var(--color-text-alt)
+    &:hover
+        a, &::before
+            color: var(--color-accent)
     @include media-breakpoint-down(desktop)
         .publication-meta
             padding-right: $spacing-4

--- a/layouts/partials/blocks/templates/publications.html
+++ b/layouts/partials/blocks/templates/publications.html
@@ -1,0 +1,54 @@
+{{ $heading_level := .heading_level | default 3 }}
+{{ $heading := printf "h%d" $heading_level }}
+{{ $heading_tag := (dict 
+  "open" ((printf "<%s class='publication-title' itemprop='headline'>" $heading) | safeHTML)
+  "close" ((printf "</%s>" $heading) | safeHTML)
+  ) }}
+  
+{{- $block := .block -}}
+{{- $template := .block.template -}}
+{{- $position := .block.position -}}
+{{- $title := .block.title -}}
+
+{{- with .block.data -}}
+
+  <div class="block block-publications {{- if $title }} block-with-title {{- end -}}">
+    <div class="container">
+      <div class="block-content">
+        {{ partial "blocks/top.html" (dict
+          "title" $block.title
+          "heading_level" $block.ranks.self
+          "description" .description
+        )}}
+
+        <div class="publications">
+          {{ range $publication := .publications -}}
+            {{ with site.GetPage (printf "/publications/%s" $publication) }}
+              <article class="publication" itemscope itemtype="http://schema.org/ScholarlyArticle">
+                <div class="publication-content">
+                  {{- $title := partial "PrepareHTML" .Title -}}
+
+                  {{ $heading_tag.open }}
+                    <a href="{{ .Permalink }}" title="{{ safeHTML (i18n "commons.more_aria" (dict "Title" $title)) }}">{{ $title }}</a>
+                  {{ $heading_tag.close }}
+
+                  {{ with .Params.authors_list }}
+                    <div class="publication-authors">
+                      <span itemprop="author">{{ . }}</span>
+                    </div>
+                  {{ end }}
+
+                  {{ with .Params.ref }}
+                    <div class="publication-meta" itemprop="isPartOf" itemscope itemtype="http://schema.org/PublicationIssue">
+                      <span itemprop="name">{{ . }}</span>
+                    </div>
+                  {{ end }}
+                </div>
+              </article>  
+            {{ end}}
+          {{ end}}
+        </div>
+      </div>
+    </div>
+  </div>
+{{- end -}}


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout du bloc listant les publications au thème + reprise légère du style déjà préparé pour l'index.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

Pas de page, il faut ajouter des données à un endroit : 

```
- kind: block
    template: publications
    title: >-
      Toutes les actualités - Liste
    ranks:
      self: 2
      children: 3
    data:
      description: >-
        Lorem ipsum dolor sit amet consectetur. Laoreet donec vulputate lorem pellentesque nisl non sapien. Vulputate blandit aliquet tellus pretium vel massa maecenas. Porttitor praesent vulputate congue nisl fringilla.
      publications:
        - "2019/universite-pedagogie-innovation-cherchez-l-intrus"
```

## Screenshots

### Avec sidebar :
<img width="1470" alt="Capture d’écran 2024-05-22 à 11 39 41" src="https://github.com/osunyorg/theme/assets/91660674/d308a9ce-365d-4d19-ab0a-95ea07c78965">

### Au survol : 
<img width="934" alt="Capture d’écran 2024-05-22 à 11 39 48" src="https://github.com/osunyorg/theme/assets/91660674/26a3a096-8564-4e37-9df7-cb48a28be443">

### Pleine largeur : 

<img width="1470" alt="Capture d’écran 2024-05-22 à 11 39 18" src="https://github.com/osunyorg/theme/assets/91660674/24f13155-c063-461c-90e2-38e6a26df34c">

### Mobile : 
<img width="371" alt="Capture d’écran 2024-05-22 à 13 19 37" src="https://github.com/osunyorg/theme/assets/91660674/94c4bf35-a6e6-4dc4-a190-65fead6c66bf">

