### PR TITLE
Ajouter la détection des liens externes aux boutons du hero

### DIFF
--- a/layouts/partials/header/hero.html
+++ b/layouts/partials/header/hero.html
@@ -47,7 +47,10 @@
 
         {{ with $button }}
           {{ if and .display .target .label }}
-            <a href="{{ .target }}" class="btn">{{ .label }}</a>
+            {{ $title := .label }}
+            {{ $isExternal := .external | default false }}
+            {{ $link_title := cond $isExternal (safeHTML (i18n "commons.link.blank_aria" (dict "Title" $title))) $title}}
+            <a href="{{ .target }}" title ="{{ $link_title }}" class="btn" {{ if $isExternal -}} target="_blank" rel="noopener" {{- end }}>{{ .label }}</a>
           {{ end }}
         {{ end }}
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Ajouter la détection du lien externe sur le modèle du bloc lien.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/futurs-site/issues/4

## URL de test du site FUTURs

http://localhost:1313/fr/

## Screenshots

<img width="298" alt="Capture d’écran 2024-10-03 à 18 06 44" src="https://github.com/user-attachments/assets/ad1f4ed6-7ff4-4a6f-9ea2-46094f23b0e4">

![Capture d’écran 2024-10-03 à 18 08 27](https://github.com/user-attachments/assets/a3728b9e-0429-4729-81e4-9d30165c0624) ![Capture d’écran 2024-10-03 à 18 08 12](https://github.com/user-attachments/assets/ffe2f61a-7973-4b22-941b-dc177ca5a49c)
