### PR TITLE
Gestion de la taille des icônes png dans les blocs key_figures et features

### DIFF
--- a/assets/sass/_theme/blocks/features.sass
+++ b/assets/sass/_theme/blocks/features.sass
@@ -17,7 +17,14 @@
                 @include meta
                 margin-top: $spacing-2
                 text-align: right
-
+            picture.is-png
+                display: block
+                padding-top: $spacing-3
+                img
+                    margin: initial
+                    max-width: $block-features-icon-max-width
+                @include media-breakpoint-down(desktop)
+                    margin-bottom: $spacing-2
     @include in-page-with-sidebar
         li
             flex-direction: row

--- a/assets/sass/_theme/blocks/features.sass
+++ b/assets/sass/_theme/blocks/features.sass
@@ -32,6 +32,9 @@
                 width: columns(2)
                 flex-shrink: 0
                 margin-right: var(--grid-gutter)
+                picture.is-png
+                    img
+                        margin: auto
 
     @include in-page-without-sidebar
         .top

--- a/assets/sass/_theme/blocks/key_figures.sass
+++ b/assets/sass/_theme/blocks/key_figures.sass
@@ -33,14 +33,11 @@
                 max-width: $block-key_figures-image-max-width
             picture.is-png 
                 img
-                    max-width: pxToRem(50)
+                    max-width: $block-key_figures-icon-max-width
             @include media-breakpoint-up(desktop)
                 font-size: $block-key_figures-font-size-desktop
                 strong
                     font-size: $block-key_figures-number-font-size-desktop
-                picture.is-png 
-                    img
-                        max-width: pxToRem(60)
             @include media-breakpoint-up(lg)
                 font-size: $block-key_figures-font-size-lg
                 strong

--- a/assets/sass/_theme/blocks/key_figures.sass
+++ b/assets/sass/_theme/blocks/key_figures.sass
@@ -31,10 +31,16 @@
                 display: block
                 margin-bottom: $spacing-2
                 max-width: $block-key_figures-image-max-width
+            picture.is-png 
+                img
+                    max-width: pxToRem(50)
             @include media-breakpoint-up(desktop)
                 font-size: $block-key_figures-font-size-desktop
                 strong
                     font-size: $block-key_figures-number-font-size-desktop
+                picture.is-png 
+                    img
+                        max-width: pxToRem(60)
             @include media-breakpoint-up(lg)
                 font-size: $block-key_figures-font-size-lg
                 strong

--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -79,6 +79,7 @@ $block-key_figures-number-font-family: $heading-font-family !default
 $block-key_figures-unit-font-weight: normal !default
 $block-key_figures-number-font-weight: bold !default
 $block-key_figures-image-max-width: $spacing-6 !default
+$block-key_figures-icon-max-width: pxToRem(60) !default
 
 $block-key_figures-font-size: pxToRem(16) !default
 $block-key_figures-number-font-size: pxToRem(32) !default

--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -112,3 +112,6 @@ $block-links-card-background: var(--color-background-alt) !default
 $block-links-card-color: var(--color-text) !default
 $block-links-card-hover-background: var(--color-accent) !default
 $block-links-card-hover-color: var(--color-background) !default
+
+// Bloc fonctionnalités
+$block-features-icon-max-width: pxToRem(80) !default

--- a/layouts/partials/blocks/templates/key_figures.html
+++ b/layouts/partials/blocks/templates/key_figures.html
@@ -20,7 +20,6 @@
           {{ end }}
           <ul class="{{ $list_class }}">
             {{- range .figures }}
-              
               <li>
                 <dl>
                   <dt>

--- a/layouts/partials/commons/image.html
+++ b/layouts/partials/commons/image.html
@@ -33,7 +33,7 @@
       {{ $image_class = "is-svg" }}
     {{ end }}
 
-    <picture {{ if or $is_png $is_svg }}class="{{ $image_class }}"{{ end }}>
+    <picture {{ with $image_class }}class="{{ . }}"{{ end }}>
 
       {{- if strings.HasSuffix $image.name "svg" -}}
 

--- a/layouts/partials/commons/image.html
+++ b/layouts/partials/commons/image.html
@@ -35,7 +35,7 @@
 
     <picture {{ with $image_class -}} class="{{ . }}" {{- end }}>
 
-      {{- if strings.HasSuffix $image.name "svg" -}}
+      {{- if $is_svg -}}
 
         <img src="{{ partial "GetImageUrl" (dict "url" $url) }}"
             alt="{{ chomp (plainify $alt) }}"

--- a/layouts/partials/commons/image.html
+++ b/layouts/partials/commons/image.html
@@ -33,7 +33,7 @@
       {{ $image_class = "is-svg" }}
     {{ end }}
 
-    <picture {{ with $image_class }}class="{{ . }}"{{ end }}>
+    <picture {{ with $image_class -}} class="{{ . }}" {{- end }}>
 
       {{- if strings.HasSuffix $image.name "svg" -}}
 

--- a/layouts/partials/commons/image.html
+++ b/layouts/partials/commons/image.html
@@ -24,8 +24,16 @@
     {{- if .crop -}}
       {{- $crop = true -}}
     {{- end -}}
+    {{ $image_class := "" }}
+    {{ $is_png := strings.HasSuffix $image.name "png" }}
     {{ $is_svg := strings.HasSuffix $image.name "svg" }}
-    <picture {{ if $is_svg }}class="is-svg"{{ end }}>
+    {{ if $is_png }}
+      {{ $image_class = "is-png" }}
+    {{ else if $is_svg }}
+      {{ $image_class = "is-svg" }}
+    {{ end }}
+
+    <picture {{ if or $is_png $is_svg }}class="{{ $image_class }}"{{ end }}>
 
       {{- if strings.HasSuffix $image.name "svg" -}}
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Certaines personnes pourraient être tentées d'ajouter des icônes d'illustrations dans les chiffres clés et les fonctionnalités. Pour le moment, elles sont énormes et il s'agit donc de rendre tout ça joli.
En soi, le thème gérait déjà la présence de petites icônes, mais si on en met une énorme, alors il n'y avait pas de délimitation de taille.

- Dans le partial image, comme pour la class `is-svg`, on détecte la présence d'un png
- En s'appuyant sur `picture.is-png` dans les features/key_figures, on ajoute une taille max que j'ai ajouté en variable (`$block-features-icon-max-width` et `$block-key_figures-icon-max-width`)

Ça implique quelques légers changement de style (annulations) du côté des features, mais rien de dérangeant (d'ailleurs la prod n'était pas conforme à la maquette, où les icônes sont alignées à gauche (là elles sont au milieu).

## Niveau d'incidence

- [] Incidence faible 😌
- [X] Incidence moyenne 😲 → p-e repasse sur les sites pour vérifier que des png ne sont pas pétés ?
- [ ] Incidence forte 😱

## URL de test sur example

- Pour les features : [http://localhost:1313/fr/blocks/blocks-narratifs/les-fonctionnalites/#fonctionnalites-avec-des-icones-png](http://localhost:1313/fr/blocks/blocks-narratifs/les-fonctionnalites/#fonctionnalites-avec-des-icones-png)
- Pour les key_figures : [http://localhost:1313/fr/blocks/blocks-narratifs/chiffre-cles/#plusieurs-chiffres-cles-avec-des-icones-png](http://localhost:1313/fr/blocks/blocks-narratifs/chiffre-cles/#plusieurs-chiffres-cles-avec-des-icones-png)

## URL de test du site : [EPV](https://github.com/osunyorg/epv-site)

- Pour les features : [http://localhost:1313/fr/le-label-epv/candidater-au-label/](http://localhost:1313/fr/le-label-epv/candidater-au-label/)
- Pour les key_figures : [http://localhost:1313/fr/le-label-epv/presentation-du-label/](http://localhost:1313/fr/le-label-epv/presentation-du-label/)

## Screenshots

### Les chiffres clés : 

![Capture d’écran 2024-06-11 à 18 06 25](https://github.com/osunyorg/theme/assets/91660674/9e259afb-60db-404d-8d05-a01088df316c)

#### Sur EPV : 
![Capture d’écran 2024-06-11 à 17 04 00](https://github.com/osunyorg/theme/assets/91660674/32edbf51-6404-4520-b1e8-621e2f8a5596)
![Capture d’écran 2024-06-11 à 17 04 13](https://github.com/osunyorg/theme/assets/91660674/84b55da8-e2a9-4819-8719-0771f4717163)

### Les features
![Capture d’écran 2024-06-11 à 17 57 01](https://github.com/osunyorg/theme/assets/91660674/e3608f9c-548e-4647-a4a4-41c156f6652d)
![Capture d’écran 2024-06-11 à 17 57 14](https://github.com/osunyorg/theme/assets/91660674/8defe8e0-40d4-4e24-9f1e-9cdaeea55407)

#### Sur EPV : 
![Capture d’écran 2024-06-11 à 17 23 03](https://github.com/osunyorg/theme/assets/91660674/cc51188c-a81b-4b8d-a678-aa788efca7ae)
![Capture d’écran 2024-06-11 à 17 22 37](https://github.com/osunyorg/theme/assets/91660674/855d84f5-bdf4-46ad-be36-7c904cb59152)
