### PR TITLE
Configuration de l'index des posts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -95,16 +95,13 @@ params:
     default_image: false
     date_format: ":date_long"
     index:
-      show_categories: true
-      show_author: false
-      show_description: true
       truncate_description: 200 # Set to 0 to disable truncate
       layout: list # grid | list
       options:
         hide_image: false
         hide_summary: false
         hide_category: false
-        hide_author: false
+        hide_author: true
         hide_date: false
     # share_links: # Optional
     #   enabled: true


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Dans la config, on se basait encore sur l'ancienne : 

```
index:
      show_categories: true
      show_author: false
      show_description: true
```

J'ai enlevé ces 3 lignes et passé `hide_author` à `true` pour assurer que ça fait la même chose.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

