### PR TITLE
Changement de l'affichage de la page des campus : blocs après la liste

### DIFF
--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -14,7 +14,6 @@
             @include icon(arrow-right-line, after)
                 margin-left: $spacing-2
             margin-top: $spacing-1
-
         .media
             width: 100%
             img
@@ -119,3 +118,20 @@
                     box-shadow: none
                     overflow: hidden
                     padding: 0
+
+.locations__taxonomy
+    .page-with-blocks
+        .locations
+            margin-bottom: $block-space-y
+    @include media-breakpoint-up(desktop)
+        &.full-width .page-with-blocks 
+            .locations
+                margin-bottom: $block-space-y-desktop
+    &.full-width
+        .blocks 
+            .block:last-child
+                &.block-organizations--map
+                    margin-bottom: calc(-1 * (var(--spacing-5) / 2))
+                    padding-bottom: 0
+                    @include media-breakpoint-up(desktop)
+                        margin-bottom: calc(-1 * var(--spacing-5))

--- a/layouts/locations/list.html
+++ b/layouts/locations/list.html
@@ -7,12 +7,12 @@
         "context" .
       ) }}
 
-    {{ partial "contents/list.html" . }}
+      <div class="container">
+        {{ partial "locations/locations.html" . }}
+        {{ partial "commons/pagination.html" . }}
+      </div>
 
-    <div class="container">
-      {{ partial "locations/locations.html" . }}
-      {{ partial "commons/pagination.html" . }}
-    </div>
+      {{ partial "contents/list.html" . }}
   </div>
 
 {{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Sur l'IUT de Bordeaux, on a le cas d'une carte avant les campus, ce qui n'est pas très élégant et ne permet pas d'accéder facilement à l'information.

- J'ai passé les blocs sous la liste des campus, en ajustant la marge des campus
- J'ai ajusté la marge sous la carte pour qu'elle colle au footer, comme dans la page d'un campus (pour un cas de pleine largeur et en desktop)

Ceci dit est-ce que ça fait sens de déplacer les blocs comme ça ?

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

#630 

## URL de test sur example.osuny.org

Les campus ont disparu

## URL de test du site (optionnel)

http://localhost:1313/sites-formation/

## Screenshots
![Capture d’écran 2024-10-02 à 16 44 20](https://github.com/user-attachments/assets/521e8d2a-2a3e-4e68-81f5-57f9595da950)
![Capture d’écran 2024-10-02 à 16 56 04](https://github.com/user-attachments/assets/2d2bf54c-f37f-4d82-93bb-77c8650457a5)
![Capture d’écran 2024-10-02 à 16 59 37](https://github.com/user-attachments/assets/53e28403-9d9c-4d33-b8fa-de7099aead28)