### PR TITLE
Fix de la taille du bouton de partage d'une formation pour tous les écrans

### DIFF
--- a/assets/sass/_theme/sections/diplomas.sass
+++ b/assets/sass/_theme/sections/diplomas.sass
@@ -134,13 +134,10 @@ ul.diplomas
         @include media-breakpoint-up(md)
             flex-direction: column
             gap: $spacing-3
-            --btn-min-width: #{columns(2)}
             button, > a
                 max-width: columns(3)
         @include media-breakpoint-up(xl)
-            button, > a
-                max-width: columns(2)
-                width: columns(2)
+            --btn-min-width: #{columns(2)}
         @include media-breakpoint-down(desktop)
             margin-top: $spacing-3
     .container

--- a/assets/sass/_theme/sections/diplomas.sass
+++ b/assets/sass/_theme/sections/diplomas.sass
@@ -136,7 +136,11 @@ ul.diplomas
             gap: $spacing-3
             --btn-min-width: #{columns(2)}
             button, > a
+                max-width: columns(3)
+        @include media-breakpoint-up(xl)
+            button, > a
                 max-width: columns(2)
+                width: columns(2)
         @include media-breakpoint-down(desktop)
             margin-top: $spacing-3
     .container


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Petite pétouille sur un des breakpoints !

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`/offre-de-formation/metiers-du-multimedia-et-de-linternet/`

## Screenshots (du plus grand écran vers le plus petit)

![Capture d’écran 2024-06-03 à 15 49 25](https://github.com/osunyorg/theme/assets/91660674/3d317b55-0103-4ac3-8337-66b0da85f212)

![Capture d’écran 2024-06-03 à 15 49 36](https://github.com/osunyorg/theme/assets/91660674/677e058f-3248-4524-b310-384f5518ab0a)

![Capture d’écran 2024-06-03 à 15 49 47](https://github.com/osunyorg/theme/assets/91660674/df32f774-a01f-42a2-94d2-988b4975d87f)

![Capture d’écran 2024-06-03 à 15 49 57](https://github.com/osunyorg/theme/assets/91660674/9b0cc3da-1a05-40ab-a2b6-62c9c494b242)

![Capture d’écran 2024-06-03 à 15 50 10](https://github.com/osunyorg/theme/assets/91660674/3b7c48c4-d10a-4e79-8483-4ea5cff1c8cc)
