### PR TITLE
Liste des blocs : changement d'appel de la liste des blocs

### DIFF
--- a/layouts/partials/blocks/list.html
+++ b/layouts/partials/blocks/list.html
@@ -1,3 +1,4 @@
+{{/*  TODO : supprimer ce partial  */}}
 {{ $context := . }}
 {{- if .Params.contents -}}
   <div class="blocks">

--- a/layouts/partials/blocks/list.html
+++ b/layouts/partials/blocks/list.html
@@ -7,6 +7,6 @@
         "block" . 
         "context" $context
     )}}
-    {{- end -}}
+  {{- end -}}
   </div>
 {{- end -}}

--- a/layouts/partials/blocks/list.html
+++ b/layouts/partials/blocks/list.html
@@ -2,18 +2,11 @@
 {{- if .Params.contents -}}
   <div class="blocks">
   {{- range .Params.contents -}}
-    {{ if eq .kind "block" }}
-      {{ $template := printf "blocks/templates/%s.html" .template }}
-      {{ partial $template (dict 
-          "block" . 
-          "context" $context
-      )}}
-    {{- else if (eq .kind "heading") -}}
-      {{ $headingId := .slug | default (urlize .title) }}
-      <div class="heading container" id="{{ $headingId }}">
-        <h2>{{ partial "PrepareHTML" .title }}</h2>
-      </div>
+    {{ $template := printf "blocks/templates/%s.html" .template }}
+    {{ partial $template (dict 
+        "block" . 
+        "context" $context
+    )}}
     {{- end -}}
-  {{- end -}}
   </div>
 {{- end -}}

--- a/layouts/partials/blocks/list.html
+++ b/layouts/partials/blocks/list.html
@@ -2,11 +2,18 @@
 {{- if .Params.contents -}}
   <div class="blocks">
   {{- range .Params.contents -}}
-    {{ $template := printf "blocks/templates/%s.html" .template }}
-    {{ partial $template (dict 
-        "block" . 
-        "context" $context
-    )}}
+    {{ if eq .kind "block" }}
+      {{ $template := printf "blocks/templates/%s.html" .template }}
+      {{ partial $template (dict 
+          "block" . 
+          "context" $context
+      )}}
+    {{- else if (eq .kind "heading") -}}
+      {{ $headingId := .slug | default (urlize .title) }}
+      <div class="heading container" id="{{ $headingId }}">
+        <h2>{{ partial "PrepareHTML" .title }}</h2>
+      </div>
+    {{- end -}}
   {{- end -}}
   </div>
 {{- end -}}

--- a/layouts/publications/list.html
+++ b/layouts/publications/list.html
@@ -2,7 +2,7 @@
   {{ partial "publications/hero-list.html" . }}
   <div class="document-content">
     {{ partial "commons/list-content.html" . }}
-    {{ partial "blocks/list.html" . }}
+    {{ partial "contents/list.html" . }}
   
     <div class="container">
       {{ partial "publications/statistics.html" . }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Le Postgrowth Lab s'est mis à crasher lorsqu'il y a eu un ajout de titres à la page des publications. Contrairement au fichier `contents/list.html`, on ne vérifiait pas dans `blocks/list.html` si le bloc envoyé était un heading, le partial cherchait donc automatiquement le `template`, inexistant pour un heading.

Le partial `block/list.html` ne doit plus être utilisé, or il était appelé dans `layout/publications/list`, j'ai donc remplacé : `{{ partial "blocks/list.html" . }}` par `{{ partial "contents/list.html" . }}`

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

Crash : https://github.com/osunyorg/vigo-postgrowth-lab/actions/runs/9806364640/job/27077922183

![image](https://github.com/osunyorg/theme/assets/91660674/60a5f37f-ba3f-414b-acda-6ac8314cdc53)

## URL de test sur example.osuny.org

Osuny Example journal : [http://localhost:1313/publications/](http://localhost:1313/publications/)

En ajoutant le contenu : 

```
  - kind: heading
    title: >-
      2023
    slug: "titre qui casse tout"
    position: 1
    rank: 2
```

## URL de test du site (optionnel)

[Postgrowth Lab](https://postgrowth-lab.uvigo.es/) : [http://localhost:1313/publications/](http://localhost:1313/publications/)