### PR TITLE
Correction de la liste des actualités

### DIFF
--- a/assets/sass/_theme/sections/posts.sass
+++ b/assets/sass/_theme/sections/posts.sass
@@ -45,10 +45,11 @@
                     width: 33.33333%
                 @include media-breakpoint-up(desktop)
                     grid-column: 1/4
+                    &:empty
+                        background: var(--color-background-alt)
+                        aspect-ratio: 3/2
                 &, img
                     aspect-ratio: auto
-                &:empty
-                    background: var(--color-background-alt)
             @include media-breakpoint-up(desktop)
                 .post-meta
                     max-width: columns(3)

--- a/assets/sass/_theme/sections/posts.sass
+++ b/assets/sass/_theme/sections/posts.sass
@@ -23,11 +23,11 @@
             display: flex
             margin-bottom: $spacing-3
             padding-bottom: $spacing-3
+            flex-direction: row
             .post-title + p
                 margin-top: $spacing-2
             @include media-breakpoint-up(desktop)
                 @include grid
-                flex-direction: row
                 margin-bottom: $spacing-5
                 padding-bottom: $spacing-5
             .post-content
@@ -35,6 +35,9 @@
                 .post-meta
                     > *
                         display: block
+                @include media-breakpoint-down(desktop)
+                    flex: 1
+                    margin-left: $spacing-2
             .media
                 background: none
                 margin: 0
@@ -44,6 +47,8 @@
                     grid-column: 1/4
                 &, img
                     aspect-ratio: auto
+                &:empty
+                    background: var(--color-background-alt)
             @include media-breakpoint-up(desktop)
                 .post-meta
                     max-width: columns(3)

--- a/layouts/partials/commons/image-default.html
+++ b/layouts/partials/commons/image-default.html
@@ -1,8 +1,8 @@
-{{ $section_type := . }}
-{{ $use_default := (index site.Params $section_type).default_image }}
-{{ $image := index site.Data.website.default "image" }}
+{{- $section_type := . -}}
+{{- $use_default := (index site.Params $section_type).default_image -}}
+{{- $image := index site.Data.website.default "image" -}}
 
-{{ if and $use_default $image }}
+{{- if and $use_default $image -}}
   {{ with index site.Params.image_sizes.sections $section_type }}
     {{ $sizes := .item }}
 
@@ -12,4 +12,4 @@
           "sizes"    $sizes
         ) -}}
   {{ end }}
-{{ end }}
+{{- end -}}

--- a/layouts/partials/posts/post.html
+++ b/layouts/partials/posts/post.html
@@ -71,7 +71,7 @@
     </div>
     {{ if $options.image }}
       <div class="media">
-        {{- if and .Params.image -}}
+        {{- if .Params.image -}}
           {{- partial "commons/image.html"
               (dict
                 "image"    .Params.image


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Les actus dans l'index des actus étaient cassées en mobile.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots

Avant :

![image](https://github.com/user-attachments/assets/238376f1-7c60-453e-9e3b-bb5ec03e8235)

![image](https://github.com/user-attachments/assets/cfbcfc19-8eaa-403e-8ff8-366cbfe23219)


Après : 

![image](https://github.com/user-attachments/assets/de0df66c-c5af-402d-93f4-1fd8bb954c65)

![image](https://github.com/user-attachments/assets/0cb16435-a9cd-4522-a23e-96010d4f0178)


