### PR TITLE
Ajout de variables au CTA / bouton pour styliser les bordures

### DIFF
--- a/assets/sass/_theme/_variables.sass
+++ b/assets/sass/_theme/_variables.sass
@@ -122,6 +122,7 @@
   --btn-background: #{$btn-background}
   --btn-hover-background: #{$btn-hover-background}
   --btn-border: #{$btn-border}
+  --btn-hover-border: #{$btn-hover-border}
   --btn-border-radius: #{$btn-border-radius}
   --btn-padding: #{$btn-padding}
   --btn-min-width: #{$btn-min-width}

--- a/assets/sass/_theme/blocks/call_to_action.sass
+++ b/assets/sass/_theme/blocks/call_to_action.sass
@@ -35,10 +35,11 @@
                 text-decoration-color: alphaColor($block-call-to-action-color, 0.3)
                 &:first-child
                     --btn-background: #{$block-call-to-action-button-background}
+                    --btn-border: #{$block-call-to-action-button-border}
                     --btn-color: #{$block-call-to-action-button-color}
                     --btn-hover-background: #{$block-call-to-action-button-hover-background}
+                    --btn-hover-border: #{$block-call-to-action-button-hover-border}
                     --btn-hover-color: #{$block-call-to-action-button-hover-color}
-                    --btn-border: none
                     --btn-min-width: #{columns(2)}
                     @extend .button
                 &:last-child

--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -23,8 +23,10 @@ $block-space-y-with-sidebar: $spacing-5 !default
 $block-call-to-action-background: var(--color-accent) !default
 $block-call-to-action-color: var(--color-background) !default
 $block-call-to-action-button-background: var(--color-background) !default
+$block-call-to-action-button-border: pxToRem(1) solid $block-call-to-action-button-background !default
 $block-call-to-action-button-color: var(--color-text) !default
 $block-call-to-action-button-hover-background: var(--color-text-alt) !default
+$block-call-to-action-button-hover-border: pxToRem(1) solid $block-call-to-action-button-hover-background !default
 $block-call-to-action-button-hover-color: var(--color-background) !default
 
 // Block chapter

--- a/assets/sass/_theme/configuration/components.sass
+++ b/assets/sass/_theme/configuration/components.sass
@@ -9,6 +9,7 @@ $btn-hover-color: var(--color-text) !default
 $btn-background: transparent !default
 $btn-hover-background: var(--color-background) !default
 $btn-border: pxToRem(1) solid var(--color-border) !default
+$btn-hover-border: $btn-border !default
 $btn-border-desktop: $btn-border !default
 $btn-border-radius: pxToRem(4) !default
 $btn-border-radius-desktop: $btn-border-radius !default

--- a/assets/sass/_theme/design-system/button.sass
+++ b/assets/sass/_theme/design-system/button.sass
@@ -14,10 +14,11 @@
     min-width: var(--btn-min-width)
     text-align: center
     display: inline-block
-    transition: background .3s ease, color .3s ease
+    transition: background .3s ease, border .3s ease, color .3s ease
     &:hover, &:focus, &:focus-visible
         color: var(--btn-hover-color)
         background: var(--btn-hover-background)
+        border: var(--btn-hover-border)
 
 .button-accent
     @extend .button

--- a/assets/sass/_theme/design-system/button.sass
+++ b/assets/sass/_theme/design-system/button.sass
@@ -24,15 +24,19 @@
     @extend .button
     --btn-color: #{$color-background}
     --btn-background: #{$color-accent}
+    --btn-border: pxToRem(1) solid var(--btn-background)
     --btn-hover-color: #{$color-background}
     --btn-hover-background: #{alphaColor($color-accent, 0.85)}
+    --btn-hover-border: pxToRem(1) solid var(--btn-hover-background)
 
 .button-alt
     @extend .button
     --btn-color: #{$color-background}
     --btn-background: #{$color-text-alt}
+    --btn-border: pxToRem(1) solid var(--btn-background)
     --btn-hover-color: #{$color-background}
     --btn-hover-background: #{$color-text}
+    --btn-hover-border: pxToRem(1) solid var(--btn-hover-background)
 
 .squared-button
     @include meta


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

1. Ajout des variables `$block-call-to-action-button-border` et `$block-call-to-action-button-hover-border` au CTA : les 2 prennent la couleur du fond du boutton en normal et au survol.
2. Ajout de `$btn-hover-border` au composant button/btn dont on revoit le style au hover (bordure au hover pas prise en charge au départ, nécessaire pour la CTA) : la bordure au hover est par défaut identique à celle en normal.
3. Les boutons accent et alt prennent pour la bordure les valeurs de leur fond.

Je ne sais pas s'il faudrait séparer globalement les bordures en `$btn-border-width` / `$btn-border-color`, etc.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

#416 

## URL de test sur example.osuny.org

- Accueil d'example pour le bouton dans le hero
- `/fr/blocks/blocks-narratifs/appels-a-action/` pour les cta
- `/fr/offre-de-formation/metiers-du-multimedia-et-de-linternet/` pour les boutons dans une formation

## Screenshots

N/A