### PR TITLE
Correction du soulignement des liens dans le header

### DIFF
--- a/assets/sass/_theme/design-system/nav.sass
+++ b/assets/sass/_theme/design-system/nav.sass
@@ -14,10 +14,6 @@
         margin-top: $spacing-3
         max-height: var(--header-menu-max-height)
         overflow: auto
-    a,
-    a:focus,
-    a:active
-        @include link($header-color, false)
     span
         color: $header-color
     ul
@@ -55,9 +51,10 @@
             position: absolute
             max-height: calc(100vh - var(--header-height))
             overflow: auto
-        a
-            color: $header-dropdown-color
-            @extend %underline-on-hover
+        a,
+        a:focus,
+        a:active
+            @include link($header-color, false)
         .dropdown-menu-title
             @include h2
 
@@ -68,6 +65,7 @@
                 @include meta
                 display: block
                 padding: $spacing-1 $spacing-2
+                text-decoration: none
             &:last-child 
                 a, span
                     padding-right: 0


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

On avait un souligné au survol sur le lien "Offre de formation", car il s'agit d'un lien avec un target dans le static, au contraire des autres liens de navigation : 
 
![Capture d’écran 2024-07-18 à 16 26 37](https://github.com/user-attachments/assets/a008ee1c-e0a1-4315-9ab0-3bfebc754b8b)

J'ai donc descendu d'un niveau l'include `link` pour le mettre dans le dropdown menu.

Maintenant, on peut se demander s'il faut distinguer les liens des toogle de dropdown et donc permettre le souligné dès le premier niveau dans le cas où une page n'ouvre pas de dropdown, ce que mon fix ne fait pas (je suis partie du principe qu'avoir un lien souligné puis 3 liens pas soulignés pouvait faire bizarre, mais ça se discute).

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱