### PR TITLE
Ajustement des rôles administratifs, d'enseignement, etc dans la page d'une personne

### DIFF
--- a/assets/sass/_theme/sections/persons.sass
+++ b/assets/sass/_theme/sections/persons.sass
@@ -211,7 +211,9 @@ ol.persons--list
         .informations
             @include grid
             margin-bottom: $spacing-4
-            > div:first-of-type
+            .roles
+                grid-column: 1 / -1
+            .biography
                 grid-column: 1 / 9
                 + .roles
                     grid-column: 9 / 13

--- a/assets/sass/_theme/sections/persons.sass
+++ b/assets/sass/_theme/sections/persons.sass
@@ -213,9 +213,9 @@ ol.persons--list
             margin-bottom: $spacing-4
             > div:first-of-type
                 grid-column: 1 / 9
-            .roles
-                grid-column: 9 / 13
-                text-align: right
+                + .roles
+                    grid-column: 9 / 13
+                    text-align: right
             .lead + div
                 margin-top: $spacing-4
     .contacts-details ul

--- a/layouts/persons/single.html
+++ b/layouts/persons/single.html
@@ -43,7 +43,7 @@
 
       <div class="informations">
         {{ if .Content }}
-          <div>
+          <div class="biography">
             {{ partial "persons/summary.html" (dict
               "context" .
             ) }}
@@ -54,16 +54,18 @@
             {{ end }}
           </div>
         {{ end }}
-        {{ range $programsForAdministrator }}
-        {{ $program := . }}
+        {{ if $programsForAdministrator }}
           <div class="roles">
-            {{ range .Params.roles }}
-              {{ $role := .title }}
-              {{ if in .persons $slug }}
-                <p>
-                  {{ safeHTML $role }}<br>
-                  <a href="{{ $program.Permalink }}" class="link">{{ safeHTML $program.Title }}</a>
-                </p>
+            {{ range $programsForAdministrator }}
+            {{ $program := . }}
+              {{ range .Params.roles }}
+                {{ $role := .title }}
+                {{ if in .persons $slug }}
+                  <p>
+                    {{ safeHTML $role }}<br>
+                    <a href="{{ $program.Permalink }}" class="link">{{ safeHTML $program.Title }}</a>
+                  </p>
+                {{ end }}
               {{ end }}
             {{ end }}
           </div>

--- a/layouts/persons/single.html
+++ b/layouts/persons/single.html
@@ -42,16 +42,18 @@
       {{ end }}
 
       <div class="informations">
-        <div>
-          {{ partial "persons/summary.html" (dict
-            "context" .
-          ) }}
-          {{ if (partial "GetTextFromHTML" .Content) }}
-            <div class="rich-text">
-              {{ partial "PrepareHTML" .Content }}
-            </div>
-          {{ end }}
-        </div>
+        {{ if .Content }}
+          <div>
+            {{ partial "persons/summary.html" (dict
+              "context" .
+            ) }}
+            {{ if (partial "GetTextFromHTML" .Content) }}
+              <div class="rich-text">
+                {{ partial "PrepareHTML" .Content }}
+              </div>
+            {{ end }}
+          </div>
+        {{ end }}
         {{ range $programsForAdministrator }}
         {{ $program := . }}
           <div class="roles">


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

En l'absence de biographie, mais avec des rôles administratifs, les rôles s'affichent à droite et on a un blanc important : 

![Capture d’écran 2024-09-19 à 10 29 27](https://github.com/user-attachments/assets/298fe7f3-b40b-4606-80d3-f3c181b2e12b)
![Capture d’écran 2024-09-19 à 10 25 38](https://github.com/user-attachments/assets/c7b00065-1027-4991-b1a1-632d3509785f)

J'en ai profité pour noter un autre bug : si Marlène avait eu effectivement une biographie, le 2e rôle passait à la ligne suivante de la grille

![Capture d’écran 2024-09-19 à 10 45 12](https://github.com/user-attachments/assets/06450fcf-8a1c-4275-a919-b81692d9234f)

- J'ai ajouté une class à la div qu'on ciblait de façon un peu risquée (`.biography`)
- J'ai mis tous les rôles (qui sont des `p`) à l'intérieur de `.roles`
- J'ai ajouté un sélecteur qui active l'alignement à droite de `.roles` en cas de présence de `.biography`

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

http://localhost:1313/fr/equipe/arnaud-levy/

## URL de test du [IUT Bordeaux Montaigne](https://github.com/osunyorg/bordeauxmontaigne-iut)

http://localhost:1314/notre-institut/ressources/equipe/marlene-dulaurans/

## Screenshots

![Capture d’écran 2024-09-19 à 10 47 34](https://github.com/user-attachments/assets/e4bce103-83dc-4bd8-80c9-6aed3e35ec07)
![Capture d’écran 2024-09-19 à 10 50 06](https://github.com/user-attachments/assets/bef40d06-6e2c-4f1a-8d01-8f39b81f30ef)
