### PR TITLE
Correction de l'affichage des icônes dans le bloc contact et dans le footer

### DIFF
--- a/assets/sass/_theme/blocks/contact.sass
+++ b/assets/sass/_theme/blocks/contact.sass
@@ -60,7 +60,9 @@
             position: relative
             &::before
                 font-size: $footer-icons-size
-                margin-left: -0.3em
+                margin-right: $spacing-2
+                @include media-breakpoint-up(desktop)
+                    font-size: $footer-icons-size-desktop
             a
                 @include stretched-link
             &.facebook

--- a/assets/sass/_theme/design-system/footer.sass
+++ b/assets/sass/_theme/design-system/footer.sass
@@ -110,8 +110,6 @@ footer#document-footer
                     display: flex
                     justify-content: flex-end
                     position: relative
-                    &::after
-                        margin-left: $spacing-2
                     a::after
                         display: none
                     &.facebook
@@ -140,21 +138,19 @@ footer#document-footer
                         @include icon(rss-fill, after)
                     &::after
                         font-size: $footer-icons-size
-                        margin-right: $spacing-2
-                        transform: translateX(-25%)
                     + li
                         margin-top: $spacing-3
                     @include media-breakpoint-up(desktop)
                         &::after
                             font-size: $footer-icons-size-desktop
-                            margin-right: $spacing-2
-                            margin-right: -0.2em
-                            padding-left: $spacing-2
+                            margin-left: $spacing-2
                         + li
                             margin-top: space(4)
                     @include media-breakpoint-down(desktop)
                         width: fit-content
                         flex-direction: row-reverse
+                        &::after
+                            margin-right: $spacing-2
         @if $footer-text-hidden
             &-social.site-links li
                 font-size: 0


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Avec le changement de librairie d'icône, les espacements autour des icônes ont changé, il y avait deux correction à faire : 
- Magali (EPV) a repéré que les icônes étaient plus grosses dans le bloc contact, il manquait en effet le breakpoint pour ajouter `font-size : $footer-icons-size-desktop` en desktop
- Ces mêmes icônes n'avaient pas d'espacement avec le texte : 
![Capture d’écran 2024-07-18 à 15 32 10](https://github.com/user-attachments/assets/78f99ee1-95b3-452d-a0eb-ccaa4a80ab4c)

J'en ai profité pour corriger des duplications dans le footer.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

[http://localhost:1313/fr/blocks/blocks-techniques/contact/](http://localhost:1313/fr/blocks/blocks-techniques/contact/)

## URL de test sur EPV

[http://localhost:61268/fr/lassociation/reseau-excellence-en-france/ile-de-france/#contact](http://localhost:61268/fr/lassociation/reseau-excellence-en-france/ile-de-france/#contact)

Sur EPV le bug d'affichage est dû à la config qui permettait de grossir les anciennes icônes (elle était en 40px) ! J'ai préparé le thème EPV à push une fois la PR merge sur le thème.

## Screenshots

![Capture d’écran 2024-07-18 à 17 37 57](https://github.com/user-attachments/assets/b1d548dd-6714-410b-bbff-bd78bf9e4f8e)
![Capture d’écran 2024-07-18 à 17 38 07](https://github.com/user-attachments/assets/79d5b9a3-84bf-4f4f-b618-72f497c77944)