### PR TITLE
[A11Y] Table des matières

### DIFF
--- a/assets/js/theme/design-system/toc.js
+++ b/assets/js/theme/design-system/toc.js
@@ -116,11 +116,13 @@ class TableOfContents {
         this.links.forEach((link) => {
             if (link === currentLink) {
                 link.classList.add(CLASSES.linkActive);
+                link.setAttribute('aria-current', 'true');
                 this.updateCtaTitle(link);
                 this.state.id = id;
                 this.state.currentLink = link;
             } else {
-                link.classList.remove(CLASSES.linkActive)
+                link.classList.remove(CLASSES.linkActive);
+                link.removeAttribute('aria-current');
             }
         });
     }

--- a/layouts/partials/toc/container.html
+++ b/layouts/partials/toc/container.html
@@ -6,7 +6,7 @@
   <div class="toc-container" aria-hidden="false" aria-labelledby="toc-title">
     <div class="toc-content">
       {{/* TODO : quelle balise pour le titre du toc ? */}}
-      <div id="toc-title" class="toc-title">{{ i18n "commons.toc" }}</div>
+      <div id="toc-title" class="toc-title" role="heading">{{ i18n "commons.toc" }}</div>
       {{- partial (printf .toc) . -}}
       <button name="{{ i18n "commons.close" }}">{{ i18n "commons.close" }}</button>
     </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Besoin de rendre les liens accessible et de faire du "Table des matières" un titre, car c'est un titre de section dans les faits.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

Issue #565

## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/blocs-de-mise-en-page/`

## Screenshots

![Capture d’écran 2024-08-23 à 12 05 42](https://github.com/user-attachments/assets/c3f551f3-f76b-452a-8767-cf8a05152035)
