### PR TITLE
Bloc call to action : layout "discret"

### DIFF
--- a/assets/sass/_theme/blocks/call_to_action.sass
+++ b/assets/sass/_theme/blocks/call_to_action.sass
@@ -15,7 +15,7 @@
         .description
             a
                 color: inherit
-                text-decoration-color: $color-text
+                text-decoration-color: $block-call-to-action-color
             p
                 @include h2
         .actions

--- a/assets/sass/_theme/blocks/call_to_action.sass
+++ b/assets/sass/_theme/blocks/call_to_action.sass
@@ -1,6 +1,4 @@
 .block-call_to_action
-    --cta-background-color: #{$block-call-to-action-background}
-    margin-bottom: 0
     .top
         margin-bottom: 0
         .block-title
@@ -17,7 +15,7 @@
         .description
             a
                 color: inherit
-                text-decoration-color: $block-call-to-action-color
+                text-decoration-color: $color-text
             p
                 @include h2
         .actions
@@ -48,11 +46,31 @@
             margin-top: $spacing-3
         img
             display: block
+    &--accent_background
+        --cta-background-color: #{$block-call-to-action-accent-background}
+        margin-bottom: 0
+        .call_to_action
+            color: $block-call-to-action-accent-color
+            .description
+                a
+                    text-decoration-color: $block-call-to-action-accent-color
+            .actions
+                a
+                    color: $block-call-to-action-accent-color
+                    text-decoration-color: alphaColor($block-call-to-action-accent-color, 0.3)
+                    &:first-child
+                        --btn-background: #{$block-call-to-action-accent-button-background}
+                        --btn-border: #{$block-call-to-action-accent-button-border}
+                        --btn-color: #{$block-call-to-action-accent-button-color}
+                        --btn-hover-background: #{$block-call-to-action-accent-button-hover-background}
+                        --btn-hover-border: #{$block-call-to-action-accent-button-hover-border}
+                        --btn-hover-color: #{$block-call-to-action-accent-button-hover-color}
 
     @include media-breakpoint-down(desktop)
-        background-color: var(--cta-background-color)
-        padding-top: 0
-        padding-bottom: 0
+        &--accent_background
+            background-color: var(--cta-background-color)
+            // padding-top: 0
+            // padding-bottom: 0
         .call_to_action
             padding: var(--block-space-y) 0
             .actions
@@ -72,36 +90,46 @@
     @include in-page-with-sidebar
         .call_to_action
             display: flex
-            flex-direction: column
             > *
                 order: 2
-            > div
-                // TODO : simplifier l'application d'une couleur de fond sur le CTA avec sidebar et sans sidebar
-                background-color: var(--cta-background-color)
-                padding: columns(1)
-                width: 100%
-                position: relative
-                &::after
-                    background-color: var(--cta-background-color)
-                    content: ''
-                    display: block
-                    position: absolute
-                    top: 0
-                    bottom: 0
-                    left: 100%
-                    // Calcul de la largeur nécessaire pour remplir l'espace droit entre le container et le bord droit de la fenêtre
-                    width: grid-external-space()
-            &--with-image
-                picture
-                    order: 1
-                    padding-left: columns(1)
-                    padding-right: offset(4)
-                    position: relative
-                    z-index: 2
-                    img
-                        margin-bottom: calc(var(--grid-gutter-negative) + -#{$spacing-3})
+        &--no_background
+            .call_to_action
+                &--with-image
+                    > div
+                        flex: 1
+                    picture
+                        margin-left: var(--grid-gutter)
+                        width: columns(3)
+        &--accent_background
+            .call_to_action
+                flex-direction: column
                 > div
-                    padding-top: calc(var(--grid-gutter) * 2 + #{$spacing-3})
+                    // TODO : simplifier l'application d'une couleur de fond sur le CTA avec sidebar et sans sidebar
+                    background-color: var(--cta-background-color)
+                    padding: columns(1)
+                    width: 100%
+                    position: relative
+                    &::after
+                        background-color: var(--cta-background-color)
+                        content: ''
+                        display: block
+                        position: absolute
+                        top: 0
+                        bottom: 0
+                        left: 100%
+                        // Calcul de la largeur nécessaire pour remplir l'espace droit entre le container et le bord droit de la fenêtre
+                        width: grid-external-space()
+                &--with-image
+                    picture
+                        order: 1
+                        padding-left: columns(1)
+                        padding-right: offset(4)
+                        position: relative
+                        z-index: 2
+                        img
+                            margin-bottom: calc(var(--grid-gutter-negative) + -#{$spacing-3})
+                    > div
+                        padding-top: calc(var(--grid-gutter) * 2 + #{$spacing-3})
 
     @include in-page-without-sidebar
         background-color: var(--cta-background-color)

--- a/assets/sass/_theme/blocks/call_to_action.sass
+++ b/assets/sass/_theme/blocks/call_to_action.sass
@@ -42,10 +42,22 @@
                     @extend .button
                 &:last-child
                     margin-bottom: 0
+        figure
+            figcaption
+                @include meta
         * + .actions
             margin-top: $spacing-3
         img
             display: block
+    &--no_background
+        .call_to_action--with-image
+            figure
+                img
+                    width: 100%
+                figcaption
+                    display: flex
+                    justify-content: flex-end
+                    margin-top: $spacing-2
     &--accent_background
         --cta-background-color: #{$block-call-to-action-accent-background}
         margin-bottom: 0
@@ -54,23 +66,31 @@
             .description
                 a
                     text-decoration-color: $block-call-to-action-accent-color
-            .actions
+            .actions,
+            figure
                 a
                     color: $block-call-to-action-accent-color
                     text-decoration-color: alphaColor($block-call-to-action-accent-color, 0.3)
-                    &:first-child
-                        --btn-background: #{$block-call-to-action-accent-button-background}
-                        --btn-border: #{$block-call-to-action-accent-button-border}
-                        --btn-color: #{$block-call-to-action-accent-button-color}
-                        --btn-hover-background: #{$block-call-to-action-accent-button-hover-background}
-                        --btn-hover-border: #{$block-call-to-action-accent-button-hover-border}
-                        --btn-hover-color: #{$block-call-to-action-accent-button-hover-color}
+            .actions
+                a:first-child
+                    --btn-background: #{$block-call-to-action-accent-button-background}
+                    --btn-border: #{$block-call-to-action-accent-button-border}
+                    --btn-color: #{$block-call-to-action-accent-button-color}
+                    --btn-hover-background: #{$block-call-to-action-accent-button-hover-background}
+                    --btn-hover-border: #{$block-call-to-action-accent-button-hover-border}
+                    --btn-hover-color: #{$block-call-to-action-accent-button-hover-color}
+                    
 
     @include media-breakpoint-down(desktop)
         &--accent_background
             background-color: var(--cta-background-color)
             .call_to_action
                 padding: var(--block-space-y) 0
+                figure
+                    figcaption
+                        margin-top: $spacing-2
+                        display: flex
+                        justify-content: flex-end
         .call_to_action
             .actions
                 a
@@ -82,7 +102,7 @@
             flex-direction: column
             > *
                 order: 2
-            picture
+            figure
                 margin-bottom: offset(1)
                 order: 1
 
@@ -96,7 +116,7 @@
                 &--with-image
                     > div
                         flex: 1
-                    picture
+                    figure
                         margin-left: var(--grid-gutter)
                         width: columns(3)
         &--accent_background
@@ -119,14 +139,20 @@
                         // Calcul de la largeur nécessaire pour remplir l'espace droit entre le container et le bord droit de la fenêtre
                         width: grid-external-space()
                 &--with-image
-                    picture
+                    figure
+                        align-items: flex-end
+                        display: flex
+                        justify-content: space-between
+                        margin-bottom: calc(var(--grid-gutter-negative) + -#{$spacing-3})
                         order: 1
                         padding-left: columns(1)
-                        padding-right: offset(4)
                         position: relative
                         z-index: 2
-                        img
-                            margin-bottom: calc(var(--grid-gutter-negative) + -#{$spacing-3})
+                        picture
+                            width: columns(3)
+                        figcaption
+                            flex: 1
+                            margin-left: $spacing-3
                     > div
                         padding-top: calc(var(--grid-gutter) * 2 + #{$spacing-3})
 
@@ -142,8 +168,12 @@
             @include grid
             > div
                 grid-column: 1/7
-            > picture
+            > figure
                 grid-column: 8/13
+                figcaption
+                    display: flex
+                    justify-content: flex-end
+                    margin-top: $spacing-2
         .call_to_action--without-image
             display: block
             > div

--- a/assets/sass/_theme/blocks/call_to_action.sass
+++ b/assets/sass/_theme/blocks/call_to_action.sass
@@ -69,10 +69,9 @@
     @include media-breakpoint-down(desktop)
         &--accent_background
             background-color: var(--cta-background-color)
-            // padding-top: 0
-            // padding-bottom: 0
+            .call_to_action
+                padding: var(--block-space-y) 0
         .call_to_action
-            padding: var(--block-space-y) 0
             .actions
                 a
                     &:last-child

--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -20,14 +20,22 @@ $block-space-y-desktop: $spacing-5 !default
 $block-space-y-with-sidebar: $spacing-5 !default
 
 // Block call to action
-$block-call-to-action-background: var(--color-accent) !default
-$block-call-to-action-color: var(--color-background) !default
-$block-call-to-action-button-background: var(--color-background) !default
+$block-call-to-action-color: $color-text !default
+$block-call-to-action-button-background: var(--color-text) !default
 $block-call-to-action-button-border: pxToRem(1) solid $block-call-to-action-button-background !default
-$block-call-to-action-button-color: var(--color-text) !default
+$block-call-to-action-button-color: var(--color-background) !default
 $block-call-to-action-button-hover-background: var(--color-text-alt) !default
 $block-call-to-action-button-hover-border: pxToRem(1) solid $block-call-to-action-button-hover-background !default
 $block-call-to-action-button-hover-color: var(--color-background) !default
+
+$block-call-to-action-accent-background: var(--color-accent) !default
+$block-call-to-action-accent-color: var(--color-background) !default
+$block-call-to-action-accent-button-background: var(--color-background) !default
+$block-call-to-action-accent-button-border: pxToRem(1) solid $block-call-to-action-accent-button-background !default
+$block-call-to-action-accent-button-color: var(--color-text) !default
+$block-call-to-action-accent-button-hover-background: var(--color-text-alt) !default
+$block-call-to-action-accent-button-hover-border: pxToRem(1) solid $block-call-to-action-accent-button-hover-background !default
+$block-call-to-action-accent-button-hover-color: var(--color-background) !default
 
 // Block chapter
 $block-chapter-layout-accent-background: var(--color-accent) !default

--- a/layouts/partials/blocks/templates/call_to_action.html
+++ b/layouts/partials/blocks/templates/call_to_action.html
@@ -33,14 +33,19 @@
               </div>
             {{- end -}}
           </div>
-
-          {{ partial "commons/image.html"
-            (dict
-              "image"    .image.file
-              "alt"      .image.alt
-              "sizes"    site.Params.image_sizes.blocks.call_to_action
-            )}}
-          
+          {{ if .image }}
+            <figure>
+              {{ partial "commons/image.html"
+                (dict
+                  "image"    .image.file
+                  "alt"      .image.alt
+                  "sizes"    site.Params.image_sizes.blocks.call_to_action
+              )}}
+              {{ if partial "GetTextFromHTML" .credit }}
+                <figcaption>{{ partial "PrepareHTML" .credit }}</figcaption>
+              {{ end }}
+            </figure>
+          {{ end }}
         </div>
       </div>
     </div>

--- a/layouts/partials/blocks/templates/call_to_action.html
+++ b/layouts/partials/blocks/templates/call_to_action.html
@@ -40,7 +40,7 @@
               "alt"      .image.alt
               "sizes"    site.Params.image_sizes.blocks.call_to_action
             )}}
-
+          
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

En admin, on a déjà la possibilité d'ajouter un bloc CTA avec le layout sans fond (`no_background`). Voilà ce que ça donne côté thème : 

Je suis partie du principe que le "discret" est le CTA de base, tout simple, et que le mis en avant est une spécificité, parce qu'on va lui rajouter du style : on a donc une base et du pimpé (mais ça peut bien sûr être remis en question !).

Suivant cette logique : 
1. J'ai renommé les variables en leur ajoutant `-accent` (exemple : `$block-call-to-action-color` devient `$block-call-to-action-accent-color`) et j'ai ajouté les variables du cta de base (les mêmes, sauf `$block-call-to-action-accent-background` qui n'existe que pour le layout accent.
3. J'ai légèrement remanié le style de sorte à séparer la généralité/base (`.block-call_to_action .call_to_action`) du layout accent (`.block-call_to_action&--accent_background .call_to_action`).

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

#483 | [#2061](https://github.com/osunyorg/admin/pull/2061)

## URL de test sur example.osuny.org

[http://localhost:1313/fr/blocks/blocks-narratifs/appels-a-action/](http://localhost:1313/fr/blocks/blocks-narratifs/appels-a-action/)
(il faut ajouter `no_background` au layout du bloc de test, dans les données)

## Screenshots

### Avec sidebar : 
![Capture d’écran 2024-07-10 à 11 39 48](https://github.com/osunyorg/theme/assets/91660674/0984efa8-65f2-411d-9753-9285cc183e7d)
![Capture d’écran 2024-07-10 à 11 43 05](https://github.com/osunyorg/theme/assets/91660674/59d01b00-43eb-40ec-b083-1c609c13142e)

### En pleine page : 
![Capture d’écran 2024-07-10 à 11 40 28](https://github.com/osunyorg/theme/assets/91660674/ce1097e3-1fb4-41ca-a24e-5cfa81c5129c)
![Capture d’écran 2024-07-10 à 11 40 41](https://github.com/osunyorg/theme/assets/91660674/977016e8-67b3-477b-b4f1-2088d62028ae)
![Capture d’écran 2024-07-10 à 11 43 15](https://github.com/osunyorg/theme/assets/91660674/06bf945a-a801-4bcd-862d-704bb2b9f9f5)
![Capture d’écran 2024-07-10 à 11 43 22](https://github.com/osunyorg/theme/assets/91660674/325c3b99-81fb-43e7-9d17-2975b439bd4a)

### En mobile : 
![Capture d’écran 2024-07-10 à 11 48 21](https://github.com/osunyorg/theme/assets/91660674/b0a5271b-b5a7-4fe5-aa2c-4f421b144b6f)
![Capture d’écran 2024-07-10 à 11 48 28](https://github.com/osunyorg/theme/assets/91660674/90075781-75f4-44dc-9b34-782079083904)