### PR TITLE
Block organisations layout carte : largeur de la carte

### DIFF
--- a/assets/sass/_theme/sections/organizations.sass
+++ b/assets/sass/_theme/sections/organizations.sass
@@ -55,23 +55,24 @@
                 width: columns(2)
 
 .organizations
-    max-width: 100%
-    @include grid(2)
-    @include grid(3, md)
-    @include grid(4, lg)
-    @include grid(6, xl)
-    &.with-summaries
-        @include grid(1)
-        @include grid(1, md)
-        @include in-page-without-sidebar
-            @include grid(2, lg)
-            @include grid(3, xl)
-    @include in-page-program
+    &:not(.block-organizations--map &)
+        max-width: 100%
+        @include grid(2)
         @include grid(3, md)
-        @include grid(3, lg)
-        @include grid(3, xl)
-    @include media-breakpoint-down(desktop)
-        grid-column-gap: $spacing-3 !important
+        @include grid(4, lg)
+        @include grid(6, xl)
+        &.with-summaries
+            @include grid(1)
+            @include grid(1, md)
+            @include in-page-without-sidebar
+                @include grid(2, lg)
+                @include grid(3, xl)
+        @include in-page-program
+            @include grid(3, md)
+            @include grid(3, lg)
+            @include grid(3, xl)
+        @include media-breakpoint-down(desktop)
+            grid-column-gap: $spacing-3 !important
 
 .organizations__section
     .organizations


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

En retravaillant les grilles des organisations pour les options, on a appliqué des propriétés au layout carte, mais celles-ci causent des problèmes (la carte devrait coller le bord droit) : 

<img width="1470" alt="Capture d’écran 2024-08-26 à 15 35 08" src="https://github.com/user-attachments/assets/82f6a009-dfd3-404b-973d-5dc7e39dd55d">

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

[http://localhost:1313/fr/blocks/tous-les-blocks-pleine-largeur/](http://localhost:1313/fr/blocks/tous-les-blocks-pleine-largeur/)

## Test sur le site [EPV](https://github.com/osunyorg/epv-site)

[https://www.reseauexcellence.fr/fr/lassociation/reseau-excellence-en-france/auvergne-rhone-alpes/](https://www.reseauexcellence.fr/fr/lassociation/reseau-excellence-en-france/auvergne-rhone-alpes/)

## Screenshots

<img width="1470" alt="Capture d’écran 2024-08-26 à 15 33 49" src="https://github.com/user-attachments/assets/d02eabdc-05a3-42b6-a684-14d2adb82f17">
<img width="984" alt="Capture d’écran 2024-08-26 à 15 36 05" src="https://github.com/user-attachments/assets/8b135d82-97d7-4838-b953-00e3f996d5d3">
