### PR TITLE
Correction du soulignement des icônes

### DIFF
--- a/assets/sass/_theme/design-system/nav.sass
+++ b/assets/sass/_theme/design-system/nav.sass
@@ -27,6 +27,7 @@
         display: block
         &[aria-expanded]
             @include icon(arrow-down-s-line, after)
+                display: inline-block
                 margin-left: pxToRem(5)
                 transition: transform 0.15s
             &[aria-expanded="true"]


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Pour les sites qui appliquent un souligné à tous les liens du menu, il faut pouvoir prévoir le souligné de l'icône en cas de dropdown. Actuellement, c'est cassé comme ceci : 

![Capture d’écran 2024-07-31 à 16 59 28](https://github.com/user-attachments/assets/fe374548-8ce4-4b59-bb61-447513503664)

On ajoute donc un `display: inline-block` sous l'include de l'icon.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test de [Transition Design Lab](https://github.com/osunyorg/cyu-transition-design-lab)

Accueil

## Screenshots

![Capture d’écran 2024-07-31 à 16 59 18](https://github.com/user-attachments/assets/4593d0ca-fc37-4e95-a0c2-3357e0165358)