### PR TITLE
Réparation du partial GetTruncateContent

### DIFF
--- a/layouts/partials/GetTruncateContent
+++ b/layouts/partials/GetTruncateContent
@@ -1,4 +1,4 @@
-{{ $length := .length | default 150 }}
+{{ $length := cond (eq .length 0) 0 (default 150 .length) }}
 {{ $text := .text }}
 
 {{ if gt $length 0 }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

On s'est rendu compte que la configuration `truncate_description: 0` ne fonctionnait pas. 

Cela vient du fait que nous avons dans notre partial cette manière de récupérer la donnée : `{{ $length := .length | default 150 }}`. En fait, 0 est interprêté par `default` comme une valeur nulle ! Il passe donc automatiquement à 150.

J'ai essayé avec `or`, mais cela fonctionne de la même façon. 

J'ai donc opté pour [cond](https://gohugo.io/functions/compare/conditional/), qu'on utilise à quelques endroits : `{{ $length := cond (eq .length 0) 0 (default 150 .length) }}`
- Si le premier argument est vrai (`.length` = 0), alors ça retourne 0
- Sinon elle retourne le dernier, et c'est à cet endroit qu'on donne le `default` si .length n'est pas défini

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test du site (optionnel)

IUT Bordeaux montaigne (accueil)
Mais n'importe quel site avec des blocs pages/actus, etc.

## Screenshots

1) Sans préciser de taille (défault 150)
![Capture d’écran 2024-09-16 à 15 03 10](https://github.com/user-attachments/assets/5811d6e6-b0a4-4838-ac8b-c256d4f9c7c7)

2) On précise une taille de 14 pour tester en config
![Capture d’écran 2024-09-16 à 15 02 52](https://github.com/user-attachments/assets/2a73c53a-ccc6-4cd2-8256-437fe4f2144e)

3) 0 en config
![Capture d’écran 2024-09-16 à 15 02 40](https://github.com/user-attachments/assets/2b0a0be4-26b1-49a5-96d8-06152c03edf9)