### PR TITLE
fix issue with min-height and margin-bottom from child

### DIFF
--- a/assets/sass/_theme/design-system/hero.sass
+++ b/assets/sass/_theme/design-system/hero.sass
@@ -59,10 +59,10 @@
                     margin-left: var(--grid-gutter-negative)
                     margin-right: var(--grid-gutter-negative)
         &--image-portrait, &--image-square
+            margin-bottom: $spacing-7
             .container
                 display: flex
                 flex-direction: column
-                margin-bottom: $spacing-7
             figure
                 margin-bottom: calc(#{-$spacing-7} + #{$spacing-4})
 
@@ -95,4 +95,3 @@
         margin-top: 0
         @include media-breakpoint-down(desktop)
             margin-bottom: $spacing-5
-


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Quand le contenu du hero est plus petit en hauteur que la min-height appliquée, cela casse la margin-bottom de l'enfant direct .hero > .container sur Chrome OS X et Firefox (on soupçonne un bug de webkit).

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


