### PR TITLE
Bloc Contact : label "Email"

### DIFF
--- a/layouts/partials/blocks/templates/contact.html
+++ b/layouts/partials/blocks/templates/contact.html
@@ -50,7 +50,14 @@
               {{ end }}
               {{ if or .url .emails }}
                 <div>
-                  <p class="meta">{{- i18n "commons.contact.web" -}}</p>
+                  <p class="meta">
+                    {{ if .url }}
+                      {{- i18n "commons.contact.web" -}}
+                    {{ else }}
+                      {{- i18n "commons.contact.email" -}}
+                    {{ end }}
+                  </p>
+                  
                   {{ range .emails }}
                     <p><a itemprop="email" href="mailto:{{ . }}">{{ . }}</a></p>
                   {{ end }}


### PR DESCRIPTION
## Type

- [x] Ajustement

## Description

Dans le bloc Contact, afficher le label "web" uniquement si un lien est rempli, sinon, afficher le label "Email".

## Niveau d'incidence

- [x] Incidence faible 😌

## Référence (ticket et/ou figma)

[commentaire figma](https://click.figma.com/ls/click?upn=u001.Y4GnNWhdnCDA1MWI-2FhIyfOSqzSOOn-2BuE-2BZrF9-2BcnUGiivhcOhY3M9uAFq63kbTUtR394Qn5A4XzkUEvl-2ByqtsXLJZaLJE2JJI4LfeNhC0zIiTakbYQUpIeCnyTOPnRKR2STYX54eAoX9zuDLEHWBXw-3D-3D3T3f_8nN-2FTMUUBzCRm0ClTbTnSMekcNt7CK-2BCzePoXnGa-2B6OCOUXRzwRMDikAeH0ccdDFy77zPVarNcY3pmXakTZjjNjeGHhWckeNe6IiOY6gzDWHnOKQ9DN5EMg3NcRYJ15NIIZH-2B5ei-2BVRNAH95KdfNtxAcf4jRceuC4QcXYySb-2FnkNzNLYVHQkndm4apzmXBwOAC8surIijk1pbO12kRiWqCnGosHGrxPbf0dg2AO143Q01NnPcL-2BBkX0OHPqDk-2F80GRZX-2FWu-2BKbuhReXLFotocA-3D-3D)


## Screenshots

Sans lien web :
![image](https://github.com/osunyorg/theme/assets/4630530/96e2eede-c3a4-4cf3-94a8-fd5f6668b17e)

Avec lien web et email :
![image](https://github.com/osunyorg/theme/assets/4630530/aac3dd1d-9e35-4649-b4fa-b36e52b27d13)

Avec lien web sans email :
![image](https://github.com/osunyorg/theme/assets/4630530/aa9308a6-28cf-4020-b614-00020e1497ba)


