### PR TITLE
Ajustement des descriptions des personnes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -109,7 +109,6 @@ params:
         link: true
     single:
       backlinks: false
-      truncate_description: 200
   posts:
     default_image: false
     date_format: ":date_long"

--- a/layouts/partials/blocks/templates/persons.html
+++ b/layouts/partials/blocks/templates/persons.html
@@ -37,7 +37,6 @@
               "options" $options
               "person" $person
               "role" .role
-              "biography_enabled" true
             ) }}
           {{- end -}}
         </div>

--- a/layouts/partials/blocks/templates/persons.html
+++ b/layouts/partials/blocks/templates/persons.html
@@ -37,6 +37,7 @@
               "options" $options
               "person" $person
               "role" .role
+              "biography_enabled" true
             ) }}
           {{- end -}}
         </div>

--- a/layouts/partials/persons/person.html
+++ b/layouts/partials/persons/person.html
@@ -22,13 +22,13 @@
       <p itemprop="jobTitle">
         {{ if (partial "GetTextFromHTML" $role) }}
           {{ partial "PrepareHTML" $role }}
+        {{ else if partial "GetTextFromHTML" $person.Params.summary }}
+          {{ partial "PrepareHTML" $person.Params.summary }}
         {{ else if (partial "GetTextFromHTML" $person.Params.biography) }}
           {{ partial "GetTruncateContent" ( dict 
               "text" $person.Params.biography
               "length" site.Params.persons.single.truncate_description
           )}}
-        {{ else if partial "GetTextFromHTML" $person.Params.summary }}
-          {{ partial "PrepareHTML" $person.Params.summary }}
         {{ end }}
       </p>
     {{ end }}

--- a/layouts/partials/persons/person.html
+++ b/layouts/partials/persons/person.html
@@ -6,6 +6,7 @@
 ) }}
 {{ $person := .person }}
 {{ $role := .role }}
+{{ $biography_enabled := .biography_enabled | default false }}
 
 <article class="person" itemscope itemtype="https://schema.org/Person">
   <div class="description">
@@ -24,7 +25,7 @@
           {{ partial "PrepareHTML" $role }}
         {{ else if partial "GetTextFromHTML" $person.Params.summary }}
           {{ partial "PrepareHTML" $person.Params.summary }}
-        {{ else if (partial "GetTextFromHTML" $person.Params.biography) }}
+        {{ else if and $biography_enabled (partial "GetTextFromHTML" $person.Params.biography) }}
           {{ partial "GetTruncateContent" ( dict 
               "text" $person.Params.biography
               "length" site.Params.persons.single.truncate_description

--- a/layouts/partials/persons/person.html
+++ b/layouts/partials/persons/person.html
@@ -6,7 +6,6 @@
 ) }}
 {{ $person := .person }}
 {{ $role := .role }}
-{{ $biography_enabled := .biography_enabled | default false }}
 
 <article class="person" itemscope itemtype="https://schema.org/Person">
   <div class="description">
@@ -25,11 +24,6 @@
           {{ partial "PrepareHTML" $role }}
         {{ else if partial "GetTextFromHTML" $person.Params.summary }}
           {{ partial "PrepareHTML" $person.Params.summary }}
-        {{ else if and $biography_enabled (partial "GetTextFromHTML" $person.Params.biography) }}
-          {{ partial "GetTruncateContent" ( dict 
-              "text" $person.Params.biography
-              "length" site.Params.persons.single.truncate_description
-          )}}
         {{ end }}
       </p>
     {{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

On enlève la biographie du partial `person`

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

http://localhost:1313/fr/equipe/

## URL de test du site [Vigo Postgrowth Lab](https://github.com/osunyorg/vigo-postgrowth-lab)

http://localhost:1313/fr/people/

## Screenshots

Ici Arnaud n'a pas de résumé, ni de rôle : 
<img width="939" alt="Capture d’écran 2024-10-01 à 21 04 59" src="https://github.com/user-attachments/assets/373a64ce-7d0b-4f6c-8819-e875073bf22f">

<img width="926" alt="Capture d’écran 2024-10-01 à 19 43 12" src="https://github.com/user-attachments/assets/5e0ee760-4acf-4fba-9dbe-69bbacbda092">

