### PR TITLE
Ajout de l'image et du sous-titre aux options actives des événements

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -58,9 +58,9 @@ params:
       options:
         dates: true
         categories: false
-        image: false
+        image: true
         status: false
-        subtitle: false
+        subtitle: true
         summary: true
     # share_links: # Optional
     #   enabled: true


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Logiquement, on veut une image et un sous-titre dans les événement, ça fait partie des options de base, mais ces deux paramètres étaient à `false` dans la config.

![Capture d’écran 2024-08-19 à 10 16 54](https://github.com/user-attachments/assets/87f16a96-f09d-49d7-91e3-dc0d370d5c78)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

Issue #557 

## URL de test sur example.osuny.org

`http://localhost:1313/fr/agenda/`

## URL de test sur [La Criée](https://github.com/osunyorg/lacriee-site)

`http://localhost:1314/fr/agenda/`

## Screenshots

![Capture d’écran 2024-08-19 à 10 16 34](https://github.com/user-attachments/assets/63580699-e734-4f00-a652-31d28ef99fcb)
