### PR TITLE
Vérifier la présence de l'image dans le partial ratio

### DIFF
--- a/layouts/partials/GetImageDirection
+++ b/layouts/partials/GetImageDirection
@@ -1,10 +1,12 @@
 {{ $direction := "square" }}
 {{ $image := partial "GetMedia" .id }}
 
-{{ if gt $image.ratio 1 }}
-  {{ $direction = "landscape" }}
-{{ else if lt $image.ratio 1 }}
-  {{ $direction = "portrait" }}
+{{ if $image }}
+  {{ if gt $image.ratio 1 }}
+    {{ $direction = "landscape" }}
+  {{ else if lt $image.ratio 1 }}
+    {{ $direction = "portrait" }}
+  {{ end }}
 {{ end }}
 
 {{ return $direction }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Une erreur se déclenche si le champ image est une chaîne de caractère au lieu d'un objet.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


