### PR TITLE
Gallerie carousel: Ajustement  des hauteurs d'image

### DIFF
--- a/assets/sass/_theme/blocks/gallery.sass
+++ b/assets/sass/_theme/blocks/gallery.sass
@@ -91,9 +91,9 @@
                 margin-right: calc(var(--grid-gutter) / 2)
                 picture
                     img
-                        max-height: $block-gallery-carousel-max-height
+                        height: $block-gallery-carousel-max-height
                         width: auto
-                        max-width: calc(100vw - #{var(--grid-gutter)} * 2)
+                        max-width: none
                         @include media-breakpoint-up(desktop)
                             height: $block-gallery-carousel-max-height-desktop
                             width: auto

--- a/assets/sass/_theme/blocks/gallery.sass
+++ b/assets/sass/_theme/blocks/gallery.sass
@@ -91,13 +91,11 @@
                 margin-right: calc(var(--grid-gutter) / 2)
                 picture
                     img
-                        // FIXME Arnaud: I would like images at constant height, can't manage to get it right.
                         max-height: $block-gallery-carousel-max-height
                         width: auto
-                        height: auto
                         max-width: calc(100vw - #{var(--grid-gutter)} * 2)
                         @include media-breakpoint-up(desktop)
-                            height: $block-gallery-carousel-max-height
+                            height: $block-gallery-carousel-max-height-desktop
                             width: auto
                             max-width: none
                 @include in-page-without-sidebar

--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -106,8 +106,8 @@ $block-key_figures-number-font-size-xxl: pxToRem(80) !default
 
 // Block gallery
 $block-gallery-carousel-background: var(--color-background-alt) !default
-$block-gallery-carousel-max-height: 70vh !default
-
+$block-gallery-carousel-max-height: 20vh !default
+$block-gallery-carousel-max-height-desktop: 50vh !default
 // Block image
 $block-image-max-height-with-sidebar: calc(100vh - var(--header-height)) !default
 $block-image-max-height-without-sidebar: none !default

--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -106,8 +106,8 @@ $block-key_figures-number-font-size-xxl: pxToRem(80) !default
 
 // Block gallery
 $block-gallery-carousel-background: var(--color-background-alt) !default
-$block-gallery-carousel-max-height: 20vh !default
-$block-gallery-carousel-max-height-desktop: 50vh !default
+$block-gallery-carousel-max-height: 40vh !default
+$block-gallery-carousel-max-height-desktop: 60vh !default
 // Block image
 $block-image-max-height-with-sidebar: calc(100vh - var(--header-height)) !default
 $block-image-max-height-without-sidebar: none !default


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description
Ajustement des hauteurs des images de la gallerie en mode caroussel


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)
[#539](https://github.com/osunyorg/theme/issues/539) 



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)
http://localhost:1313/fr/blocks/blocks-narratifs/galeries/#galerie-carousel 


## Screenshots
<img width="1034" alt="image" src="https://github.com/user-attachments/assets/187ff03b-1416-4d73-ae1a-c37f795f7d86">
<img width="1020" alt="image" src="https://github.com/user-attachments/assets/0a79a270-f8db-4f06-9178-e65641b479d0">
<img width="224" alt="image" src="https://github.com/user-attachments/assets/3553c8c2-5993-40a2-b13f-716f89789f81">


