### PR TITLE
Ajustement de la variable de couleur pour les liens des dropdowns du menu

### DIFF
--- a/assets/sass/_theme/design-system/nav.sass
+++ b/assets/sass/_theme/design-system/nav.sass
@@ -51,7 +51,7 @@
         a,
         a:focus,
         a:active
-            @include link($header-color, false)
+            @include link($header-dropdown-color, false)
         .dropdown-menu-title
             @include h2
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Sur l'IUT Bordeaux montaigne, le soulignement a disparu, car on utilise `$header-color` pour appliquer le souligné. Ça marche bien pour des sites classiques, mais pas lorsqu'il y a une différence de couleur entre le header en statut normal (ici, violet avec font blanche) et avec les dropdowns d'ouverts. Il faut donc utiliser la variable `$header-dropdown-color`.

![Capture d’écran 2024-07-26 à 15 14 23](https://github.com/user-attachments/assets/bbfa8715-e342-4bfe-b843-2ed44feabb82)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

Issue [#101](https://github.com/osunyorg/bordeauxmontaigne-iut/issues/101) sur l'IUT Bordeaux Montaigne.

## URL de test sur example.osuny.org

N'importe où.

## URL de test du site (optionnel)

N'importe où.

## Screenshots

![Capture d’écran 2024-07-26 à 15 17 12](https://github.com/user-attachments/assets/8ea35e88-454b-482f-9e58-c7432a103351)

![Capture d’écran 2024-07-26 à 15 17 28](https://github.com/user-attachments/assets/40993c9b-f7df-40bb-9c24-399acd94e74c)