### PR TITLE
Feat: Add a base_url arg defaulting to `/`

### DIFF
--- a/bin/osuny.js
+++ b/bin/osuny.js
@@ -19,6 +19,7 @@ console.log(`
  `);
 
 const command = process.argv[2];
+const base_url = process.argv[3] || "/";
 
 let pagefindExclude = '';
 // Categories: No list of categories
@@ -59,13 +60,13 @@ if (command === "dev") {
 
 if (command === "build") {
     execute("yarn upgrade");
-    execute("hugo --minify");
+    execute("hugo --minify --base_url=" + base_url);
     execute("npm_config_yes=true npx pagefind --site 'public' --exclude-selectors '" + pagefindExclude + "'");
 }
 
 if (command === "percy-build") {
     execute("yarn upgrade");
-    execute("hugo --baseURL=/");
+    execute("hugo --baseURL=" + base_url);
     execute("npm_config_yes=true npx pagefind --site 'public' --exclude-selectors '" + pagefindExclude + "'");
 }
 


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

J'ai besoin de controller l'URL du site généré lors d'un `yarn osuny build`.

Désormais :

* `yarn osuny build` va _build_ pour `/`.
* `yarn osuny build https://autruche.bird` va _build_ pour `https://autruche.bird`.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
