### PR TITLE
Ajout des réseaux sociaux au bloc Contact

### DIFF
--- a/assets/sass/_theme/blocks/contact.sass
+++ b/assets/sass/_theme/blocks/contact.sass
@@ -18,8 +18,10 @@
         .contacts
             margin-top: $spacing-3
             @include media-breakpoint-down(desktop)
-                > div + div
-                    margin-top: $spacing-3
+                > div 
+                    + div,
+                    + ul
+                        margin-top: $spacing-3
         + span
             display: block
             margin-top: $spacing-4

--- a/assets/sass/_theme/blocks/contact.sass
+++ b/assets/sass/_theme/blocks/contact.sass
@@ -23,9 +23,9 @@
         + span
             display: block
             margin-top: $spacing-4
-            + ul
+            + .schedule-table
                 margin-top: $spacing-1
-    ul
+    .schedule-table
         @include list-reset
         li
             display: flex
@@ -49,6 +49,35 @@
         @include icon(arrow-right, before)
             display: inline-block
             padding: 0 pxToRem(7) 0 pxToRem(3)
+    .socials-list
+        @include list-reset
+        li
+            position: relative
+            &::before
+                font-size: $footer-icons-size
+                margin-left: -0.3em
+            a
+                @include stretched-link
+            &.facebook
+                @include icon(social-facebook, before)
+            &.instagram
+                @include icon(social-instagram, before)
+            &.linkedin
+                @include icon(social-linkedin, before)
+            &.mastodon
+                @include icon(social-mastodon, before)
+            &.youtube
+                @include icon(social-youtube, before)
+            &.x
+                @include icon(social-x, before)
+            &.peertube
+                @include icon(social-peertube, before)
+            &.vimeo
+                @include icon(social-vimeo, before)
+            &.tiktok
+                @include icon(social-tiktok, before)
+            &.github
+                @include icon(social-github, before)
 
     @include in-page-without-sidebar
         .top
@@ -56,15 +85,25 @@
         .informations
             .contacts
                 @include grid(3)
-        ul
+        .schedule-table
+            &.full-size
+                grid-column: 1/4
+                span
+                    width: columns(4)
+            &.reduced
+                grid-column: 2/4
             span
-                width: columns(4)
+                width: columns(2)
+                &:first-child
+                    width: columns(4)
 
     @include in-page-with-sidebar
         .contacts
             @include grid(2)
             row-gap: $spacing-3
-        ul
+
+        .schedule-table
+            grid-column: 1/3
             span
                 width: columns(2)
                 &:last-child

--- a/assets/sass/_theme/blocks/contact.sass
+++ b/assets/sass/_theme/blocks/contact.sass
@@ -55,6 +55,8 @@
     .socials-list
         @include list-reset
         li
+            align-items: center
+            display: flex
             position: relative
             &::before
                 font-size: $footer-icons-size

--- a/assets/sass/_theme/blocks/contact.sass
+++ b/assets/sass/_theme/blocks/contact.sass
@@ -32,18 +32,20 @@
         li
             display: flex
             flex-wrap: wrap
-            padding-bottom: $spacing-2
             + li:not(.meta)
+                padding-bottom: $spacing-2
+            + li:not(.meta, .meta + li)
                 padding-top: $spacing-2
             + li:not(:last-child)
                 border-bottom: 1px solid var(--color-border)
             @include media-breakpoint-down(desktop)
-                justify-content: end
-                flex-wrap: wrap
-                span
-                    min-width: 50%
-                    &:nth-child(n+2)
-                        text-align: right
+                &:not(.meta)
+                    justify-content: end
+                    flex-wrap: wrap
+                    span
+                        min-width: 50%
+                        &:nth-child(n+2)
+                            text-align: right
             @include media-breakpoint-up(desktop)
                 gap: var(--grid-gutter)
     time + time
@@ -79,7 +81,12 @@
                 @include icon(social-tiktok, before)
             &.github
                 @include icon(social-github, before)
-
+    @include media-breakpoint-down(desktop)
+        .socials-list
+            @include grid(2)
+            row-gap: space()
+        .meta
+            margin-bottom: space()
     @include in-page-without-sidebar
         .top
             margin-bottom: $spacing-4

--- a/assets/sass/_theme/blocks/contact.sass
+++ b/assets/sass/_theme/blocks/contact.sass
@@ -94,10 +94,14 @@
                     width: columns(4)
             &.reduced
                 grid-column: 2/4
-            span
-                width: columns(2)
-                &:first-child
-                    width: columns(4)
+                span
+                    width: columns(2)
+                    &:last-child
+                        text-align: right
+                    &:first-child
+                        width: columns(4)
+                        + span
+                            text-align: left
 
     @include in-page-with-sidebar
         .contacts

--- a/assets/sass/_theme/blocks/contact.sass
+++ b/assets/sass/_theme/blocks/contact.sass
@@ -33,11 +33,10 @@
             display: flex
             flex-wrap: wrap
             padding-bottom: $spacing-2
-            &:first-of-type
-                padding-top: 0
-            + li
+            + li:not(.meta)
                 padding-top: $spacing-2
-                border-top: 1px solid var(--color-border)
+            + li:not(:last-child)
+                border-bottom: 1px solid var(--color-border)
             @include media-breakpoint-down(desktop)
                 justify-content: end
                 flex-wrap: wrap

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -93,6 +93,7 @@ commons:
     website: Website
     web: Web
     schedule: Hours
+    socials: Social Media
   credit: A low impact website crafted with <a href="https://www.osuny.org/" title="Osuny - extern link" target="_blank" rel="noreferrer">Osuny</a>
   date: Date
   download:

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -93,6 +93,7 @@ commons:
     website: Site web
     web: Web
     schedule: Horaires
+    socials: Réseaux sociaux
   credit: Un site éco-conçu produit avec <a href="https://www.osuny.org/" title="Osuny - lien externe" target="_blank" rel="noreferrer">Osuny</a>
   date: Date
   download:

--- a/layouts/partials/blocks/templates/contact.html
+++ b/layouts/partials/blocks/templates/contact.html
@@ -74,52 +74,66 @@
                   {{ end }}
                 </div>
               {{ end }}
+              {{ with .socials }}
+                <div>
+                  <p class="meta">{{- i18n "commons.contact.socials" -}}</p>
+                  <ul class="socials-list">
+                    {{ partial "commons/socials" . }}
+                  </ul>
+                </div>
+              {{ end }}
+              {{ if .timetable}}
+                {{ $time_size := "full-size" }}
+                {{ if and (or .emails .url) .phone_numbers .socials }}
+                  {{ $time_size = "reduced" }}
+                {{ end}}
+                <ul class="schedule-table {{ $time_size -}}">
+                  <span class="meta">{{- i18n "commons.contact.schedule" -}}</span>
+                  {{ range .timetable }}
+                    {{ if or
+                      .time_slot_morning.from
+                      .time_slot_morning.to
+                      .time_slot_afternoon.from
+                      .time_slot_afternoon.to
+                    }}
+                      <li>
+                        <span>{{ .title }}</span>
+                        {{ if or
+                          .time_slot_morning.from
+                          .time_slot_morning.to
+                        }}
+                        <span>
+                          {{- if .time_slot_morning.from }}
+                            <time datetime="{{ .time_slot_morning.from }}">{{ .time_slot_morning.from }}</time>
+                          {{ end -}}
+                          {{- if .time_slot_morning.to }}
+                            <time datetime="{{ .time_slot_morning.to }}">{{ .time_slot_morning.to }}</time>
+                          {{ end -}}
+                        </span>
+                        {{ end }}
+                        {{ if or
+                          .time_slot_afternoon.from
+                          .time_slot_afternoon.to
+                        }}
+                        <span>
+                          {{- if .time_slot_afternoon.from }}
+                            <time datetime="{{ .time_slot_afternoon.from }}">{{ .time_slot_afternoon.from }}</time>
+                          {{ end -}}
+                          {{- if .time_slot_afternoon.to }}
+                            <time datetime="{{ .time_slot_afternoon.to }}">{{ .time_slot_afternoon.to }}</time>
+                          {{ end -}}
+                        </span>
+                        {{ end -}}
+                      </li>
+                    {{ end }}
+                  {{ end }}
+                </ul>
+              {{ end }}
             </div>
+            
           </address>
   
-          {{ if .timetable}}
-            <span class="meta">{{- i18n "commons.contact.schedule" -}}</span>
-            <ul>
-                {{ range .timetable }}
-                  {{ if or
-                    .time_slot_morning.from
-                    .time_slot_morning.to
-                    .time_slot_afternoon.from
-                    .time_slot_afternoon.to
-                  }}
-                    <li>
-                      <span>{{ .title }}</span>
-                      {{ if or
-                        .time_slot_morning.from
-                        .time_slot_morning.to
-                      }}
-                      <span>
-                        {{- if .time_slot_morning.from }}
-                          <time datetime="{{ .time_slot_morning.from }}">{{ .time_slot_morning.from }}</time>
-                        {{ end -}}
-                        {{- if .time_slot_morning.to }}
-                          <time datetime="{{ .time_slot_morning.to }}">{{ .time_slot_morning.to }}</time>
-                        {{ end -}}
-                      </span>
-                      {{ end }}
-                      {{ if or
-                        .time_slot_afternoon.from
-                        .time_slot_afternoon.to
-                      }}
-                      <span>
-                        {{- if .time_slot_afternoon.from }}
-                          <time datetime="{{ .time_slot_afternoon.from }}">{{ .time_slot_afternoon.from }}</time>
-                        {{ end -}}
-                        {{- if .time_slot_afternoon.to }}
-                          <time datetime="{{ .time_slot_afternoon.to }}">{{ .time_slot_afternoon.to }}</time>
-                        {{ end -}}
-                      </span>
-                      {{ end -}}
-                    </li>
-                  {{ end }}
-                {{ end }}
-            </ul>
-          {{ end }}
+          
         </div>
       </div>
 

--- a/layouts/partials/blocks/templates/contact.html
+++ b/layouts/partials/blocks/templates/contact.html
@@ -88,7 +88,7 @@
                   {{ $time_size = "reduced" }}
                 {{ end}}
                 <ul class="schedule-table {{ $time_size -}}">
-                  <span class="meta">{{- i18n "commons.contact.schedule" -}}</span>
+                  <li class="meta">{{- i18n "commons.contact.schedule" -}}</li>
                   {{ range .timetable }}
                     {{ if or
                       .time_slot_morning.from

--- a/layouts/partials/commons/socials.html
+++ b/layouts/partials/commons/socials.html
@@ -1,0 +1,50 @@
+{{ with .mastodon }}
+  <li class="mastodon">
+    <a href="{{ . }}" rel="noreferrer" title="Mastodon" target="_blank">Mastodon</a>
+  </li>
+{{ end}}
+{{ with .peertube }}
+  <li class="peertube">
+    <a href="{{ . }}" rel="noreferrer" title="Peertube" target="_blank">Peertube</a>
+  </li>
+{{ end}}
+{{ with .github }}
+  <li class="github">
+    <a href="{{ . }}" rel="noreferrer" title="Github" target="_blank">GitHub</a>
+  </li>
+{{ end}}
+{{ with .linkedin }}
+  <li class="linkedin">
+    <a href="{{ . }}" rel="noreferrer" title="LinkedIn" target="_blank">LinkedIn</a>
+  </li>
+{{ end}}
+{{ with .youtube }}
+  <li class="youtube">
+    <a href="{{ . }}" rel="noreferrer" title="YouTube" target="_blank">YouTube</a>
+  </li>
+{{ end}}
+{{ with .vimeo }}
+  <li class="vimeo">
+    <a href="{{ . }}" rel="noreferrer" title="Vimeo" target="_blank">Vimeo</a>
+  </li>
+{{ end}}
+{{ with .instagram }}
+  <li class="instagram">
+    <a href="{{ . }}" rel="noreferrer" title="Instagram" target="_blank">Instagram</a>
+  </li>
+{{ end}}
+{{ with .facebook }}
+  <li class="facebook">
+    <a href="{{ . }}" rel="noreferrer" title="" target="_blank">Facebook</a>
+  </li>
+{{ end}}
+{{ with .tiktok }}
+  <li class="tiktok">
+    <a href="{{ . }}" rel="noreferrer" title="TikTok" target="_blank">TikTok</a>
+  </li>
+{{ end}}
+{{ with .x }}
+  <li class="x">
+    <a href="{{ . }}" rel="noreferrer" title="X, ex-Twitter" target="_blank">X (ex-Twitter)</a>
+  </li>
+{{ end}}

--- a/layouts/partials/footer/social.html
+++ b/layouts/partials/footer/social.html
@@ -13,66 +13,7 @@
   {{ $site_social_links := . }}
   {{ if $site_social_links }}
     <ul class="footer-social site-links">
-      {{ with $site_social_links.email }}
-      <li class="email">
-        <a href="mailto:{{ . }}" rel="noreferrer" title="Email" target="_blank">Email</a>
-      </li>
-      {{ end}}
-      {{ with $site_social_links.rss }}
-      <li class="rss">
-        <a href="{{ . }}" rel="noreferrer" title="RSS" target="_blank">RSS</a>
-      </li>
-      {{ end}}
-      {{ with $site_social_links.mastodon }}
-      <li class="mastodon">
-        <a href="{{ . }}" rel="noreferrer" title="Mastodon" target="_blank">Mastodon</a>
-      </li>
-      {{ end}}
-      {{ with $site_social_links.peertube }}
-      <li class="peertube">
-        <a href="{{ . }}" rel="noreferrer" title="Peertube" target="_blank">Peertube</a>
-      </li>
-      {{ end}}
-      {{ with $site_social_links.github }}
-      <li class="github">
-        <a href="{{ . }}" rel="noreferrer" title="Github" target="_blank">GitHub</a>
-      </li>
-      {{ end}}
-      {{ with $site_social_links.linkedin }}
-      <li class="linkedin">
-        <a href="{{ . }}" rel="noreferrer" title="LinkedIn" target="_blank">LinkedIn</a>
-      </li>
-      {{ end}}
-      {{ with $site_social_links.youtube }}
-      <li class="youtube">
-        <a href="{{ . }}" rel="noreferrer" title="YouTube" target="_blank">YouTube</a>
-      </li>
-      {{ end}}
-      {{ with $site_social_links.vimeo }}
-      <li class="vimeo">
-        <a href="{{ . }}" rel="noreferrer" title="Vimeo" target="_blank">Vimeo</a>
-      </li>
-      {{ end}}
-      {{ with $site_social_links.instagram }}
-      <li class="instagram">
-        <a href="{{ . }}" rel="noreferrer" title="Instagram" target="_blank">Instagram</a>
-      </li>
-      {{ end}}
-      {{ with $site_social_links.facebook }}
-      <li class="facebook">
-        <a href="{{ . }}" rel="noreferrer" title="" target="_blank">Facebook</a>
-      </li>
-      {{ end}}
-      {{ with $site_social_links.tiktok }}
-      <li class="tiktok">
-        <a href="{{ . }}" rel="noreferrer" title="TikTok" target="_blank">TikTok</a>
-      </li>
-      {{ end}}
-      {{ with $site_social_links.x }}
-      <li class="x">
-        <a href="{{ . }}" rel="noreferrer" title="X, ex-Twitter" target="_blank">X (ex-Twitter)</a>
-      </li>
-      {{ end}}
+      {{ partial "commons/socials" . }}
     </ul>
   {{ end }}
 {{ end }}


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

- J'ai déplacé le tableau des horaires dans le dom, afin qu'il soit dans la grid `.contacts`
- Ce tableau, dans le cas où tous les champs sont remplis, je lui donne la class `.reduced`, qui me permet de le placer à côté des RS, sur 2/3 de la grille, mais uniquement en pleine largeur.
- J'ai créé un partiel "commons/socials" pour réutiliser les liens rs du footer

## Niveau d'incidence

- [ ] Incidence faible 😌
- [X] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

[figma](https://www.figma.com/design/tQh3oLfNwSt8aoVDuUjQt0/Th%C3%A8me-Osuny?node-id=11180-13432&t=2svkU8DxVCq9k01w-1)

## URL de test sur example.osuny.org

[http://localhost:1313/fr/blocks/blocks-techniques/contact/](http://localhost:1313/fr/blocks/blocks-techniques/contact/)

Pour tester il faut ajouter le champ socials au bloc : 

```
      socials:
        mastodon: >-
          https://www.linkedin.com/company/osuny/
        peertube: >-
          https://www.linkedin.com/company/osuny/
        x: >-
          https://www.linkedin.com/company/osuny/
        github: >-
          https://www.linkedin.com/company/osuny/
        linkedin: >-
          https://www.linkedin.com/company/osuny/
        youtube: >-
          https://www.linkedin.com/company/osuny/
        vimeo: >-
          https://www.linkedin.com/company/osuny/
        instagram: >-
          https://www.linkedin.com/company/osuny/
        facebook: >-
          https://www.linkedin.com/company/osuny/
        tiktok: >-
          https://www.linkedin.com/company/osuny/
```

## Screenshots

### En pleine largeur, avec et sans le tableau en reduced : 
![Capture d’écran 2024-06-07 à 16 03 45](https://github.com/osunyorg/theme/assets/91660674/9bb47e46-7a8e-4855-8a0d-4677a12d1e03)
![Capture d’écran 2024-06-07 à 15 39 50](https://github.com/osunyorg/theme/assets/91660674/c3b1ccc0-4cf2-47d9-9657-4f7c34a13bff)

### En largeur partielle, pareil avec et sans reduced : 
![Capture d’écran 2024-06-07 à 15 40 05](https://github.com/osunyorg/theme/assets/91660674/52f8365b-c37c-413d-840e-e5e604096b66)
![Capture d’écran 2024-06-07 à 15 40 12](https://github.com/osunyorg/theme/assets/91660674/fe1d8d81-48bf-4c70-aec0-349a8adb681c)

### Et en mobile : 
![Capture d’écran 2024-06-07 à 16 33 08](https://github.com/osunyorg/theme/assets/91660674/f2c9ae82-03c6-41b8-b533-f71dcdef3c7d)
