### PR TITLE
Block Key Figures :  Affichage tablette

### DIFF
--- a/assets/sass/_theme/blocks/key_figures.sass
+++ b/assets/sass/_theme/blocks/key_figures.sass
@@ -3,10 +3,10 @@
         margin-bottom: 0
     ul
         @include list-reset
+        @include grid(2, md)
         @include in-page-with-sidebar
             @include grid(2)
         &.even-items
-            @include grid(2, desktop)
             @include grid(4, desktop)
         &.odd-items
             @include grid(3, desktop)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description
Ajout d'une breakpoint pour afficher deux colonne en ``md``


## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


