### PR TITLE
Bloc contact : ajustement de la largeur des colonnes

### DIFF
--- a/assets/sass/_theme/blocks/contact.sass
+++ b/assets/sass/_theme/blocks/contact.sass
@@ -67,8 +67,7 @@
         ul
             span
                 width: columns(2)
-                &:first-child,
-                &:last-child
-                    width: columns(3)
+                &:first-child
+                    width: columns(4)
                 &:last-child
                     text-align: right


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

J'ai changé la taille de la première colonne (intitulés) du tableau d'horaires pour correspondre à l'ajustement de la maquette : la première fait 4 colonnes et les deux autres 2 (c'est un fix uniquement en page avec sidebar).

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

![Capture d’écran 2024-05-29 à 10 00 11](https://github.com/osunyorg/theme/assets/91660674/b9b987a0-db76-4458-87fa-9b8b5f51b3d6)

## URL de test sur example.osuny.org

Page du bloc contact : `/fr/blocks/blocks-techniques/contact/`

## URL de test du site (optionnel)

Sur l'IUT de Bordeaux ([repo](https://github.com/osunyorg/bordeaux-iut-de-bordeaux)) : `/formations/se-former-tout-au-long-de-la-vie/`

## Screenshots

### La souci d'affichage : 
![Capture d’écran 2024-05-29 à 10 05 25](https://github.com/osunyorg/theme/assets/91660674/07c426ea-5552-421e-9160-fba0a959c168)

### Avec le fix : 
![Capture d’écran 2024-05-29 à 10 05 18](https://github.com/osunyorg/theme/assets/91660674/c25539ba-63da-486a-9d0f-9b0fccab075b)