### PR TITLE
Gestions des couleurs de fonds des dropdown sur mobile

### DIFF
--- a/assets/sass/_theme/configuration/components.sass
+++ b/assets/sass/_theme/configuration/components.sass
@@ -36,12 +36,12 @@ $header-hover-color: var(--color-accent) !default // TODO : Réflechir à plus �
 $header-background: var(--color-background-alt) !default
 $header-transition: 0.3s !default
 $header-dropdown-full: false !default
-$header-dropdown-background: $header-background !default
+$header-dropdown-background: red !default
 $header-dropdown-color: $header-color !default
 $header-dropdown-transition: $header-transition !default
 $header-sticky-enabled: true !default
 $header-sticky-background: var(--color-background) !default
-$header-sticky-dropdown-background: $header-sticky-background !default
+$header-sticky-dropdown-background: rosybrown !default
 $header-sticky-dropdown-color: $header-dropdown-color !default
 $header-sticky-color: $header-color !default
 $header-sticky-transition: $header-transition !default

--- a/assets/sass/_theme/configuration/components.sass
+++ b/assets/sass/_theme/configuration/components.sass
@@ -36,12 +36,12 @@ $header-hover-color: var(--color-accent) !default // TODO : Réflechir à plus �
 $header-background: var(--color-background-alt) !default
 $header-transition: 0.3s !default
 $header-dropdown-full: false !default
-$header-dropdown-background: red !default
+$header-dropdown-background: $header-background !default
 $header-dropdown-color: $header-color !default
 $header-dropdown-transition: $header-transition !default
 $header-sticky-enabled: true !default
 $header-sticky-background: var(--color-background) !default
-$header-sticky-dropdown-background: rosybrown !default
+$header-sticky-dropdown-background: $header-sticky-background !default
 $header-sticky-dropdown-color: $header-dropdown-color !default
 $header-sticky-color: $header-color !default
 $header-sticky-transition: $header-transition !default

--- a/assets/sass/_theme/design-system/header.sass
+++ b/assets/sass/_theme/design-system/header.sass
@@ -18,9 +18,10 @@ header#document-header
         color: $header-sticky-color
         .pagefind-ui__toggle
             color: $header-sticky-color
-        .dropdown-menu
-            background: $header-sticky-dropdown-background
-            color: $header-sticky-dropdown-color
+        @include media-breakpoint-up(desktop)
+            .dropdown-menu
+                background: $header-sticky-dropdown-background
+                color: $header-sticky-dropdown-color
         .menu
             a,
             a:hover,

--- a/assets/sass/_theme/design-system/header.sass
+++ b/assets/sass/_theme/design-system/header.sass
@@ -13,9 +13,10 @@ header#document-header
         width: 100%
     .dropdown-menu
         transition: background $header-sticky-transition
-    &.is-sticky
+    &.is-sticky, html.has-menu-opened &
         background: $header-sticky-background
         color: $header-sticky-color
+    &.is-sticky
         .pagefind-ui__toggle
             color: $header-sticky-color
         @include media-breakpoint-up(desktop)

--- a/assets/sass/_theme/design-system/header.sass
+++ b/assets/sass/_theme/design-system/header.sass
@@ -16,6 +16,13 @@ header#document-header
     &.is-sticky, html.has-menu-opened &
         background: $header-sticky-background
         color: $header-sticky-color
+        .menu
+            a,
+            a:hover,
+            a:focus,
+            a:active,
+            span
+                color: inherit
     &.is-sticky
         .pagefind-ui__toggle
             color: $header-sticky-color
@@ -23,14 +30,6 @@ header#document-header
             .dropdown-menu
                 background: $header-sticky-dropdown-background
                 color: $header-sticky-dropdown-color
-        .menu
-            a,
-            a:hover,
-            a:focus,
-            a:active
-                color: inherit
-            span
-                color: $header-sticky-color
         @if $header-sticky-invert-logo
             .logo
                 img, .logo-text

--- a/assets/sass/_theme/design-system/nav.sass
+++ b/assets/sass/_theme/design-system/nav.sass
@@ -41,10 +41,10 @@
 
     .dropdown-menu
         display: none
-        background: $header-dropdown-background
         @include media-breakpoint-down(desktop)
             padding-bottom: $spacing-3
         @include media-breakpoint-up(desktop)
+            background: $header-dropdown-background
             padding: $spacing-3
             position: absolute
             max-height: calc(100vh - var(--header-height))


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

J'ai push sans faire exprès un bout de ce fix en prod 😭 c'est donc la suite de ce commit : https://github.com/osunyorg/theme/commit/f5c43557e98255603f4cc2f9b67a76828f298cf3

En bossant sur CIDS, j'ai noté qu'on ne gérait pas le cas où les couleurs de fond des dropdown étaient différentes de celles du header. On n'utilisait pas les variables appropriées, alors même qu'elles existent.

Sur le commit sauvage, j'ai donc ajusté le sass de sorte à ce que les bonnes couleurs de background s'affichent : 
- quand le menu est en haut de page
- quand le menu est sitcky
- quand le menu est en haut de page et qu'un dropdown est ouvert, le menu doit prendre les variables liées au sticky (je les avais enlevé dans mon wip exemple sur [Bonnes Notes](https://github.com/osunyorg/joy2learn-bonnesnotes))

Le problème, c'est que le rendu est particulièrement laid sur mobile, comme le montre l'issue #535 (en pensant travailler sur une branche, j'ai remis ça à plus tard, sauf que c'est en prod).

J'ai donc ajusté mon premier fix pour que les couleurs ne s'applique qu'à partir du `desktop`.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

Pas d'incidence car on fallback automatiquement sur les valeur du header si celles des dropdown n'ont pas été renseignées, liste des sites à vérifier en dessous.

## Référence (ticket et/ou figma)

#535

## URL de test sur example.osuny.org

Accueil

## URL de test sur [CIDS](https://github.com/osunyorg/cids-site)

Accueil

## Screenshots

### En haut de page
<img width="1470" alt="Capture d’écran 2024-08-02 à 22 22 36" src="https://github.com/user-attachments/assets/12e1c7ab-4bc5-43fd-82b8-c440e33304b7">

### En sticky :
<img width="1470" alt="Capture d’écran 2024-08-02 à 22 22 47" src="https://github.com/user-attachments/assets/9f39b431-cb1d-4e6f-990c-5fdfe69db878">

### En mobile : 
<img width="371" alt="Capture d’écran 2024-08-02 à 22 16 50" src="https://github.com/user-attachments/assets/ad128f76-6531-42c2-bde6-89c4b13a2d6a">
