### PR TITLE
Ajout du rôle indiqué dans le bloc au partial "person"

### DIFF
--- a/layouts/partials/blocks/templates/persons.html
+++ b/layouts/partials/blocks/templates/persons.html
@@ -9,10 +9,9 @@
   {{ $options := .options }}
   {{ range .persons }}
     {{- $person := site.GetPage (printf "/persons/%s" .slug) -}}
+    {{- $role := .role -}}
     {{- $summary := $person.Params.summary -}}
     {{- $content := $person.Content -}}
-    {{- $role := .role -}}
-
     {{ with (or $role $summary $content)}}
       {{- $contentLength := len . -}}
       {{ if ge $contentLength $charLimit }}
@@ -37,6 +36,7 @@
               "heading_level" $block.ranks.children
               "options" $options
               "person" $person
+              "role" .role
             ) }}
           {{- end -}}
         </div>

--- a/layouts/partials/persons/person.html
+++ b/layouts/partials/persons/person.html
@@ -5,6 +5,7 @@
   "close" ((printf "</h%d>" $heading) | safeHTML)
 ) }}
 {{ $person := .person }}
+{{ $role := .role }}
 
 <article class="person" itemscope itemtype="https://schema.org/Person">
   <div class="description">
@@ -17,10 +18,10 @@
         </a>
       {{ end }}
     {{ $heading_tag.close }}
-    {{ if and $options.summary (or $person.Params.summary $person.Params.summary) }}
+    {{ if and $options.summary (or $role $person.Params.summary) }}
       <p itemprop="jobTitle">
-        {{ if (partial "GetTextFromHTML" .role) }}
-          {{ partial "PrepareHTML" .role }}
+        {{ if (partial "GetTextFromHTML" $role) }}
+          {{ partial "PrepareHTML" $role }}
         {{ else if partial "GetTextFromHTML" $person.Params.summary }}
           {{ partial "PrepareHTML" $person.Params.summary }}
         {{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Les données renseignées dans le bloc personne n'apparaissent plus : 
![Capture d’écran 2024-09-16 à 17 23 17](https://github.com/user-attachments/assets/e6f2f07f-1279-4d6e-ac29-f7ab06f5dbea)

On n'envoyait en réalité _jamais_ la donnée du `.role` dans le component `persons/person.html` qui sert à lister les personnes. Je l'ai ajouté au partial appelé dans le bloc et cela fonctionne à nouveau correctement. Les options avaient aussi un souci.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

http://localhost:1314/fr/blocks/blocs-de-liste/organigramme

## URL de test du site

https://www.communication-democratie.org/fr/l-association/organes-et-fonctionnement/#membres-du-conseil-d-administration-2023-2024

## Screenshots
![Capture d’écran 2024-09-16 à 17 20 18](https://github.com/user-attachments/assets/3e5d276a-814a-4cbf-859a-dbfbaae92ab0)