### PR TITLE
Fix du lien vers toutes les publications d'une personne

### DIFF
--- a/layouts/partials/persons/publications.html
+++ b/layouts/partials/persons/publications.html
@@ -13,7 +13,7 @@
       )}}
     {{ end }}
     {{ if $researcher.Params }}
-      <a href="{{ .author.Permalink }}" class="more">{{ i18n "persons.publications.all" (dict "author" $researcher.Params.person) }}</a>
+      <a href="{{ $researcher.Permalink }}" class="more">{{ i18n "persons.publications.all" (dict "author" $researcher.Params.person) }}</a>
     {{ end }}
   </div>
 </section>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

J'ai échangé `.researcher` par `.author` et le lien ne fonctionnait effectivement pas, c'est réparé (j'en ai profité pour vérifier que les actus et les papeirs soient ok et c'est le cas).

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example journal

http://localhost:1313/equipe/arnaud-levy/

## URL de test du site CEMTI

http://localhost:1313/equipe/sebastien-broca/
http://localhost:1313/equipe/maxime-cervulle/