### PR TITLE
Ajout de la prise en compte d'un booléen "external" aux liens du bloc de liens

### DIFF
--- a/layouts/partials/blocks/templates/links.html
+++ b/layouts/partials/blocks/templates/links.html
@@ -17,8 +17,9 @@
               <div class="link-content">
                 {{- $title := partial "PrepareHTML" .title -}}
                 {{- $url := .url -}}
+                {{- $isExternal := .external | default true -}}
                 <link itemprop="url" href="{{ .url }}">
-                <a itemprop="relatedLink" href="{{ .url }}" title="{{ $title }}" target="_blank"><span itemprop="name">{{- $title -}}</span></a>
+                <a itemprop="relatedLink" href="{{ .url }}" title="{{ $title }}" {{ if $isExternal -}} target="_blank" {{- end }}><span itemprop="name">{{- $title -}}</span></a>
                 <p>{{ .description | safeHTML }}</p>
               </div>
               {{- if .image -}}


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

On a besoin d'ajouter la possibilité de signaler si un lien est externe ou non. Pour cela, j'utilise une variable qui vérifie la présence du paramètre, et pour s'assurer de la rétrocompatibilité du bloc, sa valeur par défaut (s'il n'y a pas le paramètre) est "true". La valeur du booléen sert à appliquer ou non le `target="_blank"` au lien.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [X] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

C'est une demande de la Criée.

## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/blocks-techniques/liens/`
(Pour tester il faut ajouter `external: true/false` aux liens du bloc