### PR TITLE
Ajustement de la taille du bouton de partage d'une formation lorsqu'il est seul

### DIFF
--- a/assets/sass/_theme/sections/diplomas.sass
+++ b/assets/sass/_theme/sections/diplomas.sass
@@ -137,7 +137,9 @@ ul.diplomas
             button, > a
                 max-width: columns(3)
         @include media-breakpoint-up(xl)
-            --btn-min-width: #{columns(2)}
+            .dropdown-share,
+            &
+                --btn-min-width: #{columns(2)}
         @include media-breakpoint-down(desktop)
             margin-top: $spacing-3
     .container


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

En cherchant partout des cas d'utilisation des icônes, je suis tombée sur une page de formation qui n'a pas de lien de téléchargement vers une plaquette ou autre dans son hero. Cela donne ça : 
![Capture d’écran 2024-07-02 à 17 20 49](https://github.com/osunyorg/theme/assets/91660674/a6452eba-2f93-4a69-a5c0-33a468455b4a)

Alors qu'avec le bouton de téléchargement on a ça : 
![Capture d’écran 2024-07-02 à 17 20 38](https://github.com/osunyorg/theme/assets/91660674/a0c1ef25-59d8-4618-819b-c87aab8281ed)

En fait, on avait cette partie de code qui devait changer la taille du composant bouton dans `diplomas.sass` : 
```
@include media-breakpoint-up(xl)
            --btn-min-width: #{columns(2)}
```
Elle le fait bien pour le lien de téléchargement, mais elle n'est pas assez précise pour overider le composant `dropdown-share` (dans `button.sass`) dont la première ligne est celle-ci : 

```
.dropdown-share
    --btn-min-width: #{pxToRem(140)}
```

Il faut donc préciser le contexte et pour cela j'ai simplement changé le scope de cette façon (dans `diplomas.sass`) : 
```
@include media-breakpoint-up(xl)
            .dropdown-share,
            &
                --btn-min-width: #{columns(2)}
```

Peut-être que c'est mieux d'écrire `.dropdown-share, &` sur une seule ligne ? 

EDIT : serait-il pertinent de passer la min-width en paramètre ? Ou c'est juste un cas isolé et ça ne justifie pas ce changement ?

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

[http://localhost:1313/fr/offre-de-formation/information-communication/eco-conception-de-service-numerique/](http://localhost:1313/fr/offre-de-formation/information-communication/eco-conception-de-service-numerique/)

## Screenshots

![Capture d’écran 2024-07-02 à 17 42 26](https://github.com/osunyorg/theme/assets/91660674/e0c636ea-354f-4419-937b-f350b754c4c8)
