### PR TITLE
Carte des campus : léger fix pour mobile

### DIFF
--- a/assets/js/theme/blocks/locations.js
+++ b/assets/js/theme/blocks/locations.js
@@ -1,9 +1,9 @@
-const campusMap = document.querySelector('.campus-map');
+const locationsMap = document.querySelector('.locations-map');
 const dom = document.querySelector('main');
-class CampusMap {
-    constructor (dom, campusMap) {
+class LocationsMap {
+    constructor (dom, locationsMap) {
         this.dom = dom;
-        this.map = campusMap;
+        this.map = locationsMap;
         this.init();
     }
 
@@ -11,7 +11,7 @@ class CampusMap {
         this.markers = [];
         this.setMap = false;
         this.content = this.map.querySelector('.map');
-        this.locations = this.content.querySelectorAll('.campus');
+        this.locations = this.content.querySelectorAll('.location');
         this.openPopup = JSON.parse(this.content.getAttribute('data-open-popup'));
         let map = L.map(this.content, {
             scrollWheelZoom: false
@@ -63,6 +63,6 @@ class CampusMap {
     }
 }
 
-if (campusMap) {
-    new CampusMap(dom, campusMap);
+if (locationsMap) {
+    new LocationsMap(dom, locationsMap);
 }

--- a/assets/js/theme/index.js
+++ b/assets/js/theme/index.js
@@ -13,6 +13,6 @@ import './blocks/organizations';
 import './blocks/draggableBlocks.js';
 import './blocks/timeline.js';
 import './blocks/videos.js';
-import './blocks/campus.js';
+import './blocks/locations.js';
 import './utils/utils.js';
 import './components/carousel.js';

--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -105,7 +105,7 @@
                         order: 2
                         padding: $spacing-2 $spacing-3
                         .location-title
-                            @include h6
+                            text-transform: none
                             margin: 0 // Cancel leaflet default style
                         span:last-child
                             display: block

--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -91,25 +91,28 @@
                 color: var(--color-background)
                 height: 100%
                 margin: 0
-                min-width: min-content
-                width: auto !important // corrige la width appliquée en js par leaflet
+                width: columns(12) !important // corrige la width appliquée en js par leaflet
+                @include media-breakpoint-up(desktop)
+                    width: columns(4) !important
                 .campus
-                    align-items: center
+                    align-items: stretch
                     display: flex
                     .campus-content
+                        @include meta
+                        flex: 1
                         order: 2
                         padding: $spacing-2 $spacing-3
-                        span,
                         .campus-title
-                            display: block
+                            @include h6
                             margin: 0 // Cancel leaflet default style
-                            width: max-content
+                        span:last-child
+                            display: block
                     .media
                         aspect-ratio: 1
-                        display: block
-                        margin-bottom: 0
-                        order: 1
-                        width: $spacing-6
+                        height: auto
+                        width: columns(5)
+                        @include media-breakpoint-up(desktop)
+                            width: calc(var(--grid-gutter) + var(--column-width))
                         img
                             display: block
                             height: 100%

--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -65,13 +65,13 @@
         .location-title
             @include h3
 
-.campus-map
+.locations-map
     .map
         height: 300px
         z-index: 1
         @include media-breakpoint-up(desktop)
             height: 500px
-        > .campus,
+        > .location,
         .leaflet-popup-tip-container
             display: none
         .leaflet-tile-pane
@@ -91,18 +91,20 @@
                 color: var(--color-background)
                 height: 100%
                 margin: 0
-                width: columns(12) !important // corrige la width appliquée en js par leaflet
-                @include media-breakpoint-up(desktop)
+                width: columns(12) !important // overwrite leaflet js width
+                @include media-breakpoint-up(md)
+                    width: columns(5) !important
+                @include media-breakpoint-up(xl)
                     width: columns(4) !important
-                .campus
+                .location
                     align-items: stretch
                     display: flex
-                    .campus-content
+                    .location-content
                         @include meta
                         flex: 1
                         order: 2
                         padding: $spacing-2 $spacing-3
-                        .campus-title
+                        .location-title
                             @include h6
                             margin: 0 // Cancel leaflet default style
                         span:last-child
@@ -111,7 +113,9 @@
                         aspect-ratio: 1
                         height: auto
                         width: columns(5)
-                        @include media-breakpoint-up(desktop)
+                        @include media-breakpoint-up(md)
+                            width: columns(2)
+                        @include media-breakpoint-up(xl)
                             width: calc(var(--grid-gutter) + var(--column-width))
                         img
                             display: block

--- a/layouts/partials/locations/map.html
+++ b/layouts/partials/locations/map.html
@@ -1,16 +1,16 @@
 {{ $locations := .locations }}
 {{ $popup_opened := .popup_opened | default false }}
 
-<div class="campus-map">
+<div class="locations-map">
   <div class="map" data-open-popup="{{ $popup_opened }}" data-marker-icon="{{ "/assets/images/map-marker.svg" }}">
     {{ range $locations }}
       {{ if and .Params.contact_details.geolocation.longitude .Params.contact_details.geolocation.latitude }}
-        <article class="campus" data-longitude="{{ .Params.contact_details.geolocation.longitude }}" data-latitude="{{ .Params.contact_details.geolocation.latitude }}">
+        <article class="location" data-longitude="{{ .Params.contact_details.geolocation.longitude }}" data-latitude="{{ .Params.contact_details.geolocation.latitude }}">
           {{ $title := "" }}
           {{ if .Params.title }}
-            <div class="campus-content">
+            <div class="location-content">
               {{ $title = partial "PrepareHTML" .Params.title -}}
-              <p class="campus-title">
+              <p class="location-title">
                 {{- if and .Params.url .Params.with_link }}
                   <a href="{{ .Params.url }}" {{ if .external }} target="_blank" rel="noopener" {{ end }} title="{{ safeHTML (i18n "commons.link.blank_aria" (dict "Title" $title)) }}">
                 {{ end -}}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

- On avait un problème en mobile : quand le texte était trop long, ça dépassait de l'écran à cause du `min-width: min-content`: 
<img width="1174" alt="Capture d’écran 2024-10-09 à 12 33 18" src="https://github.com/user-attachments/assets/13a838e4-283a-4ddb-bf7c-b25ee9c58949">

J'ai testé sur Safari et ça a l'air d'aller, mais p-e que je n'ai pas toutes les clefs pour ce bug, re-test bienvenu !

- J'en ai profité pour remplacer "campus" par "location"

Aussi, le campus a été designé sans différence entre le titre (campus-title) et le reste du texte, est-ce qu'on ne pourrait pas rajouter un niveau au moins visuel pour accentuer le titre ?

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

http://localhost:1313/fr/campus/
http://localhost:1313/fr/campus/iut-bordeaux-montaigne/

## URL de test du site IUT de Bordeaux

http://localhost:1313/sites-formation/
http://localhost:1313/sites-formation/bordeaux-bastide/

## Screenshots

<img width="371" alt="Capture d’écran 2024-10-09 à 15 15 12" src="https://github.com/user-attachments/assets/26568b5e-30a8-4a2a-a901-643c20548d92">
<img width="373" alt="Capture d’écran 2024-10-09 à 14 30 40" src="https://github.com/user-attachments/assets/69344ef4-529d-4a4c-8950-b90167394ec0">