### PR TITLE
Ajout de l'email et du flux rss aux liens sociaux

### DIFF
--- a/i18n/es.yml
+++ b/i18n/es.yml
@@ -1,0 +1,3 @@
+commons:
+  contact:
+    email: Correo electrónico

--- a/layouts/partials/commons/socials.html
+++ b/layouts/partials/commons/socials.html
@@ -1,3 +1,13 @@
+{{ with $site_social_links.email }}
+  <li class="email">
+    <a href="mailto:{{ . }}" rel="noreferrer" title="Email" target="_blank">Email</a>
+  </li>
+{{ end}}
+{{ with $site_social_links.rss }}
+  <li class="rss">
+    <a href="{{ . }}" rel="noreferrer" title="RSS" target="_blank">RSS</a>
+  </li>
+{{ end}}
 {{ with .mastodon }}
   <li class="mastodon">
     <a href="{{ . }}" rel="noreferrer" title="Mastodon" target="_blank">Mastodon</a>

--- a/layouts/partials/commons/socials.html
+++ b/layouts/partials/commons/socials.html
@@ -1,6 +1,6 @@
 {{ with .email }}
   <li class="email">
-    <a href="mailto:{{ . }}" rel="noreferrer" title="Email" target="_blank">Email</a>
+    <a href="mailto:{{ . }}" rel="noreferrer" title="Email" target="_blank">{{ i18n "commons.contact.email" }}</a>
   </li>
 {{ end}}
 {{ with .rss }}

--- a/layouts/partials/commons/socials.html
+++ b/layouts/partials/commons/socials.html
@@ -1,9 +1,9 @@
-{{ with $site_social_links.email }}
+{{ with .email }}
   <li class="email">
     <a href="mailto:{{ . }}" rel="noreferrer" title="Email" target="_blank">Email</a>
   </li>
 {{ end}}
-{{ with $site_social_links.rss }}
+{{ with .rss }}
   <li class="rss">
     <a href="{{ . }}" rel="noreferrer" title="RSS" target="_blank">RSS</a>
   </li>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

En créant le partial `commons/socials` j'ai visiblement oublié de mettre l'email et le rss, ça a donc disparu, par exemple, du footer. Je les ai remis avec le reste des liens sociaux.

À voir si le rss ne reste pas un cas particulier du footer ceci dit !

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test 

- Dans le footer d'example
- Dans le footer de Sinon Virgule