### PR TITLE
Inversion de couleur du logo du menu à l'ouverture

### DIFF
--- a/assets/sass/_theme/design-system/header.sass
+++ b/assets/sass/_theme/design-system/header.sass
@@ -23,6 +23,10 @@ header#document-header
             a:active,
             span
                 color: inherit
+        @if $header-sticky-invert-logo
+            .logo
+                img, .logo-text
+                    filter: invert(1)
         @include media-breakpoint-up(desktop)
             .dropdown-menu
                 background: $header-sticky-dropdown-background
@@ -30,10 +34,6 @@ header#document-header
     &.is-sticky
         .pagefind-ui__toggle
             color: $header-sticky-color
-        @if $header-sticky-invert-logo
-            .logo
-                img, .logo-text
-                    filter: invert(1)
     html.is-scrolling-down:not(.has-menu-opened) &
         @include media-breakpoint-down(desktop)
             transform: translateY(-100%)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Le logo ne s'inverse plus à l'ouverture du menu

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots

Avant : 

![image](https://github.com/user-attachments/assets/fef45cd8-5aaf-4b4d-a809-3e37ebdb49c1)


Après : 

![image](https://github.com/user-attachments/assets/35652239-7d94-4327-aa77-3cc53d0f0b09)

