### PR TITLE
Léger fix : affichage des image des fonctionnalités

### DIFF
--- a/assets/sass/_theme/blocks/features.sass
+++ b/assets/sass/_theme/blocks/features.sass
@@ -11,9 +11,12 @@
         figure
             order: -1
             margin-bottom: $spacing-3
-            picture:not(.is-png)
+            picture
                 img
+                    margin: auto
                     display: block
+            picture:not(.is-png, .is-svg)
+                img
                     object-fit: cover
                     width: 100%
                     aspect-ratio: 16/9
@@ -25,7 +28,6 @@
                 display: block
                 padding-top: $spacing-3
                 img
-                    display: block
                     margin: initial
                     max-width: $block-features-icon-max-width
                 @include media-breakpoint-down(desktop)

--- a/assets/sass/_theme/blocks/features.sass
+++ b/assets/sass/_theme/blocks/features.sass
@@ -10,9 +10,13 @@
             margin-bottom: $spacing-2
         figure
             order: -1
-            img
-                display: block
-                margin: auto
+            margin-bottom: $spacing-3
+            picture:not(.is-png)
+                img
+                    display: block
+                    object-fit: cover
+                    width: 100%
+                    aspect-ratio: 16/9
             figcaption
                 @include meta
                 margin-top: $spacing-2
@@ -21,6 +25,7 @@
                 display: block
                 padding-top: $spacing-3
                 img
+                    display: block
                     margin: initial
                     max-width: $block-features-icon-max-width
                 @include media-breakpoint-down(desktop)
@@ -46,6 +51,4 @@
             display: flex
             + li
                 margin-top: 0
-            .name
-                margin-top: $spacing-3
 


### PR DESCRIPTION
features : added aspect ratio to images

## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Contrairement à la maquette figma, les images des features n'ont pas de ratio en 16/9 : 
![Capture d’écran 2024-07-24 à 10 57 48](https://github.com/user-attachments/assets/bd3a17ea-7fc9-4ee5-9225-233f8ee899b7)

J'ai donc ajouté un `aspect-ratio` sur les images qui ne sont pas des png ou des svg.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/blocs-de-mise-en-page/#les-fonctionnalites`

## Screenshots

![Capture d’écran 2024-07-24 à 10 43 51](https://github.com/user-attachments/assets/a0387978-dce4-4edf-b0a2-4acb793d0cde)
![Capture d’écran 2024-07-24 à 10 44 04](https://github.com/user-attachments/assets/25dd073f-b621-430d-84e9-0437d892366a)
![Capture d’écran 2024-07-24 à 10 44 18](https://github.com/user-attachments/assets/e8345fca-c7e3-456b-8130-6240f58f029c)

