### PR TITLE
Correction des listes de programmes d'un campus

### DIFF
--- a/layouts/partials/locations/diplomas.html
+++ b/layouts/partials/locations/diplomas.html
@@ -1,21 +1,17 @@
-{{/*  Get programs associated to location  */}}
-{{ $programs := .programs }}
 <ul class="diplomas">
 {{ range .diplomas }}
-  {{ $path := .path }}
-  {{ with site.GetPage (printf "/diplomas/%s" .path) }}
+  {{ $diploma := site.GetPage (printf "/diplomas/%s" .path) }}
+  {{ if $diploma }}
     <li>
-      <a href="{{ .Permalink }}" aria-label="{{ i18n "commons.more_aria" (dict "Title" .Title) }}">
-        {{- partial "PrepareHTML" .Title -}}
+      <a href="{{ $diploma.Permalink }}" aria-label="{{ i18n "commons.more_aria" (dict "Title" $diploma.Title) }}">
+        {{- partial "PrepareHTML" $diploma.Title -}}
       </a>
-      {{ if $programs }}
+      {{ with .programs }}
         <div class="content">
           <ol class="programs">
-            {{- range $programs -}}
-              {{ $program := site.GetPage (printf "/programs%s" .) }}
-              {{ if (eq $path $program.Params.diplomas)}}
-                {{- partial "partials/locations/program.html" $program.Params -}}
-              {{ end }}
+            {{- range . -}}
+              {{ $program := site.GetPage (printf "/programs%s" .slug) }}
+              {{- partial "partials/locations/program.html" $program.Params -}}
             {{- end -}}
           </ol>
         </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Les campus n'affichaient plus les listes de programmes.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots

Avant : 

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/6b63c404-b862-4f71-b31a-3451814ea932">

Après : 

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/b181ab8d-a129-4dd9-b955-bd29d0b62ac9">

