### PR TITLE
Actualités mises en avant : problème d'options

### DIFF
--- a/assets/sass/_theme/blocks/posts.sass
+++ b/assets/sass/_theme/blocks/posts.sass
@@ -236,20 +236,17 @@
                         width: columns(5)
             .list
                 article
-                    @include grid(8, desktop, 0, 0)
-                    .post-title
-                        grid-column: 1 / 7
-                    .post-categories
-                        grid-column: 1 / 7
+                    flex-direction: row
+                    gap: var(--grid-gutter)
+                    .post-content
+                        width: columns(6)
                     .post-meta
-                        grid-row: 1
-                        grid-column: 7 / 9
-                        text-align: right
-                        order: 2
-                        display: block
+                        flex-direction: column
                         margin-top: 0
+                        text-align: right
+                        width: columns(2)
                         .post-author p::before
-                            content: ''
+                            content: none
                     p[itemprop="articleBody"]
                         grid-column: 1 / 7
                         order: 3

--- a/layouts/partials/blocks/templates/posts/highlight.html
+++ b/layouts/partials/blocks/templates/posts/highlight.html
@@ -27,32 +27,33 @@
       {{ range after 1 . }}
         {{ with site.GetPage (printf "/posts/%s" .) }}
           <article class="post">
-            {{- $title := partial "PrepareHTML" .Title -}}
-            {{ $heading_tag.open }}
-              <a href="{{ .Permalink }}" title="{{ safeHTML (i18n "commons.more_aria" (dict "Title" $title)) }}">{{ $title }}</a>
-            {{ $heading_tag.close }}
-
-            {{ if eq $options.categories false }}
-              {{ partial "commons/categories" ( dict
-                "context" .
-                "kind" "post"
-              )}}
-
-            {{ end }}
-            {{ if eq $options.summary false }}
-              {{- if (partial "GetTextFromHTML" .Params.summary) -}}
-                <p itemprop="articleBody">{{ partial "GetTruncateContent" ( dict 
-                  "text" .Params.summary
-                  "length" site.Params.posts.index.truncate_description
-                  ) }}</p>
+            <div class="post-content">
+              {{- $title := partial "PrepareHTML" .Title -}}
+              {{ $heading_tag.open }}
+                <a href="{{ .Permalink }}" title="{{ safeHTML (i18n "commons.more_aria" (dict "Title" $title)) }}">{{ $title }}</a>
+              {{ $heading_tag.close }}
+  
+              {{ if $options.categories }}
+                {{ partial "commons/categories" ( dict
+                  "context" .
+                  "kind" "post"
+                )}}
+              {{ end }}
+  
+              {{ if and $options.summary (partial "GetTextFromHTML" .Params.summary) }}
+                  <p itemprop="articleBody">{{ partial "GetTruncateContent" ( dict 
+                    "text" .Params.summary
+                    "length" site.Params.posts.index.truncate_description
+                  )}}</p>
               {{- end -}}
-            {{- end -}}
-            {{- if or (eq $options.author false) (eq $options.date false) -}}
+            </div>
+
+            {{- if or $options.author $options.date -}}
               <div class="post-meta">
-                {{- if eq $options.date false -}}
+                {{- if $options.date -}}
                   <time itemprop="datePublished" datetime="{{ .Date.Format "2006-01-02T15:04" }}">{{ .Date | time.Format site.Params.posts.date_format }}</time>
                 {{ end }}
-                {{ if eq $options.author false }}
+                {{ if $options.author }}
                   {{- partial "posts/author" . -}}
                 {{ end }}
               </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

On a laissé passer un gros pépin : les options du bloc d'actualités en layout "mise en avant" avait un mix entre les anciennes et les nouvelles options : `if eq $options.categories false`. La première chose est donc de changer ça pour `$options.categories` (pour toutes les options).

Et comme c'était un peu compliqué pour rien au niveau du sass (sans les catégories ça fonctionnait parfaitement, mais on avait des marches incontrôlables à cause du `grid`), j'ai utilisé du `flex`, ça réduit pas mal le style.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [X] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

Sur CoDé : 

![Capture d’écran 2024-07-24 à 16 51 16](https://github.com/user-attachments/assets/6c5ef4a6-8ce1-4a98-9461-2aebe9e93b37)

## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/blocs-de-liste/actualites-1/`

## URL de test du site [CoDé](https://www.communication-democratie.org/fr/)

`http://localhost:1313/fr/`

## Screenshots

![Capture d’écran 2024-07-24 à 16 46 05](https://github.com/user-attachments/assets/6f95f857-c901-46c8-aa04-6c5b1de73f58)
![Capture d’écran 2024-07-24 à 16 46 25](https://github.com/user-attachments/assets/6c936c67-225a-425d-8574-866d4bc63fdc)
![Capture d’écran 2024-07-24 à 16 46 44](https://github.com/user-attachments/assets/42c74b02-fe04-41d8-ac19-94b7568e3392)
![Capture d’écran 2024-07-24 à 17 38 00](https://github.com/user-attachments/assets/e6fe2aab-ee23-4c4a-a7b1-afd0dd418f3c)
