### PR TITLE
Problème d'affichage du crédit seul dans les blocs galerie & image

### DIFF
--- a/assets/sass/_theme/blocks/gallery.sass
+++ b/assets/sass/_theme/blocks/gallery.sass
@@ -65,7 +65,7 @@
                     display: flex
                     justify-content: space-between
                     align-items: baseline
-                    p
+                    > p
                         max-width: columns(8)
                     *
                         flex: 1 1

--- a/assets/sass/_theme/blocks/image.sass
+++ b/assets/sass/_theme/blocks/image.sass
@@ -64,7 +64,7 @@
                 display: flex
                 justify-content: space-between
                 align-items: baseline
-                p
+                > p
                     max-width: columns(8)
                 *
                     flex: 1 1


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Dans un contexte d'image paysage ou de bloc galerie avec layout large dans une page en pleine largeur, si le texte de l'image n'était pas renseigné, le crédit apparaissait flottant. Il prenait en réalité la largeur donnée au texte, uniquement sélectionné via `p` à l'intérieur du `figcaption`, j'ai donc scopé à `figcaption > p` et le crédit seul prend maintenant toute la largeur, avec texte à droite.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/blocks-narratifs/galeries/#galerie-large`
`http://localhost:1313/fr/blocks/blocks-de-base/image/`

## Screenshots

### Dans le bloc galerie : 

![Capture d’écran 2024-06-27 à 11 57 47](https://github.com/osunyorg/theme/assets/91660674/738e34c2-6e54-4a7d-910a-b122bb4bbeaa)
![Capture d’écran 2024-06-27 à 11 58 09](https://github.com/osunyorg/theme/assets/91660674/5137ddae-4f0a-43ea-bd59-d87ea37cb2f9)

### Dans le bloc image : 

![Capture d’écran 2024-06-27 à 11 57 24](https://github.com/osunyorg/theme/assets/91660674/eb9d1267-ceb2-462e-84b4-97e96a12fa09)
![Capture d’écran 2024-06-27 à 11 58 23](https://github.com/osunyorg/theme/assets/91660674/c6c4099f-2779-49c7-88d0-59ac0b845a1f)
