### PR TITLE
Block liste des volumes

### DIFF
--- a/assets/sass/_theme/blocks/volumes.sass
+++ b/assets/sass/_theme/blocks/volumes.sass
@@ -1,0 +1,20 @@
+.block-volumes
+    .volumes
+        .volume
+            hgroup
+                display: flex
+                flex-direction: column-reverse
+                p
+                    margin-top: space()
+            .media
+                img
+                    aspect-ratio: 11/13
+    @include in-page-without-sidebar
+        .top
+            display: flex
+            gap: var(--grid-gutter)
+            .block-title
+                width: columns(4)
+            .description
+                width: columns(8)
+                margin-top: 0

--- a/assets/sass/_theme/blocks/volumes.sass
+++ b/assets/sass/_theme/blocks/volumes.sass
@@ -1,4 +1,8 @@
 .block-volumes
+    .top
+        .block-title a
+            @include icon(arrow, after, true)
+            @include hover-translate-icon(after)
     .volumes
         .volume
             hgroup

--- a/assets/sass/_theme/blocks/volumes.sass
+++ b/assets/sass/_theme/blocks/volumes.sass
@@ -9,6 +9,8 @@
             .media
                 img
                     aspect-ratio: 11/13
+        @include in-page-with-sidebar
+            @include grid(2)
     @include in-page-without-sidebar
         .top
             display: flex

--- a/assets/sass/_theme/hugo-osuny.sass
+++ b/assets/sass/_theme/hugo-osuny.sass
@@ -67,6 +67,7 @@
 @import blocks/testimonials
 @import blocks/timeline
 @import blocks/video
+@import blocks/volumes
 
 // Sections
 @import sections/administrators

--- a/layouts/partials/blocks/templates/volumes.html
+++ b/layouts/partials/blocks/templates/volumes.html
@@ -15,11 +15,8 @@
     <div class="container">
       <div class="block-content">
         {{ if $block.title -}}
-          {{ $link := false }}
-          {{- if .all -}}
-            {{ $volumes_page := site.GetPage "/volumes" }}
-            {{ $link = $volumes_page.Permalink }}
-          {{- end -}}
+          {{ $volumes_page := site.GetPage "/volumes" }}
+          {{ $link := $volumes_page.Permalink }}
 
           {{ partial "blocks/top.html" (dict
             "title" $block.title

--- a/layouts/partials/blocks/templates/volumes.html
+++ b/layouts/partials/blocks/templates/volumes.html
@@ -1,0 +1,36 @@
+{{ $heading_level := .heading_level | default 3 }}
+{{ $heading := printf "h%d" $heading_level }}
+{{ $heading_tag := (dict 
+  "open" ((printf "<%s class='volume-title' itemprop='headline'>" $heading) | safeHTML)
+  "close" ((printf "</%s>" $heading) | safeHTML)
+  ) }}
+
+{{- $block := .block -}}
+{{- $template := .block.template -}}
+{{- $position := .block.position -}}
+{{- $title := .block.title -}}
+
+{{- with .block.data -}}
+  <div class="block block-volumes {{- if $title }} block-with-title {{- end -}}">
+    <div class="container">
+      <div class="block-content">
+        {{ partial "blocks/top.html" (dict
+          "title" $block.title
+          "heading_level" $block.ranks.self
+          "description" .description
+        )}}
+
+        <div class="volumes">
+          {{ range $volume := .volumes -}}
+            {{ with site.GetPage (printf "/volumes/%s" $volume) }}
+              {{ partial "volumes/volume.html" (dict 
+                  "volume" .
+                  "heading" $heading) 
+              }}
+            {{ end }}
+          {{ end}}
+        </div>
+      </div>
+    </div>
+  </div>
+{{- end -}}

--- a/layouts/partials/blocks/templates/volumes.html
+++ b/layouts/partials/blocks/templates/volumes.html
@@ -14,11 +14,19 @@
   <div class="block block-volumes {{- if $title }} block-with-title {{- end -}}">
     <div class="container">
       <div class="block-content">
-        {{ partial "blocks/top.html" (dict
-          "title" $block.title
-          "heading_level" $block.ranks.self
-          "description" .description
-        )}}
+        {{ if $block.title -}}
+          {{ $link := false }}
+          {{- if .all -}}
+            {{ $volumes_page := site.GetPage "/volumes" }}
+            {{ $link = $volumes_page.Permalink }}
+          {{- end -}}
+
+          {{ partial "blocks/top.html" (dict
+            "title" $block.title
+            "heading_level" $block.ranks.self
+            "link" $link
+          )}}
+        {{- end }}
 
         <div class="volumes">
           {{ range $volume := .volumes -}}

--- a/layouts/partials/volumes/volume.html
+++ b/layouts/partials/volumes/volume.html
@@ -1,18 +1,29 @@
-<article class="volume" itemscope itemtype="https://schema.org/Book https://schema.org/PublicationVolume">
-  <hgroup>
-    <p class="suptitle" itemprop="volumeNumber">{{ i18n "volumes.volume_number" (dict "Number" .Params.Number) }}</p>
-    <h2 class="volume-title"><a href="{{ .Permalink }}" title="{{ i18n "commons.more_aria" (dict "Title" .Title) }}" itemprop="name">{{ partial "PrepareHTML" .Title }}</a></h2>
-  </hgroup>
-  <div class="media">
-    {{- if .Params.image -}}
-      {{- partial "commons/image.html"
-            (dict
-              "image"    .Params.image
-              "alt"      .Title
-              "sizes"    site.Params.image_sizes.sections.volumes.item
-            ) -}}
-    {{- else -}}
-      {{- partial "commons/image-default.html" "volumes" -}}
-    {{- end -}}
-  </div>
-</article>
+{{ $volume := .volume }}
+{{ $heading := .heading | default "h2" }}
+{{ $heading_tag := (dict 
+  "open" ((printf "<%s class='volume-title'>" $heading) | safeHTML)
+  "close" ((printf "</%s>" $heading) | safeHTML)
+) }}
+
+{{ with $volume }}
+  <article class="volume" itemscope itemtype="https://schema.org/Book https://schema.org/PublicationVolume">
+    <hgroup>
+      <p class="suptitle" itemprop="volumeNumber">{{ i18n "volumes.volume_number" (dict "Number" .Params.Number) }}</p>
+      {{ $heading_tag.open }}
+        <a href="{{ .Permalink }}" title="{{ i18n "commons.more_aria" (dict "Title" .Title) }}" itemprop="name">{{ partial "PrepareHTML" .Title }}</a>
+      {{ $heading_tag.close }}
+    </hgroup>
+    <div class="media">
+      {{- if .Params.image -}}
+        {{- partial "commons/image.html"
+              (dict
+                "image"    .Params.image
+                "alt"      .Title
+                "sizes"    site.Params.image_sizes.sections.volumes.item
+              ) -}}
+      {{- else -}}
+        {{- partial "commons/image-default.html" "volumes" -}}
+      {{- end -}}
+    </div>
+  </article>
+{{ end }}

--- a/layouts/partials/volumes/volumes.html
+++ b/layouts/partials/volumes/volumes.html
@@ -1,7 +1,9 @@
 <div class="volumes">
   {{ range .Paginator.Pages }}
     <div>
-      {{ partial "volumes/volume.html" . }}
+      {{ partial "volumes/volume.html" (dict 
+          "volume" .
+      )}}
     </div>
   {{ end }}
 </div>


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout du bloc de liste des volumes : ajout d'un partial template qui utilise celui `volumes/volume.html` (petites modifs sur ce dernier donc), et d'un peu de style.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

#428 | [figma](https://www.figma.com/design/tQh3oLfNwSt8aoVDuUjQt0/Th%C3%A8me-Osuny?node-id=11832-2516&t=hiYJyg2rbN8zKJ9y-1)

## URL de test du site (optionnel)

Degrowth journal : besoin d'ajouter le bloc quelque part comme ceci : 

```
- kind: block
    template: volumes
    title: >-
      Volumes
    ranks:
      self: false
    data:
      description: >-
        Lorem ipsum dolor sit amet consectetur. Laoreet donec vulputate lorem pellentesque nisl non sapien. Vulputate blandit aliquet tellus pretium vel massa maecenas. Porttitor praesent vulputate congue nisl fringilla.
      volumes:
        - "2023-volume-1"
```
**NB :** attention, le "volume 1" n'apparaîtra pas car il est effacé dans la traduction !

## Screenshots

![Capture d’écran 2024-06-04 à 18 07 42](https://github.com/osunyorg/theme/assets/91660674/2a8bb74d-9f41-4097-979f-cecce00db67b)

### Page sans sidebar : 
![Capture d’écran 2024-06-04 à 16 29 31](https://github.com/osunyorg/theme/assets/91660674/66115d55-049f-475a-bfdc-7f81bf6406c3)

### Page avec sidebar : 
![Capture d’écran 2024-06-04 à 16 30 37](https://github.com/osunyorg/theme/assets/91660674/f1833d4c-05c7-4750-aa71-e430e3b256a3)