### PR TITLE
Couleurs des dropdowns du menu

### DIFF
--- a/assets/sass/_theme/configuration/components.sass
+++ b/assets/sass/_theme/configuration/components.sass
@@ -41,10 +41,10 @@ $header-dropdown-color: $header-color !default
 $header-dropdown-transition: $header-transition !default
 $header-sticky-enabled: true !default
 $header-sticky-background: var(--color-background) !default
-$header-sticky-dropdown-background: $header-sticky-background !default
-$header-sticky-dropdown-color: $header-dropdown-color !default
 $header-sticky-color: $header-color !default
 $header-sticky-transition: $header-transition !default
+$header-sticky-dropdown-background: $header-sticky-background !default
+$header-sticky-dropdown-color: $header-sticky-color !default
 $header-nav-padding-y: pxToRem(20) !default
 $header-nav-padding-y-desktop: pxToRem(30) !default
 $header-logo-height: 32px !default

--- a/assets/sass/_theme/design-system/header.sass
+++ b/assets/sass/_theme/design-system/header.sass
@@ -23,13 +23,13 @@ header#document-header
             a:active,
             span
                 color: inherit
-    &.is-sticky
-        .pagefind-ui__toggle
-            color: $header-sticky-color
         @include media-breakpoint-up(desktop)
             .dropdown-menu
                 background: $header-sticky-dropdown-background
                 color: $header-sticky-dropdown-color
+    &.is-sticky
+        .pagefind-ui__toggle
+            color: $header-sticky-color
         @if $header-sticky-invert-logo
             .logo
                 img, .logo-text


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

On a ce problème : 
<img width="542" alt="Capture d’écran 2024-08-27 à 10 47 59" src="https://github.com/user-attachments/assets/c57ee7d5-6ac3-4e78-b47e-c26abeed546a">

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

Accueil

## URL de test des sites

Pour plusieurs cas : 
- [Bonnes Notes](https://github.com/osunyorg/joy2learn-bonnesnotes) (accueil)
- [CIDS](https://github.com/osunyorg/cids-site) (accueil)

## Screenshots

### Example : 
<img width="580" alt="Capture d’écran 2024-08-27 à 10 58 25" src="https://github.com/user-attachments/assets/9142d9d4-8778-41fb-b9af-e6cf06bd8dc5">

### Pour CIDS en haut de page + sticky : 
<img width="619" alt="Capture d’écran 2024-08-27 à 10 47 17" src="https://github.com/user-attachments/assets/634e9b97-1732-43a7-b117-803a688ea350">
<img width="769" alt="Capture d’écran 2024-08-27 à 10 47 09" src="https://github.com/user-attachments/assets/5de7f086-908d-4b8f-9d8d-6a900c4ac799">

### Bonnes notes (couleur du header diff entre ouverture/sticky et normal) : 
<img width="869" alt="Capture d’écran 2024-08-27 à 10 50 25" src="https://github.com/user-attachments/assets/d6efa28d-c9b8-4473-9ee8-49393622cbc1">

### Futur(s)
<img width="774" alt="Capture d’écran 2024-08-27 à 10 56 48" src="https://github.com/user-attachments/assets/088123a0-bef3-4792-a781-702bd5c0a87c">
