### PR TITLE
Affichage des metas des actualités en layout "large"

### DIFF
--- a/assets/sass/_theme/blocks/posts.sass
+++ b/assets/sass/_theme/blocks/posts.sass
@@ -51,15 +51,8 @@
                 time
                     vertical-align: baseline
                 .post-author
-                    display: inline
-                    p
+                    &, p
                         display: inline
-            .post-categories 
-                display: inline
-                *
-                    display: inline-block
-                li
-                    margin-right: $spacing-2
             // Désactiver le ratio forcé de la configuration $article-media-aspect-ratio
             .media
                 &, img
@@ -70,6 +63,11 @@
                     margin-top: $spacing-4
                 p[itemprop="articleBody"]
                     margin-top: 0
+                .post-author 
+                    margin-right: 0
+                    + time
+                        &::before
+                            content: ' • '
         @include media-breakpoint-up(desktop)
             .large
                 .post
@@ -81,8 +79,13 @@
                         @include h2
                     p[itemprop="articleBody"]
                         margin-top: $spacing-3
-                    .post-categories
+                    &-categories
+                    &-categories 
+                        display: inline
+                        *
+                            display: inline-block
                         li
+                            margin-right: $spacing-2
                             a
                                 display: inline
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Le layout large des actualités, en mobile, affichait les meta de façon un peu bancales. J'ai un petit peu repris les autres design pour afficher auteur/date et catégories en dessous.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [X] Incidence moyenne 😲 (en vrai peut-être forte ?)
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

Pb d'affichage remonté par Alexis sur [EnCommun (site)](https://www.encommuns.net/)

## URL de test sur example.osuny.org

Page des blocs d'actualités

## URL de test du site (optionnel)

Home de EnCommun (site)

## Screenshots

![Capture d’écran 2024-05-24 à 10 22 17](https://github.com/osunyorg/theme/assets/91660674/b634042d-7d7a-4b06-98a9-58798b1e617d) ![Capture d’écran 2024-05-24 à 10 42 09](https://github.com/osunyorg/theme/assets/91660674/3fe7c9a4-7077-4982-8b96-a5c4b60a8088)
