### PR TITLE
Icônes du bloc liens

### DIFF
--- a/assets/sass/_theme/blocks/links.sass
+++ b/assets/sass/_theme/blocks/links.sass
@@ -32,6 +32,11 @@
                 width: 100%
                 height: 100%
                 aspect-ratio: 16/9
+            picture.is-png 
+                img
+                    aspect-ratio: auto
+                    margin: space(4) space(4) 0
+                    max-width: $block-links-icon-max-width
         &:hover
             background-color: $block-links-card-hover-background
             &, a

--- a/assets/sass/_theme/blocks/links.sass
+++ b/assets/sass/_theme/blocks/links.sass
@@ -26,7 +26,6 @@
             @include small
             margin-top: space(3)
         .media
-
             picture:not(.is-png) 
                 img
                     display: block

--- a/assets/sass/_theme/blocks/links.sass
+++ b/assets/sass/_theme/blocks/links.sass
@@ -26,15 +26,16 @@
             @include small
             margin-top: space(3)
         .media
-            img
-                display: block
-                object-fit: cover
-                width: 100%
-                height: 100%
-                aspect-ratio: 16/9
+
+            picture:not(.is-png) 
+                img
+                    display: block
+                    object-fit: cover
+                    width: 100%
+                    height: 100%
+                    aspect-ratio: 16/9
             picture.is-png 
                 img
-                    aspect-ratio: auto
                     margin: space(4) space(4) 0
                     max-width: $block-links-icon-max-width
         &:hover

--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -112,6 +112,7 @@ $block-links-card-background: var(--color-background-alt) !default
 $block-links-card-color: var(--color-text) !default
 $block-links-card-hover-background: var(--color-accent) !default
 $block-links-card-hover-color: var(--color-background) !default
+$block-links-icon-max-width: pxToRem(40) !default
 
 // Bloc fonctionnalités
 $block-features-icon-max-width: pxToRem(80) !default


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Comme pour les blocs "chiffre clé" et "fonctionnalités", l'idée est d'utiliser la détection du format .png (à améliorer plus tard avec une config au niveau du bloc). C'est une demande pour EPV.

J'ai donc ajouté cette variable au bloc : `$block-links-icon-max-width: pxToRem(40) !default` (40px parce que les icônes de rs en grand c'est laid) et ajouté du style à l'image comme ceci : 

```
picture.is-png 
      img
            margin: space(4) space(4) 0
            max-width: $block-links-icon-max-width
```

Pour limiter les effets de bord dus à la config initiale de l'image, j'ai aussi ajouté une vérification `picture:not(.is-png)` dans le style des autres images.

**NB :** Cela soulève cependant une problématique : on a un hover sur les liens et en fonction de la couleur de l'image, celle-ci peut devenir moche ou invisible, comment bien gérer ce cas ?

![Capture d’écran 2024-07-03 à 15 12 43](https://github.com/osunyorg/theme/assets/91660674/6dbaf65c-9452-4306-801c-f4bea6bb7215)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

[http://localhost:1313/fr/blocks/blocks-techniques/liens/](http://localhost:1313/fr/blocks/blocks-techniques/liens/) (en bas de la page)



## Screenshots

### Le résultat : 
![Capture d’écran 2024-07-03 à 15 12 33](https://github.com/osunyorg/theme/assets/91660674/50e02d5c-dfa7-47e3-b9e9-ac4da96a81ef)