### PR TITLE
[A11Y] Retrait des balises vides dans les blocs

### DIFF
--- a/layouts/partials/blocks/templates/links.html
+++ b/layouts/partials/blocks/templates/links.html
@@ -22,7 +22,9 @@
 
                 <link itemprop="url" href="{{ .url }}">
                 <a itemprop="relatedLink" href="{{ .url }}" title="{{ $link_title }}" {{ if $isExternal -}} target="_blank" rel="noopener" {{- end }}><span itemprop="name">{{- $title -}}</span></a>
-                <p>{{ .description | safeHTML }}</p>
+                {{ with .description }}
+                  <p>{{ . | safeHTML }}</p>
+                {{ end }}
               </div>
               {{- if .image -}}
                 <div class="media">

--- a/layouts/partials/persons/person.html
+++ b/layouts/partials/persons/person.html
@@ -5,7 +5,6 @@
   "close" ((printf "</h%d>" $heading) | safeHTML)
 ) }}
 {{ $person := .person }}
-{{ $has_content := or (gt (len $person.Content) 1) false }}
 
 <article class="person" itemscope itemtype="https://schema.org/Person">
   <div class="description">
@@ -18,14 +17,12 @@
         </a>
       {{ end }}
     {{ $heading_tag.close }}
-    {{ if and $options.summary (or $person.Params.summary $has_content) }}
+    {{ if and $options.summary (or $person.Params.summary $person.Params.summary) }}
       <p itemprop="jobTitle">
         {{ if (partial "GetTextFromHTML" .role) }}
           {{ partial "PrepareHTML" .role }}
         {{ else if partial "GetTextFromHTML" $person.Params.summary }}
           {{ partial "PrepareHTML" $person.Params.summary }}
-        {{ else if and $has_content (partial "GetTextFromHTML" $person.Content) }}
-          {{ partial "GetTruncateContent" ( dict "text" $person.Content ) }}
         {{ end }}
       </p>
     {{ end }}

--- a/layouts/partials/persons/person.html
+++ b/layouts/partials/persons/person.html
@@ -5,6 +5,7 @@
   "close" ((printf "</h%d>" $heading) | safeHTML)
 ) }}
 {{ $person := .person }}
+{{ $has_content := or (gt (len $person.Content) 1) false }}
 
 <article class="person" itemscope itemtype="https://schema.org/Person">
   <div class="description">
@@ -17,13 +18,13 @@
         </a>
       {{ end }}
     {{ $heading_tag.close }}
-    {{ if $options.summary }}
+    {{ if and $options.summary (or $person.Params.summary $has_content) }}
       <p itemprop="jobTitle">
         {{ if (partial "GetTextFromHTML" .role) }}
           {{ partial "PrepareHTML" .role }}
         {{ else if partial "GetTextFromHTML" $person.Params.summary }}
           {{ partial "PrepareHTML" $person.Params.summary }}
-        {{ else if partial "GetTextFromHTML" $person.Content }}
+        {{ else if and $has_content (partial "GetTextFromHTML" $person.Content) }}
           {{ partial "GetTruncateContent" ( dict "text" $person.Content ) }}
         {{ end }}
       </p>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Dans deux types de blocs, nous avons des paragraphes vides. Si pour les liens, c'est aisé d'ajouter une vérification, c'est un peu plus délicat pour les personnes : 

![Capture d’écran 2024-08-19 à 11 38 49](https://github.com/user-attachments/assets/9d8e48d2-0bdb-41de-af82-da81d626e46e)

- Nous avions oublié d'ajouter une vérification supplémentaire à l'option (il n'y avait que `if options.summary`) ce qui ne permet pas de vérifier la présence de `.role` ou `.summary` ou `.Content`
- `.Content` est le noeud du problème, car hugo le considère comme rempli dès lors qu'il y a des sauts de ligne. J'ai donc ajouté une vérification pour détecter `$has_content` mais ça ne me semble pas l'idéal...

@arnaudlevy est-il possible d'empêcher l'ajout de saut de ligne dans le document ? J'ai l'impression qu'hugo détecte un espace également, mais je ne suis pas sûre.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

#546 

## URL de test sur example.osuny.org

- Bloc de personnes : `http://localhost:1313/fr/blocks/blocs-de-mise-en-page/#les-personnes`
- Bloc de liens : `http://localhost:1313/fr/blocks/blocks-techniques/liens/`