### PR TITLE
Ajout d'un niveau de taille des images du block key figures 

### DIFF
--- a/assets/sass/_theme/blocks/key_figures.sass
+++ b/assets/sass/_theme/blocks/key_figures.sass
@@ -38,6 +38,8 @@
                 font-size: $block-key_figures-font-size-desktop
                 strong
                     font-size: $block-key_figures-number-font-size-desktop
+                img
+                    max-width: $block-key_figures-image-max-width-desktop
             @include media-breakpoint-up(lg)
                 font-size: $block-key_figures-font-size-lg
                 strong

--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -86,7 +86,8 @@ $block-testimonials-pagination-progress-background: var(--color-accent) !default
 $block-key_figures-number-font-family: $heading-font-family !default
 $block-key_figures-unit-font-weight: normal !default
 $block-key_figures-number-font-weight: bold !default
-$block-key_figures-image-max-width: $spacing-6 !default
+$block-key_figures-image-max-width-desktop: $spacing-6 !default
+$block-key_figures-image-max-width: $spacing-4 !default
 $block-key_figures-icon-max-width: pxToRem(60) !default
 
 $block-key_figures-font-size: pxToRem(16) !default

--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -86,8 +86,8 @@ $block-testimonials-pagination-progress-background: var(--color-accent) !default
 $block-key_figures-number-font-family: $heading-font-family !default
 $block-key_figures-unit-font-weight: normal !default
 $block-key_figures-number-font-weight: bold !default
-$block-key_figures-image-max-width-desktop: $spacing-6 !default
-$block-key_figures-image-max-width: $spacing-4 !default
+$block-key_figures-image-max-width-desktop: pxToRem(128) !default
+$block-key_figures-image-max-width: pxToRem(48) !default
 $block-key_figures-icon-max-width: pxToRem(60) !default
 
 $block-key_figures-font-size: pxToRem(16) !default


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Ajout d'un niveau de taille des images du block key figures 

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots
<img width="321" alt="image" src="https://github.com/user-attachments/assets/22983448-8178-4e43-8e83-356cd1e1ed1f">
<img width="772" alt="image" src="https://github.com/user-attachments/assets/b23a24ce-2a01-47be-998c-a195bc84e790">


