### PR TITLE
Block call to action - ajout du logo copyright dans les crédits

### DIFF
--- a/assets/sass/_theme/blocks/call_to_action.sass
+++ b/assets/sass/_theme/blocks/call_to_action.sass
@@ -45,6 +45,9 @@
         figure
             figcaption
                 @include meta
+                p::before
+                    content: '©'
+                    margin-right: $spacing-1
         * + .actions
             margin-top: $spacing-3
         img


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description
Ajout en sass du logo copyright avant le credit ( comme fait dans le cas des figures de hero)

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots

<img width="708" alt="image" src="https://github.com/user-attachments/assets/48cdfe4b-0818-4665-bc90-508659326565">

