### PR TITLE
Taille du bouton de partage dans les programmes

### DIFF
--- a/assets/sass/_theme/sections/diplomas.sass
+++ b/assets/sass/_theme/sections/diplomas.sass
@@ -126,14 +126,16 @@ ul.diplomas
         @include media-breakpoint-down(md)
             gap: $spacing-3
             flex-direction: row
-            button, > a
+            button,
+            > a
                 width: columns(6)
+            button
+                min-width: unset
         @include media-breakpoint-up(md)
             flex-direction: column
             gap: $spacing-3
             --btn-min-width: #{columns(2)}
-            button, > a
-                width: pxToRem(200)
+            width: columns(2)
         @include media-breakpoint-down(desktop)
             margin-top: $spacing-3
     .container

--- a/assets/sass/_theme/sections/diplomas.sass
+++ b/assets/sass/_theme/sections/diplomas.sass
@@ -135,7 +135,8 @@ ul.diplomas
             flex-direction: column
             gap: $spacing-3
             --btn-min-width: #{columns(2)}
-            width: columns(2)
+            button, > a
+                max-width: columns(2)
         @include media-breakpoint-down(desktop)
             margin-top: $spacing-3
     .container

--- a/assets/sass/_theme/sections/diplomas.sass
+++ b/assets/sass/_theme/sections/diplomas.sass
@@ -130,7 +130,7 @@ ul.diplomas
             > a
                 width: columns(6)
             button
-                min-width: unset
+                min-width: auto
         @include media-breakpoint-up(md)
             flex-direction: column
             gap: $spacing-3


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Le bouton avait une `width: pxToRem(200)` qui l'empêchait de tenir sur les 2 colonnes en grand écran. J'ai donc remplacé par un max-width qui permet de gérer tous les cas. En mobile, j'ai aussi remarqué qu'on ne retombait pas comme sur la maquette, avec les 2 boutons alignés, parce qu'un `min-width` est appliqué sur le `.btn`.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

Issue #447 

## URL de test sur example.osuny.org

`/fr/offre-de-formation/metiers-du-multimedia-et-de-linternet/`

## URL de test du site (optionnel)

`/formation/offre-de-formation/cybercriminalites-enjeux-et-defis-humains/`

## Screenshots

### Pour le mobile :
![Capture d’écran 2024-06-03 à 10 21 56](https://github.com/osunyorg/theme/assets/91660674/bdfe5a0d-031e-45ae-bd3a-596a36106874)
![Capture d’écran 2024-06-03 à 10 33 10](https://github.com/osunyorg/theme/assets/91660674/8578c1c3-821f-4632-bcfb-80f436bc1dbf)

### Pour le desktop :
![Capture d’écran 2024-06-03 à 10 30 08](https://github.com/osunyorg/theme/assets/91660674/125374ae-e078-4cd5-bb20-72c8ccdbea0d)
![Capture d’écran 2024-06-03 à 10 32 44](https://github.com/osunyorg/theme/assets/91660674/b5ee5f57-45e3-4b1e-b804-34ddae29c23d)
