### PR TITLE
Gestion du nouveau répertoire du thème sur les sites

### DIFF
--- a/.github/workflows/test-with-example.yml
+++ b/.github/workflows/test-with-example.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set new submodule in new branch on Osuny Example
         uses: actions/checkout@v4
         with:
-          repository: noesya/osuny-example
+          repository: osunyorg/example
           submodules: 'recursive'
           token: ${{ secrets.OSUNY_EXAMPLE_TOKEN }}
       - name: Create new branch on Example
@@ -23,9 +23,9 @@ jobs:
       - name: Checkout submodule
         uses: actions/checkout@v4
         with:
-          repository: noesya/osuny-hugo-theme-aaa
+          repository: osunyorg/theme
           token: ${{ secrets.OSUNY_EXAMPLE_TOKEN }}
-          path: themes/osuny-hugo-theme-aaa
+          path: themes/osuny
           ref: ${{ github.head_ref || github.ref_name }}
       - name: Pushing new branch on Example
         run: |

--- a/layouts/partials/head/css.html
+++ b/layouts/partials/head/css.html
@@ -5,7 +5,7 @@
   "includePaths" (slice "node_modules")
 ) -}}
 <!-- PostCSS -->
-{{- $postCSSOpts := (dict "config" "themes/osuny-hugo-theme-aaa") -}}
+{{- $postCSSOpts := (dict "config" "themes/osuny") -}}
 
 {{- $styles := resources.Get "sass/main.sass" | toCSS $cssOpts -}}
 {{ if hugo.IsProduction }}

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "osuny-hugo-theme",
-  "version": "5.1.0",
-  "repository": "git@github.com:noesya/osuny-hugo-theme-aaa.git",
+  "version": "6.0.13",
+  "repository": "git@github.com:osunyorg/theme.git",
   "author": "alexisben <alexis.benoit@noesya.coop>",
   "contributors": [
     "olivia206 <olivia.simonet@noesya.coop>",
     "alexisben <alexis.benoit@noesya.coop>",
-    "arnaudlevy <arnaud.levy@noesya.coop>"
+    "arnaudlevy <arnaud.levy@noesya.coop>",
+    "clararigaud <clara.rigaud@noesya.coop>"
   ],
   "license": "MIT",
   "dependencies": {

--- a/theme.yaml
+++ b/theme.yaml
@@ -1,6 +1,6 @@
 name: Osuny Hugo Theme
 license: MIT
-licenselink: 'https://github.com/noesya/osuny-hugo-theme-aaa/blob/main/LICENSE'
+licenselink: 'https://github.com/osunyorg/theme/blob/main/LICENSE'
 description: Hugo theme for Osuny websites
 homepage: 'https://www.osuny.org'
 min_version: 0.111.0


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Dans le workflow de test avec le site Example, on appelle le nouveau nom du repo, ainsi que le nouveau repo du theme, ainsi qu'au nouveau path.

On met également à jour l'endroit où aller chercher la config PostCSS, la licence du thème, et quelques informations du package.json.

⚠️ **ATTENTION** : Cette PR implique que TOUS les sites Osuny aient leur thème dans le répertoire `themes/osuny` au lieu de `themes/osuny-hugo-theme-aaa`. Pour cela, il faut lancer un petit script de déplacement du submodule.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [x] Incidence forte 😱

## Référence (ticket et/ou figma)

#325 

## URL de test sur example.osuny.org

handle-new-theme--example.osuny.netlify.app
