### PR TITLE
Réparation du partiel `person` 

### DIFF
--- a/layouts/partials/blocks/templates/persons.html
+++ b/layouts/partials/blocks/templates/persons.html
@@ -37,7 +37,7 @@
               "heading_level" $block.ranks.children
               "options" $options
               "person" $person
-            )}}
+            ) }}
           {{- end -}}
         </div>
       </div>

--- a/layouts/partials/papers/authors.html
+++ b/layouts/partials/papers/authors.html
@@ -12,7 +12,7 @@
             {{ if .Params.image }}
               <meta itemprop="image" content="{{ .Params.image }}">
             {{ end }}
-            {{ partial "persons/person.html" . }}
+            {{ partial "persons/person.html" (dict "person" .) }}
           </div>
         {{ end }}
 

--- a/layouts/partials/persons/list.html
+++ b/layouts/partials/persons/list.html
@@ -14,10 +14,7 @@
 {{ else if eq site.Params.persons.index.layout "grid" }}
   <div class="persons">
     {{ range .persons }}
-      {{ partial "persons/person" (dict
-        "person" .
-        "options" $options
-      ) }}
+      {{ partial "persons/person" (dict "person" .) }}
     {{ end }}
   </div>
 {{ end }}

--- a/layouts/partials/persons/persons.html
+++ b/layouts/partials/persons/persons.html
@@ -1,9 +1,0 @@
-<div class="persons">
-  {{ $persons := .Pages.ByParam "last_name" }}
-  {{ range (.Paginate $persons).Pages }}
-    <div>
-      {{ partial "persons/person.html" . }}
-    </div>
-  {{ end }}
-</div>
-{{ partial "commons/pagination.html" . }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [x] Rangement

## Description

Réparation d'un appel du partiel `persons/person.html`.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)


## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


