### PR TITLE
Correction des options de la liste par défaut des pages enfants 

### DIFF
--- a/layouts/partials/pages/children.html
+++ b/layouts/partials/pages/children.html
@@ -10,8 +10,8 @@
           "pages" .Params.children
           "heading_level" 2
           "options" (dict
-            "descriptions" true
-            "images" (eq site.Params.pages.index.layout "grid")
+            "summary" true
+            "image" (eq site.Params.pages.index.layout "grid")
           )
         ) }}
     </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Correction des options de la liste par défaut des pages enfants 

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


