### PR TITLE
Ajout d'une carte des campus à la liste des campus

### DIFF
--- a/assets/js/theme/blocks/campus.js
+++ b/assets/js/theme/blocks/campus.js
@@ -11,38 +11,43 @@ class CampusMap {
         this.markers = [];
         this.setMap = false;
         this.content = this.map.querySelector('.map');
-        this.campus = this.content.querySelector('.campus');
+        this.locations = this.content.querySelectorAll('.campus');
+        this.openPopup = JSON.parse(this.content.getAttribute('data-open-popup'));
         let map = L.map(this.content, {
             scrollWheelZoom: false
         });
-        this.geoloc = {
-            latitude: parseFloat(this.campus.getAttribute('data-latitude')),
-            longitude: parseFloat(this.campus.getAttribute('data-longitude'))
-        };
-        this.classHidden = 'hidden';
-
-        this.themeMarker = L.icon({
-            iconUrl: this.content.getAttribute('data-marker-icon') || '/assets/images/map-marker.svg',
-            iconSize: [17, 26]
-        });
-        
-        if (Boolean(this.geoloc.latitude) && Boolean(this.geoloc.longitude)) {
-            let mapLocation = [this.geoloc.latitude, this.geoloc.longitude];
-            let marker = new L.marker(mapLocation, {
-                icon: this.themeMarker
+        this.locations.forEach((location) => {
+            this.geoloc = {
+                latitude: parseFloat(location.getAttribute('data-latitude')),
+                longitude: parseFloat(location.getAttribute('data-longitude'))
+            };
+            this.classHidden = 'hidden';
+    
+            this.themeMarker = L.icon({
+                iconUrl: this.content.getAttribute('data-marker-icon') || '/assets/images/map-marker.svg',
+                iconSize: [17, 26]
             });
-
-            const popup = new L.Popup({'autoClose':false, 'closeButton':false, 'maxWidth': 1000});
-            popup.setLatLng(mapLocation);
-            popup.setContent(this.campus);
-            popup.openOn(map);
-            marker.addTo(map).bindPopup(popup);
-            this.markers.push(marker);
-            this.setMap = true;
-            this.listen(map);
-            this.getMapBounds(map);
-            this.dom.classList.add("page-with-map");
-        }
+            
+            if (Boolean(this.geoloc.latitude) && Boolean(this.geoloc.longitude)) {
+                let mapLocation = [this.geoloc.latitude, this.geoloc.longitude];
+                let marker = new L.marker(mapLocation, {
+                    icon: this.themeMarker
+                });
+    
+                const popup = new L.Popup({'autoClose':false, 'closeButton':false, 'maxWidth': 1000});
+                popup.setLatLng(mapLocation);
+                popup.setContent(location);
+                if (this.openPopup) {
+                    popup.openOn(map);
+                }
+                marker.addTo(map).bindPopup(popup);
+                this.markers.push(marker);
+                this.setMap = true;
+                this.listen(map);
+                this.getMapBounds(map);
+                this.dom.classList.add("page-with-map");
+            }
+        });
     }
 
     listen (map) {

--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -122,9 +122,3 @@
 
     .locations__taxonomy &
         margin-top: $spacing-6
-        margin-left: var(--grid-gutter-negative)
-        margin-right: var(--grid-gutter-negative)
-
-.locations__taxonomy
-    .page-with-map
-        padding-bottom: 0

--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -98,7 +98,7 @@
                     display: flex
                     .campus-content
                         order: 2
-                        padding: 0 $spacing-3
+                        padding: $spacing-2 $spacing-3
                         span,
                         .campus-title
                             display: block

--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -119,3 +119,12 @@
                     box-shadow: none
                     overflow: hidden
                     padding: 0
+
+    .locations__taxonomy &
+        margin-top: $spacing-6
+        margin-left: var(--grid-gutter-negative)
+        margin-right: var(--grid-gutter-negative)
+
+.locations__taxonomy
+    .page-with-map
+        padding-bottom: 0

--- a/config.yaml
+++ b/config.yaml
@@ -97,6 +97,7 @@ params:
     index:
       truncate_description: 200
       layout: list # grid | list
+      map: true
       options:
         summary: true
         image: true

--- a/layouts/locations/list.html
+++ b/layouts/locations/list.html
@@ -12,6 +12,12 @@
     <div class="container">
       {{ partial "locations/locations.html" . }}
       {{ partial "commons/pagination.html" . }}
+      {{ if site.Params.locations.index.map }}
+        {{ $locations := .Pages }}
+        {{ partial "locations/map.html" (dict
+            "locations" $locations
+        )}}
+      {{ end }}
     </div>
   </div>
 

--- a/layouts/locations/list.html
+++ b/layouts/locations/list.html
@@ -12,13 +12,13 @@
     <div class="container">
       {{ partial "locations/locations.html" . }}
       {{ partial "commons/pagination.html" . }}
-      {{ if site.Params.locations.index.map }}
-        {{ $locations := .Pages }}
-        {{ partial "locations/map.html" (dict
-            "locations" $locations
-        )}}
-      {{ end }}
     </div>
+    {{ if site.Params.locations.index.map }}
+      {{ $locations := .Pages }}
+      {{ partial "locations/map.html" (dict
+          "locations" $locations
+      )}}
+    {{ end }}
   </div>
 
 {{ end }}

--- a/layouts/locations/term.html
+++ b/layouts/locations/term.html
@@ -17,6 +17,9 @@
     </div>
   </div>
   {{ if and .Params.contact_details.geolocation.longitude .Params.contact_details.geolocation.latitude }}
-    {{ partial "locations/map.html" . }}
+    {{ partial "locations/map.html" (dict
+      "locations" (slice .)
+      "popup_opened" true
+    )}}
   {{ end }}
 {{ end }}

--- a/layouts/partials/footer/js.html
+++ b/layouts/partials/footer/js.html
@@ -10,7 +10,6 @@
         {{ end }}
       {{ end }}
     {{ end }}
-
     {{ if eq .template "gallery"}}
       {{ with .data }}
         {{ if eq .layout "carousel" }}
@@ -23,6 +22,10 @@
     {{ end }}
   {{ end }}
 {{ end }}
+{{ if and (eq .Kind "taxonomy") (eq .Section "locations") }}
+  {{ $isLeafletNeeded = true }}
+{{ end }}
+
 
 <!-- check if map needed  -->
 {{ if .Params.contact_details.geolocation }} 

--- a/layouts/partials/locations/map.html
+++ b/layouts/partials/locations/map.html
@@ -1,39 +1,44 @@
+{{ $locations := .locations }}
+{{ $popup_opened := .popup_opened | default false }}
+
 <div class="campus-map">
-  <div class="map" data-marker-icon="{{ "/assets/images/map-marker.svg" }}">
-    <article class="campus" data-longitude="{{ .Params.contact_details.geolocation.longitude }}"data-latitude="{{ .Params.contact_details.geolocation.latitude }}">
-      {{ $title := "" }}
-      {{ if .Params.title }}
-        <div class="campus-content">
-          {{ $title = partial "PrepareHTML" .Params.title -}}
-          <p class="campus-title">
-            {{- if and .Params.url .Params.with_link }}
-              <a href="{{ .Params.url }}" {{ if .external }} target="_blank" rel="noopener" {{ end }} title="{{ safeHTML (i18n "commons.link.blank_aria" (dict "Title" $title)) }}">
-            {{ end -}}
-            {{- $title -}}
-            {{- if and .Params.url .Params.with_link }}
-                <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
-              </a>
-            {{ end -}}
-          </p>
-          {{ with .Params.contact_details }}
-            <span>{{ .address.value }}</span>
-            <span>
-              {{ .zipcode.value }}
-              {{ .city.value }}
-            </span>
-          {{ end }}
-        </div>
-      {{ end -}}
-      {{- if .Params.image -}}
-        <div class="media">
-          {{- partial "commons/image.html"
-            (dict
-              "image"  .Params.image
-              "alt"    $title
-              "sizes"  site.Params.image_sizes.sections.locations.map
-             ) -}}
-        </div>
-      {{- end -}}
-    </article>
+  <div class="map" data-open-popup="{{ $popup_opened }}" data-marker-icon="{{ "/assets/images/map-marker.svg" }}">
+    {{ range $locations }}
+      <article class="campus" data-longitude="{{ .Params.contact_details.geolocation.longitude }}" data-latitude="{{ .Params.contact_details.geolocation.latitude }}">
+        {{ $title := "" }}
+        {{ if .Params.title }}
+          <div class="campus-content">
+            {{ $title = partial "PrepareHTML" .Params.title -}}
+            <p class="campus-title">
+              {{- if and .Params.url .Params.with_link }}
+                <a href="{{ .Params.url }}" {{ if .external }} target="_blank" rel="noopener" {{ end }} title="{{ safeHTML (i18n "commons.link.blank_aria" (dict "Title" $title)) }}">
+              {{ end -}}
+              {{- $title -}}
+              {{- if and .Params.url .Params.with_link }}
+                  <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+                </a>
+              {{ end -}}
+            </p>
+            {{ with .Params.contact_details }}
+              <span>{{ .address.value }}</span>
+              <span>
+                {{ .zipcode.value }}
+                {{ .city.value }}
+              </span>
+            {{ end }}
+          </div>
+        {{ end -}}
+        {{- if .Params.image -}}
+          <div class="media">
+            {{- partial "commons/image.html"
+              (dict
+                "image"  .Params.image
+                "alt"    $title
+                "sizes"  site.Params.image_sizes.sections.locations.map
+              ) -}}
+          </div>
+        {{- end -}}
+      </article>
+    {{ end }}
   </div>
 </div>

--- a/layouts/partials/locations/map.html
+++ b/layouts/partials/locations/map.html
@@ -4,41 +4,43 @@
 <div class="campus-map">
   <div class="map" data-open-popup="{{ $popup_opened }}" data-marker-icon="{{ "/assets/images/map-marker.svg" }}">
     {{ range $locations }}
-      <article class="campus" data-longitude="{{ .Params.contact_details.geolocation.longitude }}" data-latitude="{{ .Params.contact_details.geolocation.latitude }}">
-        {{ $title := "" }}
-        {{ if .Params.title }}
-          <div class="campus-content">
-            {{ $title = partial "PrepareHTML" .Params.title -}}
-            <p class="campus-title">
-              {{- if and .Params.url .Params.with_link }}
-                <a href="{{ .Params.url }}" {{ if .external }} target="_blank" rel="noopener" {{ end }} title="{{ safeHTML (i18n "commons.link.blank_aria" (dict "Title" $title)) }}">
-              {{ end -}}
-              {{- $title -}}
-              {{- if and .Params.url .Params.with_link }}
-                  <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
-                </a>
-              {{ end -}}
-            </p>
-            {{ with .Params.contact_details }}
-              <span>{{ .address.value }}</span>
-              <span>
-                {{ .zipcode.value }}
-                {{ .city.value }}
-              </span>
-            {{ end }}
-          </div>
-        {{ end -}}
-        {{- if .Params.image -}}
-          <div class="media">
-            {{- partial "commons/image.html"
-              (dict
-                "image"  .Params.image
-                "alt"    $title
-                "sizes"  site.Params.image_sizes.sections.locations.map
-              ) -}}
-          </div>
-        {{- end -}}
-      </article>
+      {{ if and .Params.contact_details.geolocation.longitude .Params.contact_details.geolocation.latitude }}
+        <article class="campus" data-longitude="{{ .Params.contact_details.geolocation.longitude }}" data-latitude="{{ .Params.contact_details.geolocation.latitude }}">
+          {{ $title := "" }}
+          {{ if .Params.title }}
+            <div class="campus-content">
+              {{ $title = partial "PrepareHTML" .Params.title -}}
+              <p class="campus-title">
+                {{- if and .Params.url .Params.with_link }}
+                  <a href="{{ .Params.url }}" {{ if .external }} target="_blank" rel="noopener" {{ end }} title="{{ safeHTML (i18n "commons.link.blank_aria" (dict "Title" $title)) }}">
+                {{ end -}}
+                {{- $title -}}
+                {{- if and .Params.url .Params.with_link }}
+                    <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+                  </a>
+                {{ end -}}
+              </p>
+              {{ with .Params.contact_details }}
+                <span>{{ .address.value }}</span>
+                <span>
+                  {{ .zipcode.value }}
+                  {{ .city.value }}
+                </span>
+              {{ end }}
+            </div>
+          {{ end -}}
+          {{- if .Params.image -}}
+            <div class="media">
+              {{- partial "commons/image.html"
+                (dict
+                  "image"  .Params.image
+                  "alt"    $title
+                  "sizes"  site.Params.image_sizes.sections.locations.map
+                ) -}}
+            </div>
+          {{- end -}}
+        </article>
+      {{ end }}
     {{ end }}
   </div>
 </div>


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout d'une carte à l'index des campus → je réutilise le partial créé pour les campus seuls, le style et le js

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

#630

## URL de test sur example.osuny.org

http://localhost:1313/fr/campus/
http://localhost:1313/fr/campus/iut-bordeaux-montaigne/

## URL de test du site de l'IUT de bordeaux

http://localhost:1313/sites-formation/
http://localhost:1313/sites-formation/bordeaux-bastide/

## Screenshots

### Sur l'IUT
Sur l'index les popups sont fermés : 
![Capture d’écran 2024-10-08 à 17 08 15](https://github.com/user-attachments/assets/e58b8dc6-6429-4814-b228-47

Sur single on reste avec la popup d'ouverte :
![Capture d’écran 2024-10-08 à 17 08 29](https://github.com/user-attachments/assets/57594ad0-e8e5-4e6b-84f4-9ef6aa119f76)

### Sur example
![Capture d’écran 2024-10-08 à 17 13 54](https://github.com/user-attachments/assets/4f7bfa8b-2155-4b73-b3e2-e95503eba9cc)
![Capture d’écran 2024-10-08 à 17 14 02](https://github.com/user-attachments/assets/b099e623-37d9-4d4e-9ef6-b76b8fbb432a)
