### PR TITLE
[A11Y] Ajout d'attributs aria

### DIFF
--- a/layouts/partials/blocks/templates/call_to_action.html
+++ b/layouts/partials/blocks/templates/call_to_action.html
@@ -34,11 +34,11 @@
             {{- end -}}
           </div>
           {{ if .image }}
-            <figure>
+            <figure {{- with or .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>
               {{ partial "commons/image.html"
                 (dict
                   "image"    .image.file
-                  "alt"      .image.alt
+                  "alt"      .alt
                   "sizes"    site.Params.image_sizes.blocks.call_to_action
               )}}
               {{ if partial "GetTextFromHTML" .credit }}

--- a/layouts/partials/blocks/templates/call_to_action.html
+++ b/layouts/partials/blocks/templates/call_to_action.html
@@ -34,7 +34,7 @@
             {{- end -}}
           </div>
           {{ if .image }}
-            <figure {{- with or .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>
+            <figure role="figure" {{- with or .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>
               {{ partial "commons/image.html"
                 (dict
                   "image"    .image.file

--- a/layouts/partials/blocks/templates/chapter.html
+++ b/layouts/partials/blocks/templates/chapter.html
@@ -30,7 +30,7 @@
             {{ end -}}
           </div>
           {{ if .image }}
-            <figure class="{{- $image_class -}}">
+            <figure class="{{- $image_class -}}" {{- with or .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>
               {{ if not site.Params.image_sizes.design_system.lightbox.disabled }}
                 <a class="glightbox"
                   role="button"
@@ -44,6 +44,7 @@
                 {{ partial "commons/image.html"
                   (dict
                     "image"    .image
+                    "alt" .alt
                     "sizes"    site.Params.image_sizes.blocks.chapter
                   )}}
               {{ if not site.Params.image_sizes.design_system.lightbox.disabled }}

--- a/layouts/partials/blocks/templates/chapter.html
+++ b/layouts/partials/blocks/templates/chapter.html
@@ -30,7 +30,7 @@
             {{ end -}}
           </div>
           {{ if .image }}
-            <figure class="{{- $image_class -}}" {{- with or .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>
+            <figure role="figure" class="{{- $image_class -}}" {{- with or .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>
               {{ if not site.Params.image_sizes.design_system.lightbox.disabled }}
                 <a class="glightbox"
                   role="button"

--- a/layouts/partials/blocks/templates/features.html
+++ b/layouts/partials/blocks/templates/features.html
@@ -27,7 +27,7 @@
                   <p>{{ .description | safeHTML }}</p>
                 </div>
                 {{- if .image -}}
-                  <figure {{- with or .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>
+                  <figure role="figure" {{- with or .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>
                     {{- partial "commons/image.html"
                       (dict
                         "image"    .image

--- a/layouts/partials/blocks/templates/features.html
+++ b/layouts/partials/blocks/templates/features.html
@@ -27,7 +27,7 @@
                   <p>{{ .description | safeHTML }}</p>
                 </div>
                 {{- if .image -}}
-                  <figure>
+                  <figure {{- with or .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>
                     {{- partial "commons/image.html"
                       (dict
                         "image"    .image

--- a/layouts/partials/blocks/templates/gallery/carousel-image.html
+++ b/layouts/partials/blocks/templates/gallery/carousel-image.html
@@ -5,7 +5,7 @@
   {{ if .file }}
     {{- $image := partial "GetMedia" .file -}}
     {{- if $image -}}
-      <figure {{ if $is_carousel }} id="carousel-item-{{$index}}" role="{{$role}}" aria-roledescription="slide" class="carousel__slide" aria-label="item-{{$index}} {{- with or .text .alt .credit }} | {{ . | plainify }} {{- end }}" {{ end }}>
+      <figure role="figure" {{ if $is_carousel }} id="carousel-item-{{$index}}" role="{{$role}}" aria-roledescription="slide" class="carousel__slide" aria-label="item-{{$index}} {{- with or .text .alt .credit }} | {{ . | plainify }} {{- end }}" {{ end }}>
         {{ partial "commons/image.html"
           (dict
             "image"    .id

--- a/layouts/partials/blocks/templates/gallery/carousel-image.html
+++ b/layouts/partials/blocks/templates/gallery/carousel-image.html
@@ -5,7 +5,7 @@
   {{ if .file }}
     {{- $image := partial "GetMedia" .file -}}
     {{- if $image -}}
-      <figure {{ if $is_carousel }} id="carousel-item-{{$index}}" role="{{$role}}" aria-roledescription="slide" class="carousel__slide" aria-label="item-{{$index}}" {{ end }}>
+      <figure {{ if $is_carousel }} id="carousel-item-{{$index}}" role="{{$role}}" aria-roledescription="slide" class="carousel__slide" aria-label="item-{{$index}} {{- with or .text .alt .credit }} | {{ . | plainify }} {{- end }}" {{ end }}>
         {{ partial "commons/image.html"
           (dict
             "image"    .id

--- a/layouts/partials/blocks/templates/gallery/large.html
+++ b/layouts/partials/blocks/templates/gallery/large.html
@@ -4,7 +4,7 @@
       {{- $image := partial "GetMedia" .id -}}
       {{- $image_class := printf "image-%s" (partial "GetImageDirection" .) -}}
       {{- if $image -}}
-        <figure class="{{ $image_class  }}" {{- with or .text .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>
+        <figure role="figure" class="{{ $image_class  }}" {{- with or .text .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>
           {{ partial "commons/image.html"
             (dict
               "image"    .file

--- a/layouts/partials/blocks/templates/gallery/large.html
+++ b/layouts/partials/blocks/templates/gallery/large.html
@@ -4,7 +4,7 @@
       {{- $image := partial "GetMedia" .id -}}
       {{- $image_class := printf "image-%s" (partial "GetImageDirection" .) -}}
       {{- if $image -}}
-        <figure class="{{ $image_class  }}">
+        <figure class="{{ $image_class  }}" {{- with or .text .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>
           {{ partial "commons/image.html"
             (dict
               "image"    .file

--- a/layouts/partials/blocks/templates/image.html
+++ b/layouts/partials/blocks/templates/image.html
@@ -17,7 +17,7 @@
         )}}
 
         {{- with .image -}}
-          <figure class="{{ $image_class }}" {{- with or $text .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>
+          <figure role="figure" class="{{ $image_class }}" {{- with or $text .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>
             {{ if not site.Params.image_sizes.design_system.lightbox.disabled }}
               <a  class="glightbox"
                   role="button"

--- a/layouts/partials/blocks/templates/image.html
+++ b/layouts/partials/blocks/templates/image.html
@@ -17,7 +17,7 @@
         )}}
 
         {{- with .image -}}
-          <figure class="{{ $image_class }}">
+          <figure class="{{ $image_class }}" {{- with or $text .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>
             {{ if not site.Params.image_sizes.design_system.lightbox.disabled }}
               <a  class="glightbox"
                   role="button"

--- a/layouts/partials/blocks/templates/testimonials/single.html
+++ b/layouts/partials/blocks/templates/testimonials/single.html
@@ -1,4 +1,4 @@
-<figure {{- if .is_carousel }} id="carousel-item-{{.index}}" role="{{.role}}" aria-roledescription="slide" class="carousel__slide" aria-label="{{.index}} / {{ .total }}" {{ end }} class="{{ if .is_carousel }}carousel__slide{{ end }} {{ if .params.photo }}with-picture{{ end }}">
+<figure role="figure" {{- if .is_carousel }} id="carousel-item-{{.index}}" role="{{.role}}" aria-roledescription="slide" class="carousel__slide" aria-label="{{.index}} / {{ .total }}" {{ end }} class="{{ if .is_carousel }}carousel__slide{{ end }} {{ if .params.photo }}with-picture{{ end }}">
   {{ with .params }}
     {{ $is_long := gt (len .text) 150 }}
     <blockquote {{- if $is_long }} class="is-long" {{- end }}>

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -1,3 +1,3 @@
-<footer id="document-footer">
+<footer id="document-footer" role="contentinfo">
   {{ partial "footer/footer-simple.html" . }}
 </footer>

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -1,6 +1,6 @@
 {{ $primary := partial "GetMenu" "primary" }}
 
-<header id="document-header">
+<header id="document-header" role="banner">
   <nav aria-label="{{ i18n "commons.menu.main" }}">
     <div class="container">
       {{ partial "header/logo.html" }}

--- a/layouts/partials/programs/image.html
+++ b/layouts/partials/programs/image.html
@@ -1,5 +1,5 @@
 {{ if . }}
-  <figure class="featured-image">
+  <figure role="figure" class="featured-image">
     {{ partial "commons/image.html"
           (dict
             "image"    .


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

On traite ici 2 petits points : 
- Les landmarks (header / footer)
- Les figures : 
   - elles doivent prendre pour aria-label l'élément textuel renseigné dans cet ordre : texte, texte alternatif, crédit
   - elles doivent avoir le `role="figure"`

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

![Capture d’écran 2024-08-27 à 16 37 09](https://github.com/user-attachments/assets/9418f3d7-710f-4fe4-8cec-4fcb4ef27d46)
![Capture d’écran 2024-08-27 à 16 37 29](https://github.com/user-attachments/assets/d14b86b4-5a96-49ff-a3f3-ac7bd685f00e)

## URL de test sur example.osuny.org

- Appels à action
- Chapitre
- Fonctionnalités
- Image
- Galerie : carousel et large