### PR TITLE
[A11Y] Ajout de titres explicites aux liens

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -89,12 +89,18 @@ commons:
   contact:
     address: Address
     email: Email
+    empty_name: of this contact
     phone: Phone
     phone_professional: Professional phone
     website: Website
     web: Web
     schedule: Hours
-    socials: Social Media
+    socials:
+      title: Social Media
+      label: 
+        social_media: See the {{ .name }} page on {{ .media }}
+        email: Contact {{ .name }} by email
+        rss: Read the RSS feed for {{ .name }}
   credit: A low impact website crafted with <a href="https://www.osuny.org/" title="Osuny - external link" target="_blank" rel="noreferrer">Osuny</a>
   date: Date
   download:

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -108,6 +108,7 @@ commons:
     pdf: Télécharger le PDF
   "false": Non
   in: Dans
+  index: Accueil - {{ .Title }}
   language: Langue
   lightbox:
     link:

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -89,12 +89,18 @@ commons:
   contact:
     address: Adresse
     email: Email
+    empty_name: de ce contact
     phone: Téléphone
     phone_professional: Téléphone professionnel
     website: Site web
     web: Web
     schedule: Horaires
-    socials: Réseaux sociaux
+    socials:
+      title: Réseaux sociaux
+      label: 
+        social_media: Consulter la page {{ .name }} sur {{ .media }}
+        email: Contacter {{ .name }} par email
+        rss: Consulter le flux RSS du site {{ .name }}
   credit: Un site éco-conçu produit avec <a href="https://www.osuny.org/" title="Osuny - lien externe" target="_blank" rel="noreferrer">Osuny</a>
   date: Date
   download:

--- a/i18n/pt.yml
+++ b/i18n/pt.yml
@@ -94,7 +94,12 @@ commons:
     website: Site web
     web: Web
     schedule: Horários
-    socials: Redes sociais
+    socials:
+      title: Redes sociais
+      label: 
+        social_media: Ver a página {{ .name }} em {{ .media }}
+        email: Contactar {{ .name }} por correio eletrónico
+        rss: Consultar o feed RSS do sítio {{ .name }}
   credit: Um site eco-responsável produzido com <a href="https://www.osuny.org/" title="Osuny - link externo" target="_blank" rel="noreferrer">Osuny</a>
   date: Data
   download:

--- a/layouts/partials/blocks/templates/contact.html
+++ b/layouts/partials/blocks/templates/contact.html
@@ -74,11 +74,15 @@
                   {{ end }}
                 </div>
               {{ end }}
+              {{ $a11y_name := .name | default (i18n "commons.contact.empty_name") }}
               {{ with .socials }}
                 <div>
-                  <p class="meta">{{- i18n "commons.contact.socials" -}}</p>
+                  <p class="meta">{{- i18n "commons.contact.socials.title" -}}</p>
                   <ul class="socials-list">
-                    {{ partial "commons/socials" . }}
+                    {{ partial "commons/socials" (dict
+                      "context" .
+                      "name" $a11y_name
+                    ) }}
                   </ul>
                 </div>
               {{ end }}

--- a/layouts/partials/blocks/templates/links.html
+++ b/layouts/partials/blocks/templates/links.html
@@ -16,9 +16,15 @@
             <li itemscope itemtype="https://schema.org/WebPage">
               <div class="link-content">
                 {{ $title := partial "PrepareHTML" .title }}
+                {{ $alt_title := "" }}
+                {{ if .alt_title }}
+                  {{ $alt_title = partial "PrepareHTML" .alt_title }}
+                {{ end }}
+                
+                {{ $a11y_title := cond $alt_title $alt_title $title }}
                 {{ $url := .url }}
                 {{ $isExternal := .external | default true }}
-                {{ $link_title := cond $isExternal (safeHTML (i18n "commons.link.blank_aria" (dict "Title" $title))) $title}}
+                {{ $link_title := cond $isExternal (safeHTML (i18n "commons.link.blank_aria" (dict "Title" $a11y_title))) $a11y_title}}
 
                 <link itemprop="url" href="{{ .url }}">
                 <a itemprop="relatedLink" href="{{ .url }}" title="{{ $link_title }}" {{ if $isExternal -}} target="_blank" rel="noopener" {{- end }}>

--- a/layouts/partials/commons/logo.html
+++ b/layouts/partials/commons/logo.html
@@ -8,7 +8,7 @@
   {{ $file_darkmode = $logo.darkmode }}
 {{ end }}
 
-<a class="logo {{- if $file_darkmode }} with-darkmode {{ end -}}" href="{{ site.Home.Permalink }}">
+<a class="logo {{- if $file_darkmode }} with-darkmode {{ end -}}" href="{{ site.Home.Permalink }}" title="{{ i18n "commons.index" (dict "Title" site.Title )}}">
   {{ if $file }}
     {{ $fileDimensions := partial "GetImageDimensions" (dict "context" . "file" $file "static" true) }}
     <img src="{{ $file }}" alt="{{ site.Title }}" height="{{ index $fileDimensions 1 }}" width="{{ index $fileDimensions 0 }}">

--- a/layouts/partials/commons/socials.html
+++ b/layouts/partials/commons/socials.html
@@ -1,60 +1,63 @@
-{{ with .email }}
+{{ $name := .name | default (htmlUnescape site.Title) }}
+{{ $context := .context | default . }}
+
+{{ with $context.email }}
   <li class="email">
-    <a href="mailto:{{ . }}" rel="noreferrer" title="Email" target="_blank">{{ i18n "commons.contact.email" }}</a>
+    <a href="mailto:{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.email" (dict "name" $name )) }}" target="_blank">{{ i18n "commons.contact.email" }}</a>
   </li>
 {{ end}}
-{{ with .rss }}
+{{ with $context.rss }}
   <li class="rss">
-    <a href="{{ . }}" rel="noreferrer" title="RSS" target="_blank">RSS</a>
+    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.rss" (dict "name" $name )) }}" target="_blank">RSS</a>
   </li>
 {{ end}}
-{{ with .mastodon }}
+{{ with $context.mastodon }}
   <li class="mastodon">
-    <a href="{{ . }}" rel="noreferrer" title="Mastodon" target="_blank">Mastodon</a>
+    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Mastodon" "name" $name )) }}" target="_blank">Mastodon</a>
   </li>
 {{ end}}
-{{ with .peertube }}
+{{ with $context.peertube }}
   <li class="peertube">
-    <a href="{{ . }}" rel="noreferrer" title="Peertube" target="_blank">Peertube</a>
+    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Peertub" "name" $name )) }}" target="_blank">Peertube</a>
   </li>
 {{ end}}
-{{ with .github }}
+{{ with $context.github }}
   <li class="github">
-    <a href="{{ . }}" rel="noreferrer" title="Github" target="_blank">GitHub</a>
+    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Github" "name" $name )) }}" target="_blank">GitHub</a>
   </li>
 {{ end}}
-{{ with .linkedin }}
+{{ with $context.linkedin }}
   <li class="linkedin">
-    <a href="{{ . }}" rel="noreferrer" title="LinkedIn" target="_blank">LinkedIn</a>
+    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "LinkedIn" "name" $name )) }}" target="_blank">LinkedIn</a>
   </li>
 {{ end}}
-{{ with .youtube }}
+{{ with $context.youtube }}
   <li class="youtube">
-    <a href="{{ . }}" rel="noreferrer" title="YouTube" target="_blank">YouTube</a>
+    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "YouTube" "name" $name )) }}" target="_blank">YouTube</a>
   </li>
 {{ end}}
-{{ with .vimeo }}
+{{ with $context.vimeo }}
   <li class="vimeo">
-    <a href="{{ . }}" rel="noreferrer" title="Vimeo" target="_blank">Vimeo</a>
+    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Vimeo" "name" $name )) }}" target="_blank">Vimeo</a>
   </li>
 {{ end}}
-{{ with .instagram }}
+{{ with $context.instagram }}
   <li class="instagram">
-    <a href="{{ . }}" rel="noreferrer" title="Instagram" target="_blank">Instagram</a>
+    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Instagram" "name" $name )) }}" target="_blank">Instagram</a>
   </li>
 {{ end}}
-{{ with .facebook }}
+{{ with $context.facebook }}
   <li class="facebook">
-    <a href="{{ . }}" rel="noreferrer" title="" target="_blank">Facebook</a>
+    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Facebook" "name" $name )) }}" target="_blank">Facebook</a>
   </li>
 {{ end}}
-{{ with .tiktok }}
+{{ with $context.tiktok }}
   <li class="tiktok">
-    <a href="{{ . }}" rel="noreferrer" title="TikTok" target="_blank">TikTok</a>
+    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "TikTok" "name" $name )) }}" target="_blank">TikTok</a>
   </li>
 {{ end}}
-{{ with .x }}
+{{ with $context.x }}
   <li class="x">
-    <a href="{{ . }}" rel="noreferrer" title="X, ex-Twitter" target="_blank">X (ex-Twitter)</a>
+    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "X, ex-twitter" "name" $name )) }}" target="_blank">X (ex-Twitter)</a>
   </li>
 {{ end}}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Plusieurs liens (externes ou internes) manquent de précision (voire de title), c'est le cas de ceux : 
- [X] Des logos (footer / header) 

→ j'ai ajouté un i18n `Accueil - {{ .Title }}` comme précisé dans le rapport

- [X] Des liens réseaux sociaux du footer
- [X] Des liens réseaux sociaux du bloc contact

→ Pour ce cas, les 2 listes de rs utilisent le même partial `socials.html`, j'ai donc ajouté en paramètre la variable $name, que j'utilise pour indiquer une traduction valide avec `commons.contact.socials.label.social_media` auquel je dicte à la fois le type de rs (ex: `"media" "Mastodon"`) et le `$name`.
Pour la plupart des réseaux, cela donne : 
- Si on est dans le footer : _Consulter la page Example sur Mastodon_
- Si on est dans contact avec le champ "nom du contact" rempli : _Consulter la page X sur Mastodon_
- Si on est dans contact avec le champ "nom" vide : _Consulter la page de ce contact sur Mastodon_

L'email et le flux rss ont chacun une traduction spécifique car c'est compliqué de trouver une formulation grammaticalement correcte pour inclure ces deux cas, mais je suis preneuse de suggestions !

- [x] Des liens du bloc liens
→ Ajout d'un `alt-title` dans le statique pour compléter au besoin l'information.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

#548

## URL de test sur example.osuny.org

- Accueil pour les logos et les liens rs footer
- Pour les rs contact : [http://localhost:1313/fr/blocks/blocks-techniques/contact/](http://localhost:1313/fr/blocks/blocks-techniques/contact/)
- Pour les liens : http://localhost:1313/fr/blocks/blocks-techniques/liens/

## Screenshots
### Pour les logos : 
![Capture d’écran 2024-08-30 à 11 52 34](https://github.com/user-attachments/assets/1123f45c-dd70-4073-82bc-61ffde0b8c98)

### Pour les réseaux sociaux : 

![Capture d’écran 2024-08-28 à 15 21 49](https://github.com/user-attachments/assets/71b67e8c-79ba-4531-9129-6fbb0591bd3a)
![Capture d’écran 2024-08-28 à 15 20 12](https://github.com/user-attachments/assets/39269a94-2541-45da-9825-1562d876f256)
![Capture d’écran 2024-08-28 à 15 21 14](https://github.com/user-attachments/assets/6802d1cc-1404-4159-bf31-06f7f293a28d)
<img width="918" alt="Capture d’écran 2024-10-03 à 11 49 23" src="https://github.com/user-attachments/assets/ad6d9f5a-4d64-4364-9a87-523eb8b27c5f">