### PR TITLE
Gérer les animations des blocs chiffres clés avec la config

### DIFF
--- a/assets/js/theme/blocks/keyFigures.js
+++ b/assets/js/theme/blocks/keyFigures.js
@@ -15,9 +15,10 @@ class KeyFigures {
     constructor (dom) {
         this.dom = dom;
         this.time = 0;
+        this.isAnimated = this.dom.classList.contains('is-animated') ? true : false;
         this.init();
     }
-
+    
     init () {
         let target = 0;
         this.figures = this.dom.querySelectorAll('strong');
@@ -31,7 +32,7 @@ class KeyFigures {
         });
 
         // Show format value if reduced motion
-        if (!isReducedMotionPrefered()) {
+        if (this.isAnimated && !isReducedMotionPrefered()) {
             this.intersectionObserver = new IntersectionObserver(this.observe.bind(this));
             this.intersectionObserver.POLL_INTERVAL = 100;
             this.intersectionObserver.observe(this.dom);
@@ -117,7 +118,7 @@ class KeyFigures {
 }
 
 window.addEventListener('load', () => {
-    const keyFigures = document.querySelectorAll('.block-key_figures.is-animated');
+    const keyFigures = document.querySelectorAll('.block-key_figures');
     keyFigures.forEach((dom) => {
         new KeyFigures(dom);
     });

--- a/assets/js/theme/blocks/keyFigures.js
+++ b/assets/js/theme/blocks/keyFigures.js
@@ -15,7 +15,7 @@ class KeyFigures {
     constructor (dom) {
         this.dom = dom;
         this.time = 0;
-        this.isAnimated = this.dom.classList.contains('is-animated') ? true : false;
+        this.isAnimated = this.dom.classList.contains('is-animated');
         this.init();
     }
     

--- a/assets/js/theme/blocks/keyFigures.js
+++ b/assets/js/theme/blocks/keyFigures.js
@@ -24,7 +24,7 @@ class KeyFigures {
         this.targets = [];
         this.values = [];
         this.figures.forEach((figure) => {
-            target = parseFloat(figure.innerHTML, 10);
+            target = parseFloat(figure.innerHTML.replace(/\s/g, ''), 10);
             this.values.push(0);
             this.targets.push(target);
             figure.innerText = this.formatValue(target);
@@ -87,7 +87,7 @@ class KeyFigures {
     }
 
     formatValue (value, separator = ' ') {
-        return value.toLocaleString('en').replace(',', separator);
+        return value.toLocaleString('en').replace(/,/g, separator);
     }
 
     onEnded() {

--- a/assets/js/theme/blocks/keyFigures.js
+++ b/assets/js/theme/blocks/keyFigures.js
@@ -25,7 +25,7 @@ class KeyFigures {
         this.targets = [];
         this.values = [];
         this.figures.forEach((figure) => {
-            target = parseFloat(figure.innerHTML.replace(/\s/g, ''), 10);
+            target = parseFloat(figure.innerHTML, 10);
             this.values.push(0);
             this.targets.push(target);
             figure.innerText = this.formatValue(target);

--- a/assets/js/theme/blocks/keyFigures.js
+++ b/assets/js/theme/blocks/keyFigures.js
@@ -117,7 +117,7 @@ class KeyFigures {
 }
 
 window.addEventListener('load', () => {
-    const keyFigures = document.querySelectorAll('.block-key_figures.with-animation');
+    const keyFigures = document.querySelectorAll('.block-key_figures.is-animated');
     keyFigures.forEach((dom) => {
         new KeyFigures(dom);
     });

--- a/assets/js/theme/blocks/keyFigures.js
+++ b/assets/js/theme/blocks/keyFigures.js
@@ -117,7 +117,7 @@ class KeyFigures {
 }
 
 window.addEventListener('load', () => {
-    const keyFigures = document.querySelectorAll('.block-key_figures');
+    const keyFigures = document.querySelectorAll('.block-key_figures.with-animation');
     keyFigures.forEach((dom) => {
         new KeyFigures(dom);
     });

--- a/config.yaml
+++ b/config.yaml
@@ -155,6 +155,8 @@ params:
         pagination: false
         autoWidth: true
         autoplay: false
+    key_figures:
+      animation: true
     testimonials:
       splide:
         arrows: false

--- a/config.yaml
+++ b/config.yaml
@@ -156,7 +156,7 @@ params:
         autoWidth: true
         autoplay: false
     key_figures:
-      animation: true
+      animated: true
     testimonials:
       splide:
         arrows: false

--- a/layouts/partials/blocks/templates/key_figures.html
+++ b/layouts/partials/blocks/templates/key_figures.html
@@ -31,7 +31,7 @@
                           "sizes"    site.Params.image_sizes.blocks.key_figures
                         )}}
                     {{ end }}
-                    <strong>{{ lang.NumFmt 0 .number "| | " "|" }}</strong>{{ partial "PrepareHTML" .unit }}
+                    <strong>{{ .number }}</strong>{{ partial "PrepareHTML" .unit }}
                   </dt>
                   <dd>{{ partial "PrepareHTML" .description }}</dd>
                 </dl>

--- a/layouts/partials/blocks/templates/key_figures.html
+++ b/layouts/partials/blocks/templates/key_figures.html
@@ -20,6 +20,7 @@
           {{ end }}
           <ul class="{{ $list_class }}">
             {{- range .figures }}
+              
               <li>
                 <dl>
                   <dt>
@@ -30,7 +31,7 @@
                           "sizes"    site.Params.image_sizes.blocks.key_figures
                         )}}
                     {{ end }}
-                    <strong>{{ .number }}</strong>{{ partial "PrepareHTML" .unit }}
+                    <strong>{{ lang.NumFmt 0 .number "| | " "|" }}</strong>{{ partial "PrepareHTML" .unit }}
                   </dt>
                   <dd>{{ partial "PrepareHTML" .description }}</dd>
                 </dl>

--- a/layouts/partials/blocks/templates/key_figures.html
+++ b/layouts/partials/blocks/templates/key_figures.html
@@ -1,9 +1,10 @@
 {{- $block := .block -}}
+{{- $isAnimated := site.Params.blocks.key_figures.animation -}}
 {{- $block_class := partial "GetBlockClass" .block -}}
 
 {{- with .block.data -}}
   {{- $figures := .figures }}
-  <div class="{{ $block_class }}">
+  <div class="{{ $block_class }} {{- if $isAnimated }} with-animation {{ end }}">
     <div class="container">
       <div class="block-content">
         {{ partial "blocks/top.html" (dict

--- a/layouts/partials/blocks/templates/key_figures.html
+++ b/layouts/partials/blocks/templates/key_figures.html
@@ -1,10 +1,10 @@
 {{- $block := .block -}}
-{{- $isAnimated := site.Params.blocks.key_figures.animation -}}
+{{- $isAnimated := site.Params.blocks.key_figures.animated -}}
 {{- $block_class := partial "GetBlockClass" .block -}}
 
 {{- with .block.data -}}
   {{- $figures := .figures }}
-  <div class="{{ $block_class }} {{- if $isAnimated }} with-animation {{ end }}">
+  <div class="{{ $block_class }} {{- if $isAnimated }} is-animated {{ end }}">
     <div class="container">
       <div class="block-content">
         {{ partial "blocks/top.html" (dict


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout de la possibilité de désactiver de façon globale les animations du block key figures.

```
  blocks:
    key_figures:
      animation: true
```

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

#434 

## URL de test sur example.osuny.org

`/fr/blocks/blocks-narratifs/chiffre-cles/`

## URL de test du site (optionnel)

Sur le [rapport openclassroom](https://github.com/osunyorg/openclassrooms-rapport-2023) : `/en/our-mission/`
(Il faut mettre à false dans la config)

## Screenshots

N/A