### PR TITLE
Problème d'affichage des icônes dans le bloc papiers

### DIFF
--- a/assets/sass/_theme/blocks/files.sass
+++ b/assets/sass/_theme/blocks/files.sass
@@ -4,18 +4,11 @@
     .files
         @include list-reset
         li
-            @include icon-block(download-2-line, before)
-                align-items: center
+            @include icon(download-2-line, before)
                 border: 1px solid var(--color-border)
-                display: flex
                 flex-shrink: 0
-                height: pxToRem(60)
-                justify-content: center
                 margin-right: $spacing-2
                 transition: background 0.3s ease, border 0.3s ease
-                width: pxToRem(60)
-                @include media-breakpoint-up(desktop)
-                    font-size: pxToRem(20)
             align-items: start
             display: flex
             position: relative

--- a/assets/sass/_theme/blocks/files.sass
+++ b/assets/sass/_theme/blocks/files.sass
@@ -4,19 +4,10 @@
     .files
         @include list-reset
         li
-            @include icon(download-2-line, before)
-                border: 1px solid var(--color-border)
-                flex-shrink: 0
-                margin-right: $spacing-2
-                transition: background 0.3s ease, border 0.3s ease
+            @include icon-frame(download-2-line, $hoverable: true)
             align-items: start
             display: flex
             position: relative
-            &:hover
-                &::before
-                    background-color: var(--color-text)
-                    border-color: transparent
-                    color: var(--color-background)
         a
             @include stretched-link(before)
             @include small

--- a/assets/sass/_theme/blocks/gallery.sass
+++ b/assets/sass/_theme/blocks/gallery.sass
@@ -130,6 +130,9 @@
                 @media (min-height: 800px)
                     padding-top: space(10)
             &__arrow
+                &:disabled
+                    cursor: default
+                    opacity: 0.3
                 &--prev,
                 &--next
                     @include button-reset

--- a/assets/sass/_theme/design-system/button.sass
+++ b/assets/sass/_theme/design-system/button.sass
@@ -38,35 +38,6 @@
     --btn-hover-background: #{$color-text}
     --btn-hover-border: pxToRem(1) solid var(--btn-hover-background)
 
-.squared-button
-    @include meta
-    @include button-reset
-    align-items: center
-    color: var(--color-text)
-    cursor: pointer
-    display: flex
-    padding: 0
-    text-decoration: none
-    &::before 
-        align-items: center
-        background-color: var(--color-background)
-        border: 1px solid var(--color-border)
-        display: flex
-        height: pxToRem(64)
-        justify-content: center
-        margin-right: $spacing-2
-        transition: background 0.3s ease, border 0.3s ease
-        width: pxToRem(64)
-        @include media-breakpoint-up(desktop)
-            font-size: pxToRem(20)
-            margin-right: $spacing-3
-    &:hover
-        text-decoration: none
-        &::before
-            background-color: var(--color-text)
-            border-color: transparent
-            color: var(--color-background)
-
 @mixin link-icon($icon: false)
     @include button-reset
     line-height: $body-line-height

--- a/assets/sass/_theme/design-system/button.sass
+++ b/assets/sass/_theme/design-system/button.sass
@@ -48,12 +48,17 @@
     padding: 0
     text-decoration: none
     &::before 
+        align-items: center
         background-color: var(--color-background)
         border: 1px solid var(--color-border)
+        display: flex
+        height: pxToRem(64)
+        justify-content: center
         margin-right: $spacing-2
-        padding: $spacing-1
         transition: background 0.3s ease, border 0.3s ease
+        width: pxToRem(64)
         @include media-breakpoint-up(desktop)
+            font-size: pxToRem(20)
             margin-right: $spacing-3
     &:hover
         text-decoration: none

--- a/assets/sass/_theme/sections/papers.sass
+++ b/assets/sass/_theme/sections/papers.sass
@@ -153,15 +153,9 @@
         flex-wrap: wrap
         gap: $spacing-3
     button.squared-button
-        @include icon-block(eye-line, before)
+        @include icon(eye-line, before)
     a.squared-button
-        @include icon-block(download-2-line, before)
-    button.squared-button,
-    a.squared-button
-        &::before
-            display: flex
-            align-items: center
-            justify-content: center
+        @include icon(download-2-line, before)
 
 .citations
     &:not(:first-child)

--- a/assets/sass/_theme/sections/papers.sass
+++ b/assets/sass/_theme/sections/papers.sass
@@ -77,10 +77,6 @@
                 margin-top: $spacing-4
                 @include media-breakpoint-up(desktop)
                     margin-top: $spacing-6
-            .squared-button
-                margin-bottom: 0
-                margin-top: $spacing-2
-                width: auto
             h2
                 margin-bottom: $spacing-2
             .paper-essentials
@@ -152,10 +148,19 @@
     @include media-breakpoint-down(desktop)
         flex-wrap: wrap
         gap: $spacing-3
-    button.squared-button
-        @include icon(eye-line, before)
-    a.squared-button
-        @include icon(download-2-line, before)
+    button, a
+        @include meta
+        @include button-reset
+        align-items: center
+        color: var(--color-text)
+        cursor: pointer
+        display: flex
+        padding: 0
+        text-decoration: none
+    button
+        @include icon-frame(eye-line, $hoverable: true)
+    a
+        @include icon-frame(download-2-line, $hoverable: true)
 
 .citations
     &:not(:first-child)

--- a/assets/sass/_theme/sections/papers.sass
+++ b/assets/sass/_theme/sections/papers.sass
@@ -156,6 +156,12 @@
         @include icon-block(eye-line, before)
     a.squared-button
         @include icon-block(download-2-line, before)
+    button.squared-button,
+    a.squared-button
+        &::before
+            display: flex
+            align-items: center
+            justify-content: center
 
 .citations
     &:not(:first-child)

--- a/assets/sass/_theme/utils/icons.sass
+++ b/assets/sass/_theme/utils/icons.sass
@@ -11,7 +11,6 @@
 @mixin icon($icon-name: '', $pseudo-element: before, $non-breaking: false)
     &::#{$pseudo-element}
         content: map-get($icons, $icon-name)
-        display: inline-block
         font-family: 'Icon'
         font-style: normal
         font-variant: normal

--- a/assets/sass/_theme/utils/icons.sass
+++ b/assets/sass/_theme/utils/icons.sass
@@ -33,6 +33,26 @@
         vertical-align: middle
         @content
 
+@mixin icon-frame($icon-name: '', $pseudo-element: before, $non-breaking: false, $hoverable: false)
+    @include icon($icon-name, $pseudo-element, $non-breaking)
+        border: 1px solid var(--color-border)
+        display: inline-block
+        flex-shrink: 0
+        height: pxToRem(64)
+        line-height: pxToRem(64)
+        margin-right: $spacing-2
+        text-align: center
+        transition: background 0.3s ease, border 0.3s ease
+        vertical-align: middle
+        width: pxToRem(64)
+        @content
+    @if $hoverable
+        &:hover
+            &::#{$pseudo-element}
+                background-color: var(--color-text)
+                border-color: transparent
+                color: var(--color-background)
+
 @mixin arrow-right-hover
     position: relative
     display: flex

--- a/assets/sass/_theme/utils/icons.sass
+++ b/assets/sass/_theme/utils/icons.sass
@@ -45,6 +45,8 @@
         transition: background 0.3s ease, border 0.3s ease
         vertical-align: middle
         width: pxToRem(64)
+        @include media-breakpoint-up(desktop)
+            font-size: pxToRem(20)
         @content
     @if $hoverable
         &:hover

--- a/layouts/partials/papers/actions.html
+++ b/layouts/partials/papers/actions.html
@@ -5,7 +5,7 @@
 {{ with .paper }}
   <div class="paper-actions" role="group">
     {{- if $with_modal }}
-      <button class="squared-button" type="button" data-open-modal="{{ $modalId }}">{{ i18n "volumes.abstract" }}</button>
+      <button type="button" data-open-modal="{{ $modalId }}">{{ i18n "volumes.abstract" }}</button>
     {{ end -}}
     {{- if .Params.pdf -}}
       {{- $file := partial "GetMedia" .Params.pdf -}}
@@ -19,7 +19,7 @@
       {{- end -}}
       {{ if $file }}
         <figure>
-          <a href="{{ $url }}" download="{{ partial "PrepareHTML" $file.name }}" target="_blank" title="{{ i18n "commons.link.blank_aria" (dict "Title" $title_with_size) }}" class="squared-button">
+          <a href="{{ $url }}" download="{{ partial "PrepareHTML" $file.name }}" target="_blank" title="{{ i18n "commons.link.blank_aria" (dict "Title" $title_with_size) }}">
             <figcaption>
               <abbr title="{{ i18n (printf "commons.extensions.%s" $extension) }}">{{ $extension }}</abbr>
               - {{ $size.weight }} <abbr title="{{ $size.full_unit }}">{{ $size.unit }}</abbr>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Le mixin `icon-block` ne s'appliquait pas très bien avec les nouvelles icônes dans le cadre du bloc papiers. J'ai donc retiré l'appel de `icon-block` pour remplacer par `icon` simple dans le style du bloc papiers. J'ai retiré le `display: inline-block` du mixin `icon()` de base, car ça ne servait pas (vérifié sur example) pour qu'on n'ait plus d'override quand on est dans le cadre du `.squared-button` (avec donc `display-flex` et tout centré).

Et on a passé le style du bouton carré à 64*64px pour être iso avec la maquette.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

## URL de test du site (optionnel)

degrowthjournal : [http://localhost:1313/volumes/2023-volume-1/](http://localhost:1313/volumes/2023-volume-1/)

## Screenshots
![Capture d’écran 2024-07-12 à 17 19 55](https://github.com/user-attachments/assets/0f06bdd4-b93c-46cd-aa91-cb794b96903d)

![Capture d’écran 2024-07-12 à 17 40 40](https://github.com/user-attachments/assets/702f207f-4ee2-42df-9f62-29641487aeee)
