### PR TITLE
[A11Y] Ajout d'un label visible pour le TA et sans css aux liens externes

### DIFF
--- a/layouts/partials/blocks/templates/links.html
+++ b/layouts/partials/blocks/templates/links.html
@@ -21,7 +21,12 @@
                 {{ $link_title := cond $isExternal (safeHTML (i18n "commons.link.blank_aria" (dict "Title" $title))) $title}}
 
                 <link itemprop="url" href="{{ .url }}">
-                <a itemprop="relatedLink" href="{{ .url }}" title="{{ $link_title }}" {{ if $isExternal -}} target="_blank" rel="noopener" {{- end }}><span itemprop="name">{{- $title -}}</span></a>
+                <a itemprop="relatedLink" href="{{ .url }}" title="{{ $link_title }}" {{ if $isExternal -}} target="_blank" rel="noopener" {{- end }}>
+                  <span itemprop="name">{{- $title -}}</span>
+                  {{ if $isExternal }}
+                    <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+                  {{ end }}
+                </a>
                 {{ with .description }}
                   <p>{{ . | safeHTML }}</p>
                 {{ end }}

--- a/layouts/partials/blocks/templates/organizations.html
+++ b/layouts/partials/blocks/templates/organizations.html
@@ -43,7 +43,10 @@
             <a href="{{ .url }}" {{ if .external }} target="_blank" rel="noopener" {{ end }} title="{{ safeHTML (i18n "commons.link.blank_aria" (dict "Title" $title)) }}">
           {{ end -}}
             {{- $title -}}
-          {{- if .url }}
+          {{- if and .url $options.link }}
+            {{ if .external }}
+              <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+            {{ end }}
             </a>
           {{ end -}}
           </p>

--- a/layouts/partials/commons/share.html
+++ b/layouts/partials/commons/share.html
@@ -10,49 +10,49 @@
   {{ if $share_options.facebook }}
     <li>
       <a href="https://www.facebook.com/sharer/sharer.php?u={{ .Permalink | absURL }}" target="_blank" rel="noopener" class="icon icon-facebook-fill" title="{{ i18n "posts.share_aria" (dict "Title" "Facebook") }}">
-        <span>Facebook</span>
+        <span class="sr-only">{{ i18n "posts.share_aria" (dict "Title" "Facebook") }}</span>
       </a>
     </li>
   {{ end }}
   {{ if $share_options.linkedin }}
     <li>
       <a href="https://www.linkedin.com/sharing/share-offsite/?url={{ .Permalink | absURL }}" target="_blank" rel="noopener" class="icon icon-linkedin-fill" title="{{ i18n "posts.share_aria" (dict "Title" "Linkedin") }}">
-        <span>Linkedin</span>
+        <span class="sr-only">{{ i18n "posts.share_aria" (dict "Title" "Linkedin") }}</span>
       </a>
     </li>
   {{ end }}
   {{ if $share_options.mastodon }}
     <li>
       <a href="https://mastodonshare.com/?text={{ .Title }}&url={{ .Permalink | absURL }}" target="_blank" rel="noopener" class="icon icon-mastodon-fill" title="{{ i18n "posts.share_aria" (dict "Title" "Mastodon") }}">
-        <span>Mastodon</span>
+        <span class="sr-only">{{ i18n "posts.share_aria" (dict "Title" "Mastodon") }}</span>
       </a>
     </li>
   {{ end }}
   {{ if $share_options.twitter }}
     <li>
       <a href="https://twitter.com/intent/tweet?text={{ .Title }} {{ .Permalink | absURL }}" target="_blank" rel="noopener" class="icon icon-twitter-x-line" title="{{ i18n "posts.share_aria" (dict "Title" "Twitter") }}">
-        <span>Twitter</span>
+        <span class="sr-only">{{ i18n "posts.share_aria" (dict "Title" "Twitter") }}</span>
       </a>
     </li>
   {{ end }}
   {{ if $share_options.whatsapp }}
     <li>
       <a href="https://api.whatsapp.com/send?text={{ .Permalink | absURL }}" target="_blank" rel="noopener" class="icon icon-whatsapp-fill" title="{{ i18n "posts.share_aria" (dict "Title" "Whatsapp") }}">
-        <span>Whatsapp</span>
+        <span class="sr-only">{{ i18n "posts.share_aria" (dict "Title" "Whatsapp") }}</span>
       </a>
     </li>
   {{ end }}
   {{ if $share_options.telegram }}
     <li>
       <a href="https://t.me/share/url?url={{ .Permalink | absURL }}&text={{ .Title }}" target="_blank" rel="noopener" class="icon icon-telegram-fill" title="{{ i18n "posts.share_aria" (dict "Title" "Telegram") }}">
-        <span>Telegram</span>
+        <span class="sr-only">{{ i18n "posts.share_aria" (dict "Title" "Telegram") }}</span>
       </a>
     </li>
   {{ end }}
   {{ if $share_options.email }}
     <li>
       <a href="mailto:?subject={{ .Title }}&body={{ .Permalink | absURL }}" target="_blank" rel="noopener" class="icon icon-mail-fill" title="{{ i18n "posts.share_aria" (dict "Title" "E-mail") }}">
-        <span>E-mail</span>
+        <span class="sr-only">{{ i18n "posts.share_aria" (dict "Title" "E-mail") }}</span>
       </a>
     </li>
   {{ end }}

--- a/layouts/partials/locations/map.html
+++ b/layouts/partials/locations/map.html
@@ -10,7 +10,8 @@
               <a href="{{ .Params.url }}" {{ if .external }} target="_blank" rel="noopener" {{ end }} title="{{ safeHTML (i18n "commons.link.blank_aria" (dict "Title" $title)) }}">
             {{ end -}}
             {{- $title -}}
-            {{- if .Params.url }}
+            {{- if and .Params.url .Params.with_link }}
+                <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
               </a>
             {{ end -}}
           </p>

--- a/layouts/partials/organizations/contact-details.html
+++ b/layouts/partials/organizations/contact-details.html
@@ -6,35 +6,50 @@
           {{ with .website }}
             <li>
               <span>{{ i18n "commons.contact.website" }}</span>
-              <a href="{{ chomp .value }}" target="_blank" rel="noopener" itemprop="url">{{ chomp .label }}</a>
+              <a href="{{ chomp .value }}" target="_blank" rel="noopener" itemprop="url">
+                {{ chomp .label }}
+                <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+              </a>
             </li>
           {{ end }}
 
           {{ with .linkedin }}
             <li>
               <span>LinkedIn</span>
-              <a href="{{ chomp .value }}" target="_blank" rel="noopener" itemprop="url">{{ chomp .label }}</a>
+              <a href="{{ chomp .value }}" target="_blank" rel="noopener" itemprop="url">
+                {{ chomp .label }}
+                <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+              </a>
             </li>
           {{ end }}
         
           {{ with .mastodon }}
             <li>
               <span>Mastodon</span>
-              <a href="{{ chomp .value }}" target="_blank" rel="noopener" itemprop="url">{{ chomp .label }}</a>
+              <a href="{{ chomp .value }}" target="_blank" rel="noopener" itemprop="url">
+                {{ chomp .label }}
+                <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+              </a>
             </li>
           {{ end }}
 
           {{ with .twitter }}
             <li>
               <span>Twitter</span>
-              <a href="{{ chomp .value }}" target="_blank" rel="noopener" itemprop="url">{{ chomp .label }}</a>
+              <a href="{{ chomp .value }}" target="_blank" rel="noopener" itemprop="url">
+                {{ chomp .label }}
+                <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+              </a>
             </li>
           {{ end }}
 
           {{ with .email }}
             <li>
               <span>{{ i18n "commons.contact.email" }}</span>
-              <a href="{{ chomp .value }}" itemprop="email">{{ chomp .label }}</a>
+              <a href="{{ chomp .value }}" itemprop="email">
+                {{ chomp .label }}
+                <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+              </a>
             </li>
           {{ end }}
         </ul>

--- a/layouts/partials/persons/contact-details.html
+++ b/layouts/partials/persons/contact-details.html
@@ -6,35 +6,50 @@
           {{ with .website }}
             <li>
               <span>{{ i18n "commons.contact.website" }}</span>
-              <a href="{{ chomp .value }}" target="_blank" rel="noopener" itemprop="url">{{ chomp .label }}</a>
+              <a href="{{ chomp .value }}" target="_blank" rel="noopener" itemprop="url">
+                {{ chomp .label }}
+                <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+              </a>
             </li>
           {{ end }}
 
           {{ with .linkedin }}
             <li>
               <span>LinkedIn</span>
-              <a href="{{ chomp .value }}" target="_blank" rel="noopener" itemprop="url">{{ chomp .label }}</a>
+              <a href="{{ chomp .value }}" target="_blank" rel="noopener" itemprop="url">
+                {{ chomp .label }}
+                <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+              </a>
             </li>
           {{ end }}
 
           {{ with .mastodon }}
             <li>
               <span>Mastodon</span>
-              <a href="{{ chomp .value }}" target="_blank" rel="noopener" itemprop="url">{{ chomp .label }}</a>
+              <a href="{{ chomp .value }}" target="_blank" rel="noopener" itemprop="url">
+                {{ chomp .label }}
+                <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+              </a>
             </li>
           {{ end }}
 
           {{ with .twitter }}
             <li>
               <span>Twitter</span>
-              <a href="{{ chomp .value }}" target="_blank" rel="noopener" itemprop="url">{{ chomp .label }}</a>
+              <a href="{{ chomp .value }}" target="_blank" rel="noopener" itemprop="url">
+                {{ chomp .label }}
+                <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+              </a>
             </li>
           {{ end }}
 
           {{ with .email }}
             <li>
               <span>{{ i18n "commons.contact.email" }}</span>
-              <a href="{{ chomp .value }}" itemprop="email">{{ chomp .label }}</a>
+              <a href="{{ chomp .value }}" itemprop="email">
+                {{ chomp .label }}
+                <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+              </a>
             </li>
           {{ end }}
 

--- a/layouts/partials/persons/contacts.html
+++ b/layouts/partials/persons/contacts.html
@@ -2,35 +2,50 @@
   {{ if .Params.linkedin }}
     <li>
       <span>Linkedin</span>
-      <a href="{{ .Params.linkedin }}" target="_blank" rel="noopener" itemprop="url">{{ .Params.linkedin }}</a>
+      <a href="{{ .Params.linkedin }}" target="_blank" rel="noopener" itemprop="url">
+        {{ .Params.linkedin }}
+        <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+      </a>
     </li>
   {{ end }}
 
   {{ if .Params.twitter }}
     <li>
       <span>Twitter</span>
-      <a href="https://twitter.com/{{ .Params.twitter }}" target="_blank" rel="noopener" itemprop="url">{{ .Params.twitter }}</a>
+      <a href="https://twitter.com/{{ .Params.twitter }}" target="_blank" rel="noopener" itemprop="url">
+        {{ .Params.twitter }}
+        <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+      </a>
     </li>
   {{ end }}
 
   {{ if .Params.website }}
     <li>
       <span>{{ i18n "commons.contact.website" }}</span>
-      <a href="{{ .Params.website }}" target="_blank" rel="noopener" itemprop="url">{{ .Params.website }}</a>
+      <a href="{{ .Params.website }}" target="_blank" rel="noopener" itemprop="url">
+        {{ .Params.website }}
+        <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+      </a>
     </li>
   {{ end }}
 
   {{ if .Params.email }}
     <li>
       <span>{{ i18n "commons.contact.email" }}</span>
-      <a href="mailto:{{ .Params.email }}" itemprop="email">{{ .Params.email }}</a>
+      <a href="mailto:{{ .Params.email }}" itemprop="email">
+        {{ .Params.email }}
+        <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+      </a>
     </li>
   {{ end }}
 
   {{ if .Params.phone }}
     <li>
       <span>{{ i18n "commons.contact.phone" }}</span>
-      <a href="tel:{{ .Params.phone }}" itemprop="telephone">{{ .Params.phone }}</a>
+      <a href="tel:{{ .Params.phone }}" itemprop="telephone">
+        {{ .Params.phone }}
+        <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+      </a>
     </li>
   {{ end }}
 </ul>

--- a/layouts/partials/publications/downloads.html
+++ b/layouts/partials/publications/downloads.html
@@ -4,7 +4,10 @@
   <nav>
     {{ range .Params.links }}
       {{ if .url }}
-        <a href="{{ .url }}" target="_blank" rel="noopener">{{ .label }}</a>
+        <a href="{{ .url }}" target="_blank" rel="noopener">
+          {{ .label }}
+          <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+        </a>
       {{ end }}
     {{ end }}
   </nav>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Ajout d'un `span.sr-only` aux liens externes pour rendre visible à la lecture vocale et dans le cas d'une absence de css l'équivalence visuelle de l'icône des liens externes.

**NB : ** d'abord merge la class `.sr-only` 

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

#566