### PR TITLE
Program: Option de positionnement des blocks

### DIFF
--- a/assets/sass/_theme/sections/programs.sass
+++ b/assets/sass/_theme/sections/programs.sass
@@ -43,6 +43,7 @@ ol.programs
             .lead
                 margin-bottom: $spacing-3
         .content
+            @include grid(1)
             padding-bottom: $spacing-4
             section:not(.block) > * + *
                 margin-top: 1em

--- a/config.yaml
+++ b/config.yaml
@@ -155,6 +155,9 @@ params:
       quantity: 4
     related_events:
       quantity: 4
+    index:
+      options:
+        blocks_position: "after-information" # "after-image" "after-presentation" "after-objectives""after-information"
     # share_links: # Optional
     #   enabled: true
     #   email: false

--- a/layouts/partials/programs/presentation.html
+++ b/layouts/partials/programs/presentation.html
@@ -5,21 +5,31 @@
 
         <div>
           {{- partial "programs/image.html" .Params.image -}}
-
+          {{ if eq site.Params.programs.index.options.blocks_position "after-image"}} 
+        </div>
+        {{- partial "contents/list.html" . }}
+        <div>
+          {{ end }}
           {{- if partial "GetTextFromHTML" .Params.presentation -}}
             <section id="{{ urlize (i18n "programs.presentation") }}">
               <h3>{{ i18n "programs.presentation" }}</h3>
               <p>{{- partial "PrepareHTML" .Params.presentation -}}</p>
             </section>
           {{- end -}}
-
+          {{ if eq site.Params.programs.index.options.blocks_position "after-presentation"}} 
+        </div>
+          {{- partial "contents/list.html" . }}
+        <div>
+          {{ end }}
           {{- if partial "GetTextFromHTML" .Params.objectives -}}
             <section id="{{ urlize (i18n "programs.objectives") }}">
               <h3>{{ i18n "programs.objectives" }}</h3>
               {{- partial "PrepareHTML" .Params.objectives -}}
             </section>
           {{- end -}}
-
+          {{ if eq site.Params.programs.index.options.blocks_position "after-objectives"}} 
+            {{- partial "contents/list.html" . }}
+          {{ end }}
           <section id="{{ urlize (i18n "programs.administrative_information") }}">
             <h3>{{ i18n "programs.administrative_information" }}</h3>
             <table class="program-table">
@@ -55,9 +65,12 @@
               </tbody>
             </table>
           </section>
-
+          {{ if eq site.Params.programs.index.options.blocks_position "after-information"}} 
         </div>
-        {{- partial "contents/list.html" . }}
+          {{- partial "contents/list.html" . }}
+        <div>
+          {{ end }}
+        </div>
       </div>
     </div>
 </section>


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description
Ajout d'une option pour positionner les blocks à différents endroits dans la présentation de la formation.

Problemes de marges en y ( attendre le figma ou discussion pour bien gerer ça)

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [x] Incidence forte 😱

## Référence (ticket et/ou figma)
https://github.com/osunyorg/bordeaux-iut-de-bordeaux/issues/27


## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots

### after-image 
<img width="800" alt="image" src="https://github.com/user-attachments/assets/e9cc4fe3-8b97-4f9f-9e0f-1d5e1543b1f8">
<img width="187" alt="image" src="https://github.com/user-attachments/assets/171228b2-cc45-434e-80ac-8482a1b897e6">

### after-presentation
<img width="801" alt="image" src="https://github.com/user-attachments/assets/173ad41a-4e6f-48e8-ade6-b4e2dceedb5a">

<img width="189" alt="image" src="https://github.com/user-attachments/assets/27326592-e304-409a-a9ac-557ab8315fec">

### after-objectives
<img width="802" alt="image" src="https://github.com/user-attachments/assets/d5ba7c60-2b5f-4cd3-87c8-36344fc0075e">
<img width="186" alt="image" src="https://github.com/user-attachments/assets/513695e1-36ed-432e-a18a-39785d48f07d">

### after-information
<img width="800" alt="image" src="https://github.com/user-attachments/assets/67a83b4c-7cff-4ce8-b751-bdee17d3ca73">

<img width="186" alt="image" src="https://github.com/user-attachments/assets/d4645707-5f33-4acd-86a4-5782e09266de">

