### PR TITLE
Enlever le souligné des réseaux sociaux

### DIFF
--- a/assets/sass/_theme/utils/sidebar.sass
+++ b/assets/sass/_theme/utils/sidebar.sass
@@ -114,5 +114,4 @@
             display: inline-block
         a
             color: inherit
-        // li:last-child
-        //     margin-right: -$spacing-2
+            text-decoration: none


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Le icônes de réseaux sociaux dans les espaces de partage ne doivent pas être soulignés.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


Avant :

![image](https://github.com/user-attachments/assets/4d5f4789-e5b9-4011-9e50-1d88a5ece811)

Après :

![image](https://github.com/user-attachments/assets/1acb24e8-4849-4d96-ba1b-0d1ebd68ade1)
