### PR TITLE
Stretched-link sur l'article entier dans le bloc campus

### DIFF
--- a/assets/sass/_theme/blocks/programs.sass
+++ b/assets/sass/_theme/blocks/programs.sass
@@ -1,5 +1,6 @@
 .block-programs
-
+    article
+        position: relative
     &--list
         .programs
             li
@@ -27,7 +28,6 @@
                 flex-direction: column
                 .program-content
                     order: 2
-                    position: relative
                     &:hover
                         .more:after
                             transform: translateX($spacing-1)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Le `stretched-link` du bloc campus en grid ne fonctionne pas à cause d'un `position: relative` sur le contenu du texte. J'ai déplacé la position vers l'article entier.

Ça se teste sur example ici : `http://localhost:1313/fr/blocks/blocs-de-liste/programmes/`

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱