### PR TITLE
Correction de la couleur des boutons de splide

### DIFF
--- a/assets/sass/_theme/dependencies/splide.sass
+++ b/assets/sass/_theme/dependencies/splide.sass
@@ -4,7 +4,7 @@
         background: transparent
         border: 0
     &__arrow
-        color: $color-text
+        color: var(--color-text)
         position: absolute
         top: 50%
         svg


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Il manquait l'appel de la variable css `--color-text` au lieu de celle sass.

![Capture d’écran 2024-07-24 à 16 17 27](https://github.com/user-attachments/assets/14439577-5050-467c-aaa0-cef2d06489cf)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/blocks-narratifs/galeries/#galerie-caroussel`

## Screenshots

![Capture d’écran 2024-07-24 à 16 15 56](https://github.com/user-attachments/assets/d3f00686-7578-4bfb-997d-81bc6c7d5982)
