### PR TITLE
Ajustement de l'icône des liens externes dans les textes

### DIFF
--- a/assets/sass/_theme/design-system/typography.sass
+++ b/assets/sass/_theme/design-system/typography.sass
@@ -215,8 +215,9 @@ a,
     overflow-wrap: break-word
     &[target="_blank"]:not(.icon)
         @include icon(links-line, after, true)
-            vertical-align: baseline
+            display: inline-block
             font-size: 0.8em
+            vertical-align: baseline
     &[href^="mailto"]
         &::after
             content: none


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Avec les nouvelles icônes, moins délicates que les précédentes, on a un rendu sur les liens externe un peu brouillon et chargé : 

![Capture d’écran 2024-07-25 à 17 08 33](https://github.com/user-attachments/assets/ef471eb8-4f3d-4eae-a02b-a0fe16e77912)

J'ai ajouté un `display: inline-block` à l'icône pour qu'elle compte dans le lien sans être soulignée.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/blocs-de-mise-en-page/`

## Screenshots

![Capture d’écran 2024-07-25 à 17 08 26](https://github.com/user-attachments/assets/a90cbe65-0c2a-4c57-9c15-19b99641fda6)
![Capture d’écran 2024-07-26 à 10 48 48](https://github.com/user-attachments/assets/9591ddee-aa2a-41bd-aea6-21d42c1c79d2)

### Dans un crédit :
![Capture d’écran 2024-07-26 à 10 48 55](https://github.com/user-attachments/assets/18a12762-c93a-4c5d-b88e-89cad7ee986e)

