### PR TITLE
Gestion elements informatifs css

### DIFF
--- a/assets/sass/_theme/_utils.sass
+++ b/assets/sass/_theme/_utils.sass
@@ -1,3 +1,4 @@
+@import utils/a11y
 @import utils/fonts
 @import utils/colors
 @import utils/grid

--- a/assets/sass/_theme/utils/a11y.sass
+++ b/assets/sass/_theme/utils/a11y.sass
@@ -1,0 +1,19 @@
+.sr-only
+    border: 0 !important
+    clip: rect(1px,1px,1px,1px) !important
+    clip-path: inset(50%) !important
+    height: 1px !important
+    overflow: hidden !important
+    padding: 0 !important
+    position: absolute !important
+    width: 1px !important
+    white-space: nowrap !important
+
+.sr-only-focusable:focus
+    clip: auto !important
+    clip-path: none !important
+    height: auto !important
+    margin: auto !important
+    overflow: visible !important
+    width: auto !important
+    white-space: normal !important

--- a/layouts/partials/blocks/templates/carousel.html
+++ b/layouts/partials/blocks/templates/carousel.html
@@ -48,9 +48,10 @@
 
   {{ if .options.arrows }}
     <div class="carousel__arrows">
-      <button class="arrow-prev" aria-controls="carousel-items" type="button" aria-label='{{ safeHTML (i18n "commons.carousel.prev") }}'> </button>
+      <button class="arrow-prev" aria-controls="carousel-items" type="button" aria-label='{{ safeHTML (i18n "commons.carousel.prev") }}'><span class="sr-only">{{ safeHTML (i18n "commons.carousel.prev") }}</span></button>
+
       <p class="counter"></p>
-      <button class="arrow-next" aria-controls="carousel-items" type="button" aria-label='{{  safeHTML (i18n "commons.carousel.next") }}'></button>
+      <button class="arrow-next" aria-controls="carousel-items" type="button" aria-label='{{  safeHTML (i18n "commons.carousel.next") }}'><span class="sr-only">{{ safeHTML (i18n "commons.carousel.next") }}</span></button>
     </div>
   {{ end }}
 </div>

--- a/layouts/partials/blocks/templates/carousel.html
+++ b/layouts/partials/blocks/templates/carousel.html
@@ -48,10 +48,14 @@
 
   {{ if .options.arrows }}
     <div class="carousel__arrows">
-      <button class="arrow-prev" aria-controls="carousel-items" type="button" aria-label='{{ safeHTML (i18n "commons.carousel.prev") }}'><span class="sr-only">{{ safeHTML (i18n "commons.carousel.prev") }}</span></button>
+      <button class="arrow-prev" aria-controls="carousel-items" type="button" aria-label="{{ safeHTML (i18n "commons.carousel.prev")}}">
+        <span class="sr-only">{{ safeHTML (i18n "commons.carousel.prev") }}</span>
+      </button>
 
       <p class="counter"></p>
-      <button class="arrow-next" aria-controls="carousel-items" type="button" aria-label='{{  safeHTML (i18n "commons.carousel.next") }}'><span class="sr-only">{{ safeHTML (i18n "commons.carousel.next") }}</span></button>
+      <button class="arrow-next" aria-controls="carousel-items" type="button" aria-label='{{  safeHTML (i18n "commons.carousel.next") }}'>
+        <span class="sr-only">{{ safeHTML (i18n "commons.carousel.next") }}</span>
+      </button>
     </div>
   {{ end }}
 </div>

--- a/layouts/partials/blocks/templates/carousel.html
+++ b/layouts/partials/blocks/templates/carousel.html
@@ -53,7 +53,7 @@
       </button>
 
       <p class="counter"></p>
-      <button class="arrow-next" aria-controls="carousel-items" type="button" aria-label='{{  safeHTML (i18n "commons.carousel.next") }}'>
+      <button class="arrow-next" aria-controls="carousel-items" type="button" aria-label="{{ safeHTML (i18n 'commons.carousel.next') }}">
         <span class="sr-only">{{ safeHTML (i18n "commons.carousel.next") }}</span>
       </button>
     </div>

--- a/layouts/partials/blocks/templates/carousel.html
+++ b/layouts/partials/blocks/templates/carousel.html
@@ -53,7 +53,7 @@
       </button>
 
       <p class="counter"></p>
-      <button class="arrow-next" aria-controls="carousel-items" type="button" aria-label="{{ safeHTML (i18n 'commons.carousel.next') }}">
+      <button class="arrow-next" aria-controls="carousel-items" type="button" aria-label="{{ safeHTML (i18n "commons.carousel.next") }}">
         <span class="sr-only">{{ safeHTML (i18n "commons.carousel.next") }}</span>
       </button>
     </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description
Ajout d'une classe sr-only pour permettre l'ajout de texte seulement visibible par les screen readers


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)
#552
#554 

## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


