### PR TITLE
Ajout de la couleur de header aux liens du menu

### DIFF
--- a/assets/sass/_theme/design-system/nav.sass
+++ b/assets/sass/_theme/design-system/nav.sass
@@ -14,8 +14,6 @@
         margin-top: $spacing-3
         max-height: var(--header-menu-max-height)
         overflow: auto
-    span
-        color: $header-color
     ul
         list-style: none
         margin: 0
@@ -23,6 +21,7 @@
     a,
     span
         @include meta
+        color: $header-color
         cursor: pointer
         transition: text-decoration 0.15s
         display: block


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

En enlevant le souligné des liens de premier niveau dans la navaigation (avec `@include link()`), on a fait sauter la couleur des liens de premier niveau ! Ce n'est pas grave dans un cas comme example où la couleur des liens est identique à celle du texte, mais sur EPV, voilà le résultat :

![image](https://github.com/user-attachments/assets/84494f76-fc20-41de-a4d5-a18449e69907)

On avait un `span` tout seul avec une `color: $header-color` dans le menu, j'ai descendu l'info de la couleur quelques lignes en dessous, où on donne le style à la fois aux liens et aux span.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

Accueil example

## URL de test du site (optionnel)

Accueil EPV

## Screenshots

![Capture d’écran 2024-07-22 à 12 45 49](https://github.com/user-attachments/assets/f74ad9fb-ae68-489d-8626-5e83c6011c68)
![Capture d’écran 2024-07-22 à 12 45 56](https://github.com/user-attachments/assets/c8930f7d-0671-4fd4-8f25-8701c5dc64bc)
![Capture d’écran 2024-07-22 à 12 46 05](https://github.com/user-attachments/assets/c4741eb3-926a-4f7c-81da-7219176cef14)