### PR TITLE
Bloc links : ajout de l'icône et correction de l'image

### DIFF
--- a/assets/sass/_theme/blocks/links.sass
+++ b/assets/sass/_theme/blocks/links.sass
@@ -14,6 +14,7 @@
         .link-content
             line-height: 100%
             padding: space(4) space(4) space(8)
+            min-height: pxToRem(130)
             @include icon(link-blank, after)
                 position: absolute
                 bottom: $spacing-2

--- a/assets/sass/_theme/blocks/links.sass
+++ b/assets/sass/_theme/blocks/links.sass
@@ -13,8 +13,11 @@
         transition: background 0.3s ease
         .link-content
             line-height: 100%
-            min-height: pxToRem(130)
-            padding: space(4)
+            padding: space(4) space(4) space(8)
+            @include icon(link-blank, after)
+                position: absolute
+                bottom: $spacing-2
+                right: $spacing-2
         a
             @include stretched-link(before)
             text-decoration: none
@@ -26,12 +29,12 @@
             @include small
             margin-top: space(3)
         .media
-            aspect-ratio: 16/9
-            position: relative
             img
                 display: block
-                aspect-ratio: 16/9
                 object-fit: cover
+                width: 100%
+                height: 100%
+                aspect-ratio: 16/9
         &:hover
             background-color: $block-links-card-hover-background
             &, a

--- a/assets/sass/_theme/blocks/links.sass
+++ b/assets/sass/_theme/blocks/links.sass
@@ -15,17 +15,13 @@
             line-height: 100%
             padding: space(4) space(4) space(8)
             min-height: pxToRem(130)
-            @include icon(link-blank, after)
-                position: absolute
-                bottom: $spacing-2
-                right: $spacing-2
         a
             @include stretched-link(before)
             text-decoration: none
             &::after
-                bottom: space(4)
+                bottom: space(3)
                 position: absolute
-                right: space(4)
+                right: space(3)
         p
             @include small
             margin-top: space(3)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Correction d'un problème sur les images de liens et ajout du picto sur l'élément.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

https://example.osuny.org/fr/blocks/blocks-techniques/liens/

## URL de test du site (optionnel)



## Screenshots

Avant : 

![image](https://github.com/osunyorg/theme/assets/4630530/f587ef9e-13d7-4a33-83fd-8aa3a1a4826a)

![image](https://github.com/osunyorg/theme/assets/4630530/8dca0e79-7f92-41d1-b430-8bc37606105d)



Après : 

![image](https://github.com/osunyorg/theme/assets/4630530/eef345ba-abba-4ff8-80c0-1992c8648a8c)

![image](https://github.com/osunyorg/theme/assets/4630530/8ac9a6a4-2fac-4227-8294-91ffa96cd30b)

