### PR TITLE
Correction des espacements des adresses dans le pied de page

### DIFF
--- a/assets/sass/_theme/design-system/footer.sass
+++ b/assets/sass/_theme/design-system/footer.sass
@@ -28,7 +28,8 @@ footer#document-footer
     .footer
         &-site
             @include small
-            > * + *
+            > * + *,
+            p + address
                 margin-top: $spacing-2
         &-social, &-legals, &-credit
             @include meta

--- a/assets/sass/_theme/design-system/footer.sass
+++ b/assets/sass/_theme/design-system/footer.sass
@@ -20,10 +20,15 @@ footer#document-footer
         @include list-reset
         li + li
                 margin-top: $spacing-2
+    address
+        [itemprop="streetAddress"],
+        [itemprop="addressCountry"],
+        [itemprop="description"]
+            display: block
     .footer
         &-site
             @include small
-            * + *
+            > * + *
                 margin-top: $spacing-2
         &-social, &-legals, &-credit
             @include meta

--- a/layouts/partials/footer/site.html
+++ b/layouts/partials/footer/site.html
@@ -6,8 +6,9 @@
     <p itemprop="name">{{ htmlUnescape (trim .name "\n") }}</p>
     {{ if or (.address) (.country) -}}
       <address itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
-        {{ if .address }}<span itemprop="streetAddress">{{ trim .address "\n" }}</span><br>{{ end }}
-        {{ if .zipcode }}<span itemprop="postalCode">{{ trim .zipcode "\n" }}</span> {{ end }}{{ if .city }}<span itemprop="addressLocality">{{ trim .city "\n" }}</span> {{ end }}{{ if .country }}<span itemprop="addressCountry">{{ trim .country "\n" }}</span>{{ end }}
+        {{ if .address }}<span itemprop="streetAddress">{{ trim .address "\n" }}</span>{{ end }}
+        {{ if .zipcode }}<span itemprop="postalCode">{{ trim .zipcode "\n" }}</span> {{ end }}{{ if .city }}<span itemprop="addressLocality">{{ trim .city "\n" }}</span>{{ end }}
+        {{ if .country }}<span itemprop="addressCountry">{{ trim .country "\n" }}</span>{{ end }}
       </address>
     {{ end }}
     {{- if .phone -}}
@@ -23,12 +24,13 @@
   <div itemscope itemtype="https://schema.org/ResearchOrganization">
     <meta itemprop="logo" content="{{ $logo }}">
     <p itemprop="name">{{ htmlUnescape (trim .name "\n") }}</p>
-    {{ if or (.address) (.country) }}
+    {{ if or .address .country }}
     <address itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
-      {{ if .address_name }}<span itemprop="name">{{ .address_name }}</span><br>{{ end }}
-      {{ if .address }}<span itemprop="streetAddress">{{ .address }}</span><br>{{ end }}
-      {{ if .address_additional }}<span itemprop="description">{{ .address_additional }}</span><br>{{ end }}
-      {{ if .zipcode }}<span itemprop="postalCode">{{ .zipcode }}</span> {{ end }}{{ if .city }}<span itemprop="addressLocality">{{ .city }}</span> {{ end }}{{ if .country }}<span itemprop="addressCountry">{{ .country }}</span>{{ end }}
+      {{ if .address_name }}<span itemprop="name">{{ .address_name }}</span>{{ end }}
+      {{ if .address }}<span itemprop="streetAddress">{{ .address }}</span>{{ end }}
+      {{ if .address_additional }}<span itemprop="description">{{ .address_additional }}</span>{{ end }}
+      {{ if .zipcode }}<span itemprop="postalCode">{{ .zipcode }}</span> {{ end }}{{ if .city }}<span itemprop="addressLocality">{{ .city }}</span>{{ end }}
+      {{ if .country }}<span itemprop="addressCountry">{{ .country }}</span>{{ end }}
     </address>
     {{ end }}
     {{- if .phone -}}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Faire passer à la ligne le pays
Correction de l'espacement vertical
Retirer les <br> de l'adresse

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


