### PR TITLE
Ajustement de l'affichage des dates des événements en mobile

### DIFF
--- a/assets/sass/_theme/sections/events.sass
+++ b/assets/sass/_theme/sections/events.sass
@@ -239,7 +239,7 @@
                 a 
                     @include stretched-link
             &-dates 
-                @include h3
+                @include h4
                 margin-top: $spacing-2
             &-content
                 flex: 1

--- a/assets/sass/_theme/sections/events.sass
+++ b/assets/sass/_theme/sections/events.sass
@@ -228,7 +228,7 @@
             position: relative
             gap: var(--grid-gutter)
             + .event 
-                margin-top: var(--grid-gutter)
+                margin-top: $spacing-5
             &-content
                 display: flex
                 flex-direction: column
@@ -239,12 +239,14 @@
                 a 
                     @include stretched-link
             &-dates 
-                @include meta
+                @include h3
                 margin-top: $spacing-2
             &-content
                 flex: 1
-                .event-title
-                    @include h3
+                .event-title,
+                .event-subtitle, 
+                hgroup
+                    @include h2
                 .more
                     @include icon("arrow-right", after)
                     margin-top: $spacing-3
@@ -257,15 +259,12 @@
                     object-fit: cover
                     width: 100%
             @include media-breakpoint-up(desktop)
+                + .event 
+                    margin-top: var(--grid-gutter)
                 .media
                     width: columns(4)
                 .event-dates
-                    @include h3
                     margin-bottom: $spacing-4
-                .event-title,
-                .event-subtitle, 
-                hgroup
-                    @include h2
             @include media-breakpoint-down(desktop)
                 flex-direction: column
                 .media

--- a/layouts/partials/events/event.html
+++ b/layouts/partials/events/event.html
@@ -26,9 +26,15 @@
         </hgroup>
       {{ end }}
 
-      {{ if (or .Params.dates.computed.two_lines.short .Params.dates.from.hour .Params.dates.to.hour) }}
+      {{ if (or .Params.dates.computed.short .Params.dates.computed.two_lines.short .Params.dates.from.hour .Params.dates.to.hour) }}
         <div class="event-dates" itemprop="startDate" content="{{- if .Params.dates.from.day -}}{{ .Params.dates.from.day }}{{- end -}}{{- if .Params.dates.from.hour -}}T{{ .Params.dates.from.hour }}{{- end -}}">
-          <span>{{ partial "PrepareHTML" .Params.dates.computed.two_lines.short }}</span>
+          <span>
+            {{ $date_format := .Params.dates.computed.two_lines.short }}
+            {{ if ne $layout "list" }}
+              {{ $date_format = .Params.dates.computed.short }}
+            {{ end }}
+            {{ partial "PrepareHTML" $date_format }}
+          </span>
           {{- if (or .Params.dates.from.hour .Params.dates.to.hour) }}
             <div class="event-time">
               {{- if .Params.dates.from.hour }}


### PR DESCRIPTION
…or large layout + spacings between events

## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Dans le figma du bloc agenda, les dates sont en style h3 pour le layout liste et le layout large, mais en méta pour le layout grid. Ce n'était pas le cas en prod où le layout large avait le style méta en mobile. J'ai donc corrigé ceci : 
- la date du layout large s'affiche bien en `h4` sur mobile, comme pour le layout liste
- le titre et le sous-titre de l'event s'affichent en `h2` également sur mobile en layout large
- augmentation de l'espacement entre les events en large (pb de migration je pense, car usage de la var grid-gutter) en mobile
- côté **html** : on utilisait `.Params.dates.computed.two_lines.short` alors que sur le figma ce n'est utilisé que par le layout liste, j'ai donc créé une variable $date_format utilisant cette donnée par défaut (comme list est le layout par défaut) et si le layout est différent, on utilise `Params.dates.computed.short`

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

[#35](https://github.com/osunyorg/lacriee-site/issues/35)

## URL de test sur example.osuny.org

[http://localhost:1313/fr/blocks/blocs-de-liste/agenda-1/](http://localhost:1313/fr/blocks/blocs-de-liste/agenda-1/)

## URL de test du site (optionnel)

Accueil de La Criée ([repo](https://github.com/osunyorg/lacriee-site))

## Screenshots

### Layout large :
![Capture d’écran 2024-06-11 à 11 15 53](https://github.com/osunyorg/theme/assets/91660674/de08d7b1-643d-4168-b41c-fcafbda755a8)

### Layout liste
![Capture d’écran 2024-06-11 à 11 16 06](https://github.com/osunyorg/theme/assets/91660674/b6aec2d4-1c19-4942-bde4-79a7eb259f4f)

Et sur la Criée on homogénéise :
![Capture d’écran 2024-06-11 à 11 32 09](https://github.com/osunyorg/theme/assets/91660674/dcec4fba-17e0-4610-b9e9-cb7548e60493)
