### PR TITLE
Fix temporaire du problème de padding

### DIFF
--- a/assets/sass/_theme/utils/shame.sass
+++ b/assets/sass/_theme/utils/shame.sass
@@ -18,6 +18,12 @@
             &::before
                 content: ' • '
 
+
+// Fix de la suppression du padding dans les pages index ( progra, location ) des lors que le main prend la class page-with-blocks
+.programs__section main,
+.locations__taxonomy main
+    padding-bottom: var(--spacing-5)
+
 // Utilisé pour .post, .project, .page, .person, .program, .volume
 @mixin article($aspect-ratio: $article-media-aspect-ratio)
     position: relative


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description
Voir issue #617  

Le padding bottom du main est géré de cette manière 
```
main {
    &:not(.page-with-blocks, .page-with-map) {
        padding-bottom: $spacing-5; } }
```

Sauf que parfois les blocks ne sont pas positionnés à la fin du contenu.
Quand ils sont positionnés avant, comme c'est le cas pour l'index des formations et l'index des campus(locations)  le main prend la class "page-with-blocks" qui supprime le padding bottom.

Fix temporaire donc car il faudrait affiner l'ajout de cette classe en fonction de la position des blocks ( en fin de course ou non) 

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


