### PR TITLE
Correction du titre alternatif du partial `links`

### DIFF
--- a/layouts/partials/blocks/templates/links.html
+++ b/layouts/partials/blocks/templates/links.html
@@ -16,20 +16,15 @@
             <li itemscope itemtype="https://schema.org/WebPage">
               <div class="link-content">
                 {{ $title := partial "PrepareHTML" .title }}
-                {{ $alt_title := "" }}
-                {{ if .alt_title }}
-                  {{ $alt_title = partial "PrepareHTML" .alt_title }}
-                {{ end }}
-                
-                {{ $a11y_title := cond $alt_title $alt_title $title }}
+                {{ $a11y_title := .alt_title | default $title }}
                 {{ $url := .url }}
-                {{ $isExternal := .external | default true }}
-                {{ $link_title := cond $isExternal (safeHTML (i18n "commons.link.blank_aria" (dict "Title" $a11y_title))) $a11y_title}}
+                {{ $is_external := .external | default true }}
+                {{ $link_title := cond $is_external (safeHTML (i18n "commons.link.blank_aria" (dict "Title" $a11y_title))) $a11y_title }}
 
                 <link itemprop="url" href="{{ .url }}">
-                <a itemprop="relatedLink" href="{{ .url }}" title="{{ $link_title }}" {{ if $isExternal -}} target="_blank" rel="noopener" {{- end }}>
+                <a itemprop="relatedLink" href="{{ .url }}" title="{{ $link_title }}" {{ if $is_external -}} target="_blank" rel="noopener" {{- end }}>
                   <span itemprop="name">{{- $title -}}</span>
-                  {{ if $isExternal }}
+                  {{ if $is_external }}
                     <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
                   {{ end }}
                 </a>

--- a/layouts/partials/header/hero.html
+++ b/layouts/partials/header/hero.html
@@ -48,9 +48,9 @@
         {{ with $button }}
           {{ if and .display .target .label }}
             {{ $title := .label }}
-            {{ $isExternal := .external | default false }}
-            {{ $link_title := cond $isExternal (safeHTML (i18n "commons.link.blank_aria" (dict "Title" $title))) $title}}
-            <a href="{{ .target }}" title ="{{ $link_title }}" class="btn" {{ if $isExternal -}} target="_blank" rel="noopener" {{- end }}>{{ .label }}</a>
+            {{ $is_external := .external | default false }}
+            {{ $link_title := cond $is_external (safeHTML (i18n "commons.link.blank_aria" (dict "Title" $title))) $title }}
+            <a href="{{ .target }}" title ="{{ $link_title }}" class="btn" {{ if $is_external -}} target="_blank" rel="noopener" {{- end }}>{{ .label }}</a>
           {{ end }}
         {{ end }}
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Une erreur hugo du à une condition bloquait la compilation.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

