### PR TITLE
Ajout d'une option d'inversement de la navigation précédente / suivante

### DIFF
--- a/layouts/events/single.html
+++ b/layouts/events/single.html
@@ -19,6 +19,7 @@
       "context" .
       "previous_label" (i18n "events.previous")
       "next_label" (i18n "events.next")
+      "reversed" (not .Params.dates.archive)
     ) }}
 
     {{ partial "hooks/before-document-content-end.html" . }}

--- a/layouts/partials/commons/siblings-navigation.html
+++ b/layouts/partials/commons/siblings-navigation.html
@@ -1,15 +1,24 @@
 {{/*  TODO: Create a generic previous / next section for single section  */}}
 {{ $previous_label := .previous_label | default (i18n "posts.previous") }}
 {{ $next_label := .next_label | default (i18n "posts.next") }}
+{{ $reversed := .reversed | default false }}
 
 {{ with .context }}
+
+  {{ $previous_content := .PrevInSection }}
+  {{ $next_content := .NextInSection }}
+  {{ if $reversed }}
+    {{ $previous_content = .NextInSection }}
+    {{ $next_content = .PrevInSection }}
+  {{ end }}
+
   {{- if or .PrevInSection .NextInSection -}}
   <div class="block block-siblings-navigation">
     <div class="container">
       <div class="block-content">
         <nav class="siblings-navigation" aria-label="{{ i18n "commons.pagination.between.posts" }}">
           <ul>
-            {{ with .PrevInSection }}
+            {{ with $previous_content }}
               <li class="previous">
                 {{ $title := partial "PrepareHTML" .Title -}}
                 <a href="{{.RelPermalink}}" title="{{ safeHTML (i18n "posts.previous_aria" (dict "Title" $title)) }}">
@@ -20,7 +29,7 @@
                 </a>
               </li>
             {{ end }}
-            {{ with .NextInSection }}
+            {{ with $next_content }}
               <li class="next">
                 {{ $title := partial "PrepareHTML" .Title -}}
                 <a href="{{.RelPermalink}}" title="{{ safeHTML (i18n "posts.next_aria" (dict "Title" $title)) }}">


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

La navigation événement précédent / suivant doit respecter la chronologie temporel : 
Pour les événements à venir ou en cours on inverse la navigation, l'événement suivant est l'événement dont la date de début est après.
Pour les événements archivés on garde la navigation que pour posts, projects et publications.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

## Screenshots

![image](https://github.com/osunyorg/theme/assets/4630530/2f097347-1af4-4bce-8d0c-b066c5cd8411)

