### PR TITLE
Partiel pour les liens de téléchargement accessible

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -108,6 +108,7 @@ commons:
   link:
     blank: extern link
     blank_aria: “{{ .Title }}” - extern link
+    download: “Download {{ .Title }}” - extern link
   menu:
     label: Toggle navigation
     legal: Legals menu

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -108,6 +108,7 @@ commons:
   link:
     blank: lien externe
     blank_aria: “{{ .Title }}” - lien externe
+    download: Télécharger “{{ .Title }}” - lien externe
   menu:
     label: Ouvrir / Fermer le menu
     legal: Menu pages légales

--- a/layouts/partials/blocks/templates/files.html
+++ b/layouts/partials/blocks/templates/files.html
@@ -14,32 +14,15 @@
         <ul class="files">
           {{- range .files }}
             {{ if ne .id "" }}
-              {{- $file := partial "GetMedia" .id -}}
-              {{ if $file }}
+              {{ if partial "GetMedia" .id }}
                 <li>
-                  {{- $title := .title -}}
-                  {{- if (not $title) }}
-                    {{ $title = $file.name }}
-                  {{ end -}}
-                  {{- $size := partial "GetHumanSize" $file.size -}}
-                  {{- $extension := partial "GetExtensionFile" $file.name -}}
-                  {{- $extension_with_size := (printf "%.2f %s - %s" $size.weight $size.unit $extension) -}}
-                  {{- $title_with_size := printf "%s (%s)" $title $extension_with_size -}}
-                  {{- $url := $file.url -}}
-                  {{- if site.Params.keycdn -}}
-                    {{- $url = $file.direct_url -}}
-                  {{- end -}}
-                  {{ if $file }}
-                    <figure>
-                      <a href="{{ $url }}" download="{{ partial "PrepareHTML" $file.name }}" target="_blank" title="{{ i18n "commons.link.blank_aria" (dict "Title" $title_with_size) }}">
-                        {{ $title }}
-                      </a>
-                      <figcaption>
-                        <abbr title="{{ i18n (printf "commons.extensions.%s" $extension) }}">{{ $extension }}</abbr>
-                        - {{ $size.weight }} <abbr title="{{ $size.full_unit }}">{{ $size.unit }}</abbr>
-                      </figcaption>
-                    </figure>
-                  {{ end }}
+                  <figure>
+                    {{ partial "commons/download-link" (dict 
+                      "id" .id
+                      "title" .title
+                      "with_caption" true
+                    ) }}
+                  </figure>
                 </li>
               {{ end -}}
             {{ end -}}

--- a/layouts/partials/commons/download-link.html
+++ b/layouts/partials/commons/download-link.html
@@ -1,0 +1,32 @@
+{{ $file := partial "GetMedia" .id }}
+{{ $title := .title }}
+{{ $with_caption := .with_caption }}
+
+{{ if $file }}
+  {{ if (not $title) }}
+    {{ $title = $file.name }}
+  {{ end }}
+
+  {{ $a11y_title := $title }}
+  {{ if .use_filename_for_a11y_title }}
+    {{ $a11y_title = $file.name }}
+  {{ end }}
+
+  {{ $size := partial "GetHumanSize" $file.size }}
+  {{ $extension := partial "GetExtensionFile" $file.name }}
+  {{ $extension_with_size := (printf "%.2f %s - %s" $size.weight $size.unit $extension) }}
+  {{ $title_with_size := printf "%s (%s)" $a11y_title $extension_with_size }}
+  {{ $url := $file.url }}
+  {{ if site.Params.keycdn }}
+    {{ $url = $file.direct_url }}
+  {{ end }}
+  <a href="{{ $url }}" download="{{ partial "PrepareHTML" $file.name }}" target="_blank" title="{{ i18n "commons.link.download" (dict "Title" $title_with_size) }}">
+    {{ $title }}
+  </a>
+  {{ if .with_caption }}
+    <figcaption>
+      <abbr title="{{ i18n (printf "commons.extensions.%s" $extension) }}">{{ $extension }}</abbr>
+      - {{ $size.weight }} <abbr title="{{ $size.full_unit }}">{{ $size.unit }}</abbr>
+    </figcaption>
+  {{ end }}
+{{ end }}

--- a/layouts/partials/programs/essential.html
+++ b/layouts/partials/programs/essential.html
@@ -33,16 +33,11 @@
         </div>
       {{ end }}
 
-      {{ with .Params.downloadable_summary }}
-        {{- $file := partial "GetMedia" . -}}
-        {{- if $file -}}
-          {{- $url := $file.url -}}
-          {{- if site.Params.keycdn -}}
-            {{- $url = $file.direct_url -}}
-          {{- end -}}
-          <a href="{{ $url }}" download target="_blank">{{ i18n "commons.download.singular_name" }}</a>
-        {{- end -}}
-      {{ end }}
+      {{ partial "commons/download-link" (dict 
+        "id" .Params.downloadable_summary
+        "title" (i18n "commons.download.singular_name")
+        "use_filename_for_a11y_title" true
+      ) }}
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [x] Rangement

## Description

Ajout d'un partiel pour gérer les liens de téléchargement.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots

Lien de téléchargement d'un programme : 

![image](https://github.com/osunyorg/theme/assets/4630530/18c81bba-be0d-4b37-9563-da726c068480)

Lien de téléchargement d'un bloc fichier avec un titre :  
![image](https://github.com/osunyorg/theme/assets/4630530/3f1ef437-43c0-4a02-b40d-853065935da1)

Lien de téléchargement d'un bloc fichier sans titre (fallback sur le nom du fichier) : 
![image](https://github.com/osunyorg/theme/assets/4630530/7ebdfc0f-9460-423e-a25d-efaa36208235)
  
