### PR TITLE
Ajout d'élements textes SR dans les déclencheurs de lightbox

### DIFF
--- a/layouts/partials/blocks/templates/chapter.html
+++ b/layouts/partials/blocks/templates/chapter.html
@@ -39,6 +39,7 @@
                   title="{{- i18n "commons.lightbox.link.title" -}}"
                   aria-label="{{- i18n "commons.lightbox.link.title" -}}"
                   >
+                  <span class="sr-only">{{- i18n "commons.lightbox.link.title" -}}</span>
               {{ end }}
                 {{ partial "commons/image.html"
                   (dict

--- a/layouts/partials/blocks/templates/gallery/carousel-image.html
+++ b/layouts/partials/blocks/templates/gallery/carousel-image.html
@@ -25,6 +25,7 @@
               href="{{ partial "GetLightboxUrl" (dict "id" .id) }}"
               title="{{- i18n "commons.lightbox.link.title" -}}"
               aria-label="{{- i18n "commons.lightbox.link.title" -}}">
+              <span class="sr-only">{{- i18n "commons.lightbox.link.title" -}}</span>
           </a>
         {{ end }}
         {{ if or .text .credit }}

--- a/layouts/partials/blocks/templates/gallery/grid.html
+++ b/layouts/partials/blocks/templates/gallery/grid.html
@@ -29,6 +29,7 @@
                 href="{{ partial "GetLightboxUrl" (dict "id" .id) }}"
                 title="{{- i18n "commons.lightbox.link.title" -}}"
                 aria-label="{{- i18n "commons.lightbox.link.title" -}}">
+                <span class="sr-only">{{- i18n "commons.lightbox.link.title" -}}</span>
             </a>
           {{ end }}
           {{ with .text }}

--- a/layouts/partials/blocks/templates/gallery/large.html
+++ b/layouts/partials/blocks/templates/gallery/large.html
@@ -25,6 +25,7 @@
                 href="{{ partial "GetLightboxUrl" (dict "id" .id) }}"
                 title="{{- i18n "commons.lightbox.link.title" -}}"
                 aria-label="{{- i18n "commons.lightbox.link.title" -}}">
+                <span class="sr-only">{{- i18n "commons.lightbox.link.title" -}}</span>
             </a>
           {{ end }}
           {{ if or .text .credit }}

--- a/layouts/partials/blocks/templates/image.html
+++ b/layouts/partials/blocks/templates/image.html
@@ -25,6 +25,7 @@
                   href="{{- partial "GetLightboxUrl" . -}}"
                   title="{{- i18n "commons.lightbox.link.title" -}}"
                   aria-label="{{- i18n "commons.lightbox.link.title" -}}">
+                  <span class="sr-only">{{- i18n "commons.lightbox.link.title" -}}</span>
             {{ end }}
                 {{ partial "commons/image.html"
                   (dict

--- a/layouts/partials/header/hero.html
+++ b/layouts/partials/header/hero.html
@@ -72,6 +72,7 @@
                 href="{{ partial "GetLightboxUrl" .image }}"
                 title="{{- i18n "commons.lightbox.link.title" -}}"
                 aria-label="{{- i18n "commons.lightbox.link.title" -}}">
+                <span class="sr-only">{{- i18n "commons.lightbox.link.title" -}}</span>
             </a>
           {{ end }}
           {{ with .image.credit }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description
Ajout d'elements textes dans les liens qui ouvrent les lightbox ( cachés sauf pour le lecteurs d'ecrans) 
Attention il faut d'abord merge la PR #573 avant ( autrement la classe .sr-only n'existe pas


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)
#577 


## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


