### PR TITLE
Clarification des liens sur la page d'une personne

### DIFF
--- a/assets/sass/_theme/sections/persons.sass
+++ b/assets/sass/_theme/sections/persons.sass
@@ -170,16 +170,24 @@ ol.persons--list
                 transition: transform .3s ease
             &:hover::after
                 transform: translateX($spacing-2)
+        .more
+            @include icon-block(arrow-right-line, after)
+            display: inline-block
+            margin-top: $spacing-3
+            &::after
+                margin-left: space()
+                transition: 0.55s $arrow-ease-transition
+            &:hover:after
+                transform: translateX($spacing-1)
     .person-publications
         .publications
             margin-top: $spacing-2
     .person-posts
         .posts
             margin-top: $spacing-3
-        article.post:last-child
-            margin-bottom: 0
-        @include media-breakpoint-up(desktop)
-            .posts
+            article.post:last-child
+                margin-bottom: 0
+            @include media-breakpoint-up(desktop)
                 margin-top: $spacing-4
     section
         padding-bottom: $spacing-5

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -239,7 +239,7 @@ persons:
     all: View all papers published by {{ .author }}
   publications:
     recent: Latest publications
-    all: View all publications published by {{ .author }}
+    all: View all publications by {{ .author }}
   programs: Teachings
   backlinks:
     events: Events mentioning

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -231,10 +231,16 @@ papers:
     references: References
     content: Content
 persons:
-  posts: News
-  programs: Programs
-  papers: Papers
-  publications: Latest publications
+  posts:
+    recent: Latest news
+    all: View all news posted by {{ .author }}
+  papers: 
+    recent: Latest papers
+    all: View all papers published by {{ .author }}
+  publications:
+    recent: Latest publications
+    all: View all publications published by {{ .author }}
+  programs: Teachings
   backlinks:
     events: Events mentioning
     pages: Pages mentioning

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -231,11 +231,16 @@ papers:
     references: Références
     content: Texte intégral
 persons:
-  posts: Actualités publiées récemment
+  posts:
+    recent: Actualités récentes
+    all: Voir toutes les actualités publiées par {{ .author }}
   programs: Enseignements
-  papers: Papiers
-  publications: Publications récentes
-  papers: Papiers publiés récemment
+  papers: 
+    recent: Papiers publiées récemment
+    all: Voir toutes les papiers publiés par {{ .author }}
+  publications:
+    recent: Publications récentes
+    all: Voir toutes les publications publiées par {{ .author }}
   backlinks:
     events: Événements mentionnant
     pages: Pages mentionnant

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -234,13 +234,13 @@ persons:
   posts:
     recent: Actualités récentes
     all: Voir toutes les actualités publiées par {{ .author }}
-  programs: Enseignements
   papers: 
     recent: Papiers publiées récemment
     all: Voir tous les papiers publiés par {{ .author }}
   publications:
     recent: Publications récentes
     all: Voir toutes les publications publiées par {{ .author }}
+  programs: Enseignements
   backlinks:
     events: Événements mentionnant
     pages: Pages mentionnant

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -237,7 +237,7 @@ persons:
   programs: Enseignements
   papers: 
     recent: Papiers publiées récemment
-    all: Voir toutes les papiers publiés par {{ .author }}
+    all: Voir tous les papiers publiés par {{ .author }}
   publications:
     recent: Publications récentes
     all: Voir toutes les publications publiées par {{ .author }}

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -239,7 +239,7 @@ persons:
     all: Voir tous les papiers publiés par {{ .author }}
   publications:
     recent: Publications récentes
-    all: Voir toutes les publications publiées par {{ .author }}
+    all: Voir toutes les publications de {{ .author }}
   programs: Enseignements
   backlinks:
     events: Événements mentionnant

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -232,10 +232,10 @@ papers:
     content: Texte intégral
 persons:
   posts:
-    recent: Actualités récentes
+    recent: Actualités publiées récemment
     all: Voir toutes les actualités publiées par {{ .author }}
   papers: 
-    recent: Papiers publiées récemment
+    recent: Papiers publiés récemment
     all: Voir tous les papiers publiés par {{ .author }}
   publications:
     recent: Publications récentes

--- a/layouts/partials/papers/paper.html
+++ b/layouts/partials/papers/paper.html
@@ -4,8 +4,8 @@
 
 {{ $heading_level := .heading_level | default 3 }}
 {{ $heading_tag := (dict
-  "open" ((printf "<h%s class='paper-title' itemprop='headline'>" $heading_level) | safeHTML)
-  "close" ((printf "</h%s>" $heading_level) | safeHTML)
+  "open" ((printf "<h%d clads='paper-title' itemprop='headline'>" $heading_level) | safeHTML)
+  "close" ((printf "</h%d>" $heading_level) | safeHTML)
 ) }}
 
 {{ with .paper }}

--- a/layouts/partials/papers/paper.html
+++ b/layouts/partials/papers/paper.html
@@ -4,7 +4,7 @@
 
 {{ $heading_level := .heading_level | default 3 }}
 {{ $heading_tag := (dict
-  "open" ((printf "<h%d clads='paper-title' itemprop='headline'>" $heading_level) | safeHTML)
+  "open" ((printf "<h%d class='paper-title' itemprop='headline'>" $heading_level) | safeHTML)
   "close" ((printf "</h%d>" $heading_level) | safeHTML)
 ) }}
 

--- a/layouts/partials/persons/papers.html
+++ b/layouts/partials/persons/papers.html
@@ -1,15 +1,15 @@
 {{ $researchers := site.GetPage (printf "/researchers/%s" .slug) }}
-lalal
+
 <section class="persons-papers">
   <div class="top">
-    <h2>{{ i18n "persons.papers" }}</h2>
-    <a href="{{ $researchers.Permalink }}" class="link">{{ i18n "persons.papers" }}</a>
+    <h2 class="h5">{{ i18n "persons.papers" }}</h2>
   </div>
   <ul class="papers">
     {{ range first 3 .papers }}
-      <li>
-        {{ partial "papers/paper.html" (dict "paper" . ) }}
-      </li>
+    <li>
+      {{ partial "papers/paper.html" (dict "paper" . ) }}
+    </li>
     {{ end }}
   </ul>
+  <a href="{{ $researchers.Permalink }}" class="more">{{ $researchers.Params.Title }}</a>
 </section>

--- a/layouts/partials/persons/papers.html
+++ b/layouts/partials/persons/papers.html
@@ -1,5 +1,4 @@
 {{ $researcher := .researcher }}
-
 <section class="persons-papers">
   <div class="top">
     <h2 class="h5">{{ i18n "persons.papers.recent" }}</h2>

--- a/layouts/partials/persons/papers.html
+++ b/layouts/partials/persons/papers.html
@@ -1,8 +1,8 @@
-{{ $researchers := site.GetPage (printf "/researchers/%s" .slug) }}
+{{ $researcher := .researcher }}
 
 <section class="persons-papers">
   <div class="top">
-    <h2 class="h5">{{ i18n "persons.papers" }}</h2>
+    <h2 class="h5">{{ i18n "persons.papers.recent" }}</h2>
   </div>
   <ul class="papers">
     {{ range first 3 .papers }}
@@ -11,5 +11,5 @@
     </li>
     {{ end }}
   </ul>
-  <a href="{{ $researchers.Permalink }}" class="more">{{ $researchers.Params.Title }}</a>
+  <a href="{{ $researcher.Permalink }}" class="more">{{ i18n "persons.papers.all" (dict "author" $researcher.Params.person) }}</a>
 </section>

--- a/layouts/partials/persons/papers.html
+++ b/layouts/partials/persons/papers.html
@@ -1,4 +1,5 @@
 {{ $researchers := site.GetPage (printf "/researchers/%s" .slug) }}
+lalal
 <section class="persons-papers">
   <div class="top">
     <h2>{{ i18n "persons.papers" }}</h2>

--- a/layouts/partials/persons/papers.html
+++ b/layouts/partials/persons/papers.html
@@ -7,7 +7,7 @@
   <ul class="papers">
     {{ range first 3 .papers }}
     <li>
-      {{ partial "papers/paper.html" (dict "paper" . ) }}
+      {{ partial "papers/paper.html" (dict "paper" .) }}
     </li>
     {{ end }}
   </ul>

--- a/layouts/partials/persons/posts.html
+++ b/layouts/partials/persons/posts.html
@@ -1,6 +1,6 @@
 <section class="person-posts">
   <div class="top">
-    <h2 class="h5"><a href="{{ .author.Permalink }}">{{ i18n "persons.posts" }}</a></h2>
+    <h2 class="h5">{{ i18n "persons.posts" }}</h2>
   </div>
   <div class="posts posts--{{- site.Params.posts.index.layout -}}">
     {{ range first 3 .posts }}
@@ -9,5 +9,6 @@
         "options" site.Params.posts.index.options
       )}}
     {{ end }}
+    <a href="{{ .author.Permalink }}" class="more">{{ .author.Params.Title }}</a>
   </div>
 </section>

--- a/layouts/partials/persons/posts.html
+++ b/layouts/partials/persons/posts.html
@@ -1,6 +1,6 @@
 <section class="person-posts">
   <div class="top">
-    <h2 class="h5">{{ i18n "persons.posts" }}</h2>
+    <h2 class="h5">{{ i18n "persons.posts.recent" }}</h2>
   </div>
   <div class="posts posts--{{- site.Params.posts.index.layout -}}">
     {{ range first 3 .posts }}
@@ -9,6 +9,6 @@
         "options" site.Params.posts.index.options
       )}}
     {{ end }}
-    <a href="{{ .author.Permalink }}" class="more">{{ .author.Params.Title }}</a>
   </div>
+  <a href="{{ .author.Permalink }}" class="more">{{ i18n "persons.posts.all" (dict "author" .author.Params.Title )}}</a>
 </section>

--- a/layouts/partials/persons/posts.html
+++ b/layouts/partials/persons/posts.html
@@ -10,5 +10,5 @@
       )}}
     {{ end }}
   </div>
-  <a href="{{ .author.Permalink }}" class="more">{{ i18n "persons.posts.all" (dict "author" .author.Params.Title )}}</a>
+  <a href="{{ .author.Permalink }}" class="more">{{ i18n "persons.posts.all" (dict "author" .author.Params.Person )}}</a>
 </section>

--- a/layouts/partials/persons/publications.html
+++ b/layouts/partials/persons/publications.html
@@ -3,7 +3,7 @@
 
 <section class="person-publications">
   <div class="top">
-    <h2 class="h5">{{ i18n "persons.publications" }}</h2>
+    <h2 class="h5">{{ i18n "persons.publications.recent" }}</h2>
   </div>
   <div class="publications">
     {{ range first 3 $publications }}
@@ -13,7 +13,7 @@
       )}}
     {{ end }}
     {{ if $researcher.Params }}
-      <a href="{{ .author.Permalink }}" class="more">{{ $researcher.Params.title }}</a>
+      <a href="{{ .author.Permalink }}" class="more">{{ i18n "persons.publications.all" (dict "author" $researcher.Params.person) }}</a>
     {{ end }}
   </div>
 </section>

--- a/layouts/partials/persons/publications.html
+++ b/layouts/partials/persons/publications.html
@@ -3,7 +3,7 @@
 
 <section class="person-publications">
   <div class="top">
-    <h2 class="h5"><a href="{{ $researcher.Permalink }}">{{ i18n "persons.publications" }}</a></h2>
+    <h2 class="h5">{{ i18n "persons.publications" }}</h2>
   </div>
   <div class="publications">
     {{ range first 3 $publications }}
@@ -11,6 +11,9 @@
         "publication" .
         "researcher" $researcher
       )}}
+    {{ end }}
+    {{ if $researcher.Params }}
+      <a href="{{ .author.Permalink }}" class="more">{{ $researcher.Params.title }}</a>
     {{ end }}
   </div>
 </section>

--- a/layouts/persons/single.html
+++ b/layouts/persons/single.html
@@ -14,7 +14,7 @@
 
   {{ $posts := where $author.Pages "Section" "posts" }}
   {{ $publications := where $researcher.Pages "Section" "publications" }}
-  {{ $papers := where $author.Pages "Section" "papers" }}
+  {{ $papers := where $researcher.Pages "Section" "papers" }}
 
   {{ partial "persons/hero-single.html" . }}
 

--- a/layouts/persons/single.html
+++ b/layouts/persons/single.html
@@ -92,7 +92,7 @@
       {{ end }}
 
       {{ if $papers }}
-        {{ partial "persons/papers.html" (dict "papers" $papers "slug" $slug) }}
+        {{ partial "persons/papers.html" (dict "papers" $papers "researcher" $researcher) }}
       {{ end }}
     </div>
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Sébastien du CEMTI nous signalait que ce n'était pas clair d'avoir un lien "publications récentes" à destination de toutes les publications d'une personne.

J'ai donc repris les partiels de `person-objects` pour ajouter un lien `.more` à la suite des items listés.
Le partiel des papiers était aussi à légèrement reprendre !

Voilà les nouveaux textes : 

```
  posts:
    recent: Actualités récentes
    all: Voir toutes les actualités publiées par {{ .author }}
  papers: 
    recent: Papiers publiées récemment
    all: Voir tous les papiers publiés par {{ .author }}
  publications:
    recent: Publications récentes
    all: Voir toutes les publications de {{ .author }}
```

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example-journal.osuny.org

http://localhost:1314/equipe/arnaud-levy/

## URL de test du site CEMTI

http://localhost:1313/equipe/sebastien-broca/

## Screenshots

![Capture d’écran 2024-10-03 à 17 42 06](https://github.com/user-attachments/assets/eff2f478-abe0-4002-b197-c90ef830f373)
![Capture d’écran 2024-10-03 à 17 42 29](https://github.com/user-attachments/assets/2930f2b5-909b-4fa2-9987-691f83ad621c)
![Capture d’écran 2024-10-03 à 17 42 35](https://github.com/user-attachments/assets/104b9b4e-c602-4740-a233-8f1228acb293)
![Capture d’écran 2024-10-03 à 17 42 40](https://github.com/user-attachments/assets/95165823-cbcb-4a41-a84d-68f80ee3e2a2)
