### PR TITLE
Bug d'affichage du toc en mobile (ellipsis du texte)

### DIFF
--- a/assets/sass/_theme/design-system/button.sass
+++ b/assets/sass/_theme/design-system/button.sass
@@ -66,7 +66,6 @@
     @include button-reset
     line-height: $body-line-height
     white-space: nowrap
-    min-width: fit-content
     @if $icon
         @include icon-block($icon, after)
 

--- a/assets/sass/_theme/design-system/table_of_contents.sass
+++ b/assets/sass/_theme/design-system/table_of_contents.sass
@@ -100,7 +100,7 @@
         line-height: inherit
         cursor: pointer
         padding: 0
-        min-width: inherit
+        min-width: initial
         span
             @include meta
             color: $toc-color

--- a/assets/sass/_theme/design-system/table_of_contents.sass
+++ b/assets/sass/_theme/design-system/table_of_contents.sass
@@ -100,6 +100,7 @@
         line-height: inherit
         cursor: pointer
         padding: 0
+        min-width: inherit
         span
             @include meta
             color: $toc-color

--- a/assets/sass/_theme/design-system/table_of_contents.sass
+++ b/assets/sass/_theme/design-system/table_of_contents.sass
@@ -100,7 +100,6 @@
         line-height: inherit
         cursor: pointer
         padding: 0
-        min-width: initial
         span
             @include meta
             color: $toc-color


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

La propriété `text-overflow: ellipsis` ne s'appliquait plus dans le cta du toc, parce qu'une min-width était imposée à ce dernier :
![Capture d’écran 2024-06-10 à 10 56 00](https://github.com/osunyorg/theme/assets/91660674/dfe720ee-f967-4d12-8e47-ae6354ff41f6)

Je l'ai remise à une valeur initiale (pour ce cta-là uniquement)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

Bug remonté par @arnaudlevy 

## URL de test du site [EnCommuns](https://github.com/osunyorg/encommuns-site)

`http://localhost:1313/articles/2024-05-22-linternet-que-nous-aurions-pu-avoir/`