### PR TITLE
[A11Y] Crédit dans le footer

### DIFF
--- a/layouts/partials/footer/credit.html
+++ b/layouts/partials/footer/credit.html
@@ -1,1 +1,1 @@
-<small class="footer-credit">{{ safeHTML (i18n "commons.credit") }}</small>
+<p class="footer-credit">{{ safeHTML (i18n "commons.credit") }}</p>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

On doit ajouter une balise sémantique à la place de `<small>`.
J'ai remplacé le small par un `<p>`.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/575

## Screenshots
avant : 
![Capture d’écran 2024-09-06 à 16 09 15](https://github.com/user-attachments/assets/1b3ac101-5446-4327-a92a-2dd05db3009e)

après : 
![Capture d’écran 2024-09-06 à 16 09 24](https://github.com/user-attachments/assets/94ca14a2-39d8-4780-b2c2-f4af6ff5cee5)


