### PR TITLE
Ajout d'une vérification dans le partial GetBlockClass

### DIFF
--- a/layouts/partials/GetBlockClass
+++ b/layouts/partials/GetBlockClass
@@ -10,6 +10,8 @@
   {{- $class = printf "%s block-%s--%s" $class .template .data.layout -}}
 {{- end -}}
 
-{{- $class = printf "%s %s" $class .html_class -}}
+{{- if .html_class -}}
+  {{- $class = printf "%s %s" $class .html_class -}}
+{{ end }}
 
 {{- return $class -}}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Il n'y avait pas de vérification à l'endroit où on vérifie la présence d'une class personnalisée ajoutée depuis l'admin (`html_class`).

![image](https://github.com/user-attachments/assets/9de56b18-8b62-4eef-91e0-050e8844b631)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/tous-les-blocks/` (le premier chapitre a la class `block-class-special-chapter`)