### PR TITLE
[A11Y] Mise en conformité de l'élément <details>

### DIFF
--- a/assets/js/theme/design-system/accordion.js
+++ b/assets/js/theme/design-system/accordion.js
@@ -23,7 +23,7 @@ Accordion.prototype.toggleAccordion = function(open) {
     }
     this.state.isOpened = open;
     this.button.setAttribute('aria-expanded', this.state.isOpened);
-    };
+};
 
 (function () {
     var accordions = document.querySelectorAll('details');

--- a/assets/js/theme/design-system/accordion.js
+++ b/assets/js/theme/design-system/accordion.js
@@ -27,9 +27,7 @@ Accordion.prototype.toggleAccordion = function(open) {
 
 (function () {
     var accordions = document.querySelectorAll('details');
-    console.log(accordions)
     Array.prototype.forEach.call(accordions, function(accordion) {
-        console.log(accordion)
         new Accordion(accordion);
     });
 }());

--- a/assets/js/theme/design-system/accordion.js
+++ b/assets/js/theme/design-system/accordion.js
@@ -1,0 +1,35 @@
+function Accordion(element) {
+    this.element = element;
+    this.button = this.element.querySelector('summary');
+
+    this.state = {
+        isOpened: false
+    };
+
+    this.listen();
+}
+
+Accordion.prototype.listen = function() {
+    var self = this;
+
+    this.button.addEventListener('click', function() {
+        self.toggleAccordion();
+    });
+};
+
+Accordion.prototype.toggleAccordion = function(open) {
+    if (typeof open === 'undefined') {
+        open = !this.state.isOpened;
+    }
+    this.state.isOpened = open;
+    this.button.setAttribute('aria-expanded', this.state.isOpened);
+    };
+
+(function () {
+    var accordions = document.querySelectorAll('details');
+    console.log(accordions)
+    Array.prototype.forEach.call(accordions, function(accordion) {
+        console.log(accordion)
+        new Accordion(accordion);
+    });
+}());

--- a/assets/js/theme/index.js
+++ b/assets/js/theme/index.js
@@ -15,3 +15,4 @@ import './blocks/videos.js';
 import './blocks/campus.js';
 import './utils/utils.js';
 import './components/carousel.js';
+import './design-system/accordion.js';

--- a/assets/js/theme/index.js
+++ b/assets/js/theme/index.js
@@ -1,4 +1,5 @@
 import './body.js';
+import './design-system/accordion.js';
 import './design-system/clickToCopy';
 import './design-system/dropdowns';
 import './design-system/font';
@@ -15,4 +16,3 @@ import './blocks/videos.js';
 import './blocks/campus.js';
 import './utils/utils.js';
 import './components/carousel.js';
-import './design-system/accordion.js';

--- a/layouts/partials/blocks/templates/definitions.html
+++ b/layouts/partials/blocks/templates/definitions.html
@@ -12,8 +12,8 @@
         )}}
         <div class="definitions">
           {{- range .elements }}
-            <details itemscope itemtype="https://schema.org/DefinedTerm">
-              <summary itemprop="name">{{ .title | safeHTML }}</summary>
+            <details id="TODO" itemscope itemtype="https://schema.org/DefinedTerm">
+              <summary itemprop="name" aria-controls="#TODO" aria-expanded="false">{{ .title | safeHTML }}</summary>
               <p itemprop="description">{{ .description | safeHTML }}</p>
             </details>
           {{ end -}}

--- a/layouts/partials/blocks/templates/definitions.html
+++ b/layouts/partials/blocks/templates/definitions.html
@@ -1,7 +1,9 @@
 {{- $block := .block -}}
 {{- $block_class := partial "GetBlockClass" .block -}}
+{{- $block_index := .index -}}
 
 {{- with .block.data -}}
+  {{ .Params.position }}
   <div class="{{ $block_class }}">
     <div class="container">
       <div class="block-content">
@@ -11,10 +13,11 @@
           "description" .description
         )}}
         <div class="definitions">
-          {{- range .elements }}
-            <details id="TODO" itemscope itemtype="https://schema.org/DefinedTerm">
-              <summary itemprop="name" aria-controls="#TODO" aria-expanded="false">{{ .title | safeHTML }}</summary>
-              <p itemprop="description">{{ .description | safeHTML }}</p>
+          {{- range $index, $element := .elements }}
+            {{ $id := printf "block-%d-element-%d" $block_index $index}}
+            <details id="{{$id}}" itemscope itemtype="https://schema.org/DefinedTerm">
+              <summary itemprop="name" aria-controls="#{{ $id }}" aria-expanded="false">{{ $element.title | safeHTML }}</summary>
+              <p itemprop="description">{{ $element.description | safeHTML }}</p>
             </details>
           {{ end -}}
         </div>

--- a/layouts/partials/blocks/templates/definitions.html
+++ b/layouts/partials/blocks/templates/definitions.html
@@ -14,7 +14,7 @@
         )}}
         <div class="definitions">
           {{- range $index, $element := .elements }}
-            {{ $id := printf "block-%d-element-%d" $block_index $index}}
+            {{ $id := printf "block-%d-element-%d" $block_index $index }}
             <details id="{{$id}}" itemscope itemtype="https://schema.org/DefinedTerm">
               <summary itemprop="name" aria-controls="#{{ $id }}" aria-expanded="false">{{ $element.title | safeHTML }}</summary>
               <p itemprop="description">{{ $element.description | safeHTML }}</p>

--- a/layouts/partials/blocks/templates/embed.html
+++ b/layouts/partials/blocks/templates/embed.html
@@ -1,5 +1,6 @@
 {{- $block := .block -}}
 {{- $block_class := partial "GetBlockClass" .block -}}
+{{- $block_index := .index -}}
 
 {{- with .block.data -}}
   <div class="{{ $block_class }}">
@@ -15,6 +16,7 @@
         {{ end -}}
 
         {{ partial "commons/transcription" ( dict
+            "block_index" $block_index
             "transcription" .transcription
           ) }}
       </div>

--- a/layouts/partials/blocks/templates/sound.html
+++ b/layouts/partials/blocks/templates/sound.html
@@ -1,5 +1,6 @@
 {{- $block := .block -}}
 {{- $block_class := partial "GetBlockClass" .block -}}
+{{- $block_index := .index -}}
 
 {{- with .block.data -}}
   <div class="{{ $block_class }}">
@@ -23,6 +24,7 @@
           {{ end }}
 
           {{ partial "commons/transcription" ( dict
+            "block_index" $block_index
             "transcription" .transcription
           ) }}
         </div>

--- a/layouts/partials/blocks/templates/video.html
+++ b/layouts/partials/blocks/templates/video.html
@@ -1,5 +1,6 @@
 {{- $block := .block -}}
 {{- $block_class := partial "GetBlockClass" .block -}}
+{{- $block_index := .index -}}
 
 {{- with .block.data -}}
   <div class="{{ $block_class }}">
@@ -31,6 +32,7 @@
         {{ end }}
 
         {{ partial "commons/transcription" ( dict
+          "block_index" $block_index
           "transcription" .transcription
         ) }}
       </div>

--- a/layouts/partials/commons/transcription.html
+++ b/layouts/partials/commons/transcription.html
@@ -1,7 +1,10 @@
 {{ if (partial "GetTextFromHTML" .transcription) }}
+{{ $block_index := .block_index }}
+{{ $id := printf "block-%d-transcription" $block_index}}
+
 <div class="transcription">
-  <details>
-    <summary>{{ i18n "commons.accessibility.transcription" }}</summary>
+  <details id="{{$id}}">
+    <summary aria-controls="#{{ $id }}" aria-expanded="false">{{ i18n "commons.accessibility.transcription" }}</summary>
     <p>
       {{- $transcription := partial "PrepareHTML" .transcription -}}
       {{ safeHTML (replace $transcription "\n" "<br/>") }}

--- a/layouts/partials/contents/list.html
+++ b/layouts/partials/contents/list.html
@@ -1,12 +1,13 @@
 {{ $context := . }}
 {{- if .Params.contents -}}
   <div class="blocks">
-  {{- range .Params.contents -}}
+  {{- range $index, $content := .Params.contents -}}
     {{ if eq .kind "block" }}
-      {{ $template := printf "blocks/templates/%s.html" .template }}
+      {{ $template := printf "blocks/templates/%s.html" $content.template }}
       {{ partial $template (dict
-          "block" .
+          "block" $content
           "context" $context
+          "index" $index
       )}}
     {{- else if (eq .kind "heading") -}}
       {{ $headingId := .slug | default (urlize .title) }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

L'élément `<details`> natif n'est visiblement pas conforme à l'accessiblité sur tous les navgiteurs et avec toutes les TA. On doit donc ajouter une légère surcouche javascript.

- [x] Ajustement du HTML : on ajoute des attributs aria qui aident les TA → besoin d'un ID pour le `aria-controls`
- [X] Ajout d'un javascript "accordion" que j'ai mis dans le design système et non dans les blocs au cas où on en ai le besoin plus tard (j'ai essayé de faire de l'ES5 !)

Utilisé dans : 

- [x] Son
- [x] Embed
- [x] Vidéo
- [x] Définition

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/602

## URL de test sur example.osuny.org

http://localhost:1313/fr/blocks/blocks-techniques/definitions/

## Screenshots
![Capture d’écran 2024-10-03 à 12 16 43](https://github.com/user-attachments/assets/0adaa87c-0063-4182-ba82-b10ac7bf821f)
![Capture d’écran 2024-10-03 à 12 12 03](https://github.com/user-attachments/assets/130edae2-08c5-4909-a88f-e5ed1e9cad52)