### PR TITLE
Application du mixin "small" dans les notes de chapitre

### DIFF
--- a/assets/sass/_theme/blocks/chapter.sass
+++ b/assets/sass/_theme/blocks/chapter.sass
@@ -3,8 +3,7 @@
         margin-bottom: 0
     .notes
         margin-top: $spacing-3
-        *
-            @include small(false)
+        @include small
         sub, sup
             font-size: 60%
             margin-left: 0

--- a/assets/sass/_theme/blocks/chapter.sass
+++ b/assets/sass/_theme/blocks/chapter.sass
@@ -2,8 +2,8 @@
     p:last-child
         margin-bottom: 0
     .notes
-        margin-top: $spacing-3
         @include small
+        margin-top: $spacing-3
         sub, sup
             font-size: 60%
             margin-left: 0

--- a/assets/sass/_theme/blocks/chapter.sass
+++ b/assets/sass/_theme/blocks/chapter.sass
@@ -4,7 +4,7 @@
     .notes
         margin-top: $spacing-3
         *
-            @include small
+            @include small(false)
         sub, sup
             font-size: 60%
             margin-left: 0

--- a/assets/sass/_theme/design-system/typography.sass
+++ b/assets/sass/_theme/design-system/typography.sass
@@ -137,11 +137,12 @@ h2, .h2
 .signature
     @include signature
 
-@mixin small
+@mixin small($apply_weight: true)
     font-family: $small-font-family
     font-size: var(--small-size)
-    font-weight: $small-weight
     line-height: var(--small-line-height)
+    @if $apply_weight
+        font-weight: $small-weight
 
 small, .small
     @include small

--- a/assets/sass/_theme/design-system/typography.sass
+++ b/assets/sass/_theme/design-system/typography.sass
@@ -137,12 +137,11 @@ h2, .h2
 .signature
     @include signature
 
-@mixin small($apply_weight: true)
+@mixin small
     font-family: $small-font-family
     font-size: var(--small-size)
     line-height: var(--small-line-height)
-    @if $apply_weight
-        font-weight: $small-weight
+    font-weight: $small-weight
 
 small, .small
     @include small


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Explications ici : #430 

Au départ j'ai pensé qu'il fallait ajouter un paramètre au mixin, avant de réaliser que c'est surtout l'endroit où il est appliqué qui pose problème. Le `<b>` était écrasé parce que le mixin s'appliquait à `.notes *`, ce qui écrase tout.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [X] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`/fr/blocks/blocks-de-base/chapitres/`

## Screenshots

### Sans le fix : 
<img width="971" alt="Capture d’écran 2024-05-22 à 17 46 01" src="https://github.com/osunyorg/theme/assets/91660674/fa4acda2-844e-44d9-b538-c76ce8cb12e8">

### Avec le fix
<img width="938" alt="Capture d’écran 2024-05-22 à 17 45 46" src="https://github.com/osunyorg/theme/assets/91660674/b3b1fb9b-9242-4dd3-9104-16068adb7a18">