### PR TITLE
Passage de la weight Pagefind des H1 de 7 à 10

### DIFF
--- a/layouts/partials/header/hero.html
+++ b/layouts/partials/header/hero.html
@@ -13,9 +13,9 @@
 
 {{ $button := .button | default .context.Params.header_cta }}
 
-{{ $title_attribute := "" }}
+{{ $title_attribute := "" | safeHTMLAttr }}
 {{ if site.Params.search.active }}
-  {{ $title_attribute = "data-pagefind-weight=\"10\"" }}
+  {{ $title_attribute = "data-pagefind-weight='10'" | safeHTMLAttr }}
 {{ end }}
 
 {{ if not $subtitle }}

--- a/layouts/partials/header/hero.html
+++ b/layouts/partials/header/hero.html
@@ -13,6 +13,11 @@
 
 {{ $button := .button | default .context.Params.header_cta }}
 
+{{ $title_attribute := "" }}
+{{ if site.Params.search.active }}
+  {{ $title_attribute = "data-pagefind-weight=\"10\"" }}
+{{ end }}
+
 {{ if not $subtitle }}
   {{ if and (eq site.Params.summary.position "hero") $summary }}
     {{ $subtitle = $summary }}
@@ -29,7 +34,7 @@
       <div class="hero-text">
         {{ if or $subtitle $description }}
           <hgroup>
-            <h1 data-pagefind-weight="10">{{ partial "PrepareHTML" .title }}</h1>
+            <h1 {{ $title_attribute }}>{{ partial "PrepareHTML" .title }}</h1>
             {{ if $subtitle }}
               <p {{ if $subtitle_is_summary }} class="lead" {{ end }}>{{ partial "PrepareHTML" $subtitle }}</p>
             {{ end }}
@@ -38,7 +43,7 @@
             {{ end }}
           </hgroup>
         {{ else }}
-          <h1 data-pagefind-weight="10">{{ partial "PrepareHTML" .title }}</h1>
+          <h1 {{ $title_attribute }}>{{ partial "PrepareHTML" .title }}</h1>
         {{ end }}
 
         {{ with $button }}

--- a/layouts/partials/header/hero.html
+++ b/layouts/partials/header/hero.html
@@ -29,7 +29,7 @@
       <div class="hero-text">
         {{ if or $subtitle $description }}
           <hgroup>
-            <h1>{{ partial "PrepareHTML" .title }}</h1>
+            <h1 data-pagefind-weight="10">{{ partial "PrepareHTML" .title }}</h1>
             {{ if $subtitle }}
               <p {{ if $subtitle_is_summary }} class="lead" {{ end }}>{{ partial "PrepareHTML" $subtitle }}</p>
             {{ end }}
@@ -38,7 +38,7 @@
             {{ end }}
           </hgroup>
         {{ else }}
-          <h1>{{ partial "PrepareHTML" .title }}</h1>
+          <h1 data-pagefind-weight="10">{{ partial "PrepareHTML" .title }}</h1>
         {{ end }}
 
         {{ with $button }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Passage de la weight Pagefind des H1 de 7 à 10 pour mieux faire remonter les pages ayant un titre comportant le terme recherché

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/bordeauxmontaigne-iut/issues/87

