### PR TITLE
Ajustement des layouts du bloc de formations

### DIFF
--- a/assets/sass/_theme/blocks/programs.sass
+++ b/assets/sass/_theme/blocks/programs.sass
@@ -1,67 +1,89 @@
 .block-programs
-    article
-        position: relative
+    .program
+        display: flex
+        &-diploma
+            @include meta
+            display: block
+            margin-bottom: $spacing-1
+            margin-top: $spacing-1
+        .media img
+            aspect-ratio: $block-programs-aspect-ratio
+            display: block
+            object-fit: cover
+        @include media-breakpoint-up(desktop)
+            &-content
+                align-items: baseline
+                display: flex
     &--list
-        .programs
-            li
-                align-items: start
-                gap: var(--grid-gutter)
-                .program-diploma
-                    @include meta
-                    display: block
-                    margin-bottom: $spacing-1
-                a
-                    @include h3
-                    @include hover-translate-icon($fade: true)
-                    @include icon(arrow-right-line, after, true)
-                        display: inline
-                    transition: color 0.55s
-                    padding-right: $spacing-4
-                    &:hover
-                        color: var(--color-accent)
-                @include media-breakpoint-down(desktop)
+        .program
+            align-items: start
+            .program-title a
+                @include hover-translate-icon($fade: true)
+                @include icon(arrow-right-line, after, true)
+                    display: inline
+                transition: color 0.55s
+                &:hover
+                    color: var(--color-accent)
+            @include media-breakpoint-down(desktop)
+                flex-direction: column-reverse
+                gap: $spacing-2
+                .program-title a
+                    align-items: baseline
                     display: flex
-                    flex-direction: column-reverse
-                    gap: $spacing-2
-                @include media-breakpoint-up(desktop)
-                    .program-content
-                        max-width: columns(9)
-                    .media
-                        flex-shrink: 0
-                        width: columns(2)
-
+                    &::after
+                        opacity: 1
+            @include media-breakpoint-up(desktop)
+                flex-direction: row-reverse
+                .program-content
+                    flex: 1
+                    flex-wrap: wrap
+                    .program-title
+                        flex: 1
+                    .program-title,
+                    [itemprop="abstract"]
+                        min-width: columns(6)
+                    .program-diploma
+                        width: var(--grid-gutter)
+                        text-align: center
+                .media
+                    flex-shrink: 0
+                    margin-bottom: 0
+                    width: columns(2)
+        @include in-page-with-sidebar
+            .program-diploma + [itemprop="abstract"]
+                padding-right: var(--grid-gutter)
+                width: 100%
         @include in-page-without-sidebar
-            .programs li a
+            .program-title
                 @include h2
-
+            [itemprop="abstract"]
+                width: columns(9)
+            .program-diploma
+                margin-left: offset(1)
     &--grid
         .programs-grid
             align-items: start
             @include grid(1, false, $spacing-5)
             @include grid(2, xl)
-            article
-                display: flex
+            .program
                 flex-direction: column
                 .program-content
-                    order: 2
-                    &:hover
-                        .more:after
-                            transform: translateX($spacing-1)
-                [itemprop='name']
-                    margin-bottom: $spacing-1
-                a
-                    @include stretched-link
-                    text-decoration: none
-                .more
-                    @include icon(arrow-right-line, after, true)
-                    @include hover-translate-icon
+                    flex-direction: column
+                    &:hover .more:after
+                        transform: translateX($spacing-1)
+                    .program-title
+                        margin-bottom: $spacing-1
+                        order: -1
+                    .program-diploma
+                        order: 0
+                    [itemprop='abstract'],
+                    .more
+                        order: 2
+                    .more
+                        @include icon(arrow-right-line, after, true)
+                        @include hover-translate-icon
                 .media
-                    order: 1
                     margin-bottom: $spacing-3
-                    img
-                        aspect-ratio: $block-programs-aspect-ratio
-                        display: block
-                        object-fit: cover
             @include in-page-without-sidebar
                 @include grid(2)
                 @include grid(3, xl)

--- a/assets/sass/_theme/utils/shame.sass
+++ b/assets/sass/_theme/utils/shame.sass
@@ -59,7 +59,7 @@
 @mixin article-title
     @include h3
     a
-        @include stretched-link
+        @include stretched-link(before)
         display: block
         text-decoration: none
 

--- a/layouts/partials/blocks/templates/programs.html
+++ b/layouts/partials/blocks/templates/programs.html
@@ -2,7 +2,7 @@
 {{ $block_class := partial "GetBlockClass" .block }}
 {{ $heading := .heading | default "h3" }}
 {{ $heading_tag := (dict 
-    "open" ((printf "<%s itemprop='name'>" $heading) | safeHTML)
+    "open" ((printf "<%s class='program-title' itemprop='name'>" $heading) | safeHTML)
     "close" ((printf "</%s>" $heading) | safeHTML)
     ) }}
 
@@ -18,12 +18,11 @@
         )}}
 
         {{ if eq $block.data.layout "grid" }}
-
           <div class="programs-grid">
             {{ range .programs }}
               {{ $program := site.GetPage (printf "/programs%s" .path) }}
               {{ $title := $program.Title | safeHTML }}
-              <article itemscope itemtype="https://schema.org/EducationalOccupationalProgram">
+              <article class="program" itemscope itemtype="https://schema.org/EducationalOccupationalProgram">
                 <div class="program-content">
                   {{ $heading_tag.open }}
                     <a href="{{ $program.Permalink }}" itemtype="url" title="{{ safeHTML (i18n "commons.more_aria" (dict "Title" $title)) }}">
@@ -38,6 +37,14 @@
                   {{ end }}
 
                   <p class="more meta" aria-hidden="true">{{ i18n "commons.more" }}</p>
+
+                  {{ $diploma := $program.Params.diplomas }}
+                  {{ if and $options.diploma $diploma }}
+                    {{- $diploma = site.GetPage (printf "/diplomas/%s" $diploma) -}}
+                    {{- with $diploma -}}
+                      <span class="program-diploma">{{ partial "PrepareHTML" .Params.short_name }}</span>
+                    {{- end -}}
+                  {{ end }}
                 </div>
 
                 {{ if and $program.Params.image $options.image }}
@@ -58,13 +65,15 @@
 
           <ol class="programs">
             {{ range .programs }}
-              <li>
+              <li class="program">
                 {{ $program := site.GetPage (printf "/programs%s" .path) }}
                 <div class="program-content">
                   {{ $title := partial "PrepareHTML" $program.Title }}
-                  <a href="{{ $program.Permalink }}" title="{{ safeHTML (i18n "commons.more_aria" (dict "Title" $title)) }}">
-                    {{- $title -}}
-                  </a>
+                  {{ $heading_tag.open }}
+                    <a href="{{ $program.Permalink }}" itemtype="url" title="{{ safeHTML (i18n "commons.more_aria" (dict "Title" $title)) }}">
+                      {{ $title }}
+                    </a>
+                  {{ $heading_tag.close }}
 
                   {{ $diploma := $program.Params.diplomas }}
                   {{ if and $options.diploma $diploma }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Mise en conformité avec les maquettes figma des layouts du bloc de liste des formations : 
- Liste : beaucoup d'ajustements, on joue sur le flex pour garder le diplome dans notre `.program-content` car l'enlever nous embêterait pour le mobile.
- Grid : seul ajout du diplome

**NB :** J'ai passé le stretched-link en `::before`dans le mixin `article`parce que ça me semble moins dangereux, comme on peut avoir un `::after` comme ici avec une icône.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/589

## URL de test sur example.osuny.org

http://localhost:1313/fr/blocks/blocs-de-liste/programmes/

## URL de test du site (optionnel)

[http://localhost:1314/entreprise/nous-accompagner/taxe-apprentissage/](http://localhost:1314/entreprise/nous-accompagner/taxe-apprentissage/)

## Screenshots

## Avec images : 
![Capture d’écran 2024-09-11 à 10 39 31](https://github.com/user-attachments/assets/497e04ac-4eb3-429b-91e5-a54b76a205a0)
![Capture d’écran 2024-09-11 à 10 39 40](https://github.com/user-attachments/assets/77f9a017-83dd-412c-98aa-b9ae9561d2b1)

## Avec résumé + diplôme
![Capture d’écran 2024-09-11 à 10 39 56](https://github.com/user-attachments/assets/a172f5b0-23f9-46b5-ace6-6bc585b17365)
![Capture d’écran 2024-09-11 à 10 39 21](https://github.com/user-attachments/assets/25a404ad-ca95-4c52-b846-7799e900ec33)

## Résumé seul
![Capture d’écran 2024-09-11 à 10 39 14](https://github.com/user-attachments/assets/69a21bbc-f69b-4489-b171-873ebce3aac7)
![Capture d’écran 2024-09-11 à 10 40 10](https://github.com/user-attachments/assets/b13ce956-d296-42f7-b728-dd23f9f73460)

## Diplôme seul
![Capture d’écran 2024-09-11 à 11 01 50](https://github.com/user-attachments/assets/8bb8a8fc-881e-47ab-9366-eda594069f6f)

## Grid
![Capture d’écran 2024-09-11 à 11 01 15](https://github.com/user-attachments/assets/febc8c40-a44c-46c8-bca3-c51c05ef3d46)

## IUT de Bordeaux
![Capture d’écran 2024-09-11 à 11 06 40](https://github.com/user-attachments/assets/78828f81-0698-4da9-90ae-2c3872777b7d)
![Capture d’écran 2024-09-11 à 11 07 01](https://github.com/user-attachments/assets/5a0c63bd-f618-4fc1-9dc5-64d95270ab29)
![Capture d’écran 2024-09-11 à 11 07 09](https://github.com/user-attachments/assets/d26a8a88-65d3-4dd4-afd0-b2920233db70)

