### PR TITLE
Passage en gras du nom d'un campus dans la carte

### DIFF
--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -107,7 +107,6 @@
                         .location-title
                             font-weight: bold
                             margin: 0 // Cancel leaflet default style
-                            text-transform: none
                         span:last-child
                             display: block
                     .media

--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -105,6 +105,7 @@
                         order: 2
                         padding: $spacing-2 $spacing-3
                         .location-title
+                            font-weight: bold
                             text-transform: none
                             margin: 0 // Cancel leaflet default style
                         span:last-child

--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -106,8 +106,8 @@
                         padding: $spacing-2 $spacing-3
                         .location-title
                             font-weight: bold
-                            text-transform: none
                             margin: 0 // Cancel leaflet default style
+                            text-transform: none
                         span:last-child
                             display: block
                     .media


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Ajout d'une distinction de style entre le nom d'un campus et sa localisation.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

http://localhost:1313/fr/campus/

## URL de test du site IUT de Bordeaux

http://localhost:1314/sites-formation/

## Screenshots
<img width="621" alt="Capture d’écran 2024-10-10 à 13 40 54" src="https://github.com/user-attachments/assets/ff8fa814-d79e-416a-8872-b96ebc37bff0">

<img width="540" alt="Capture d’écran 2024-10-10 à 13 39 05" src="https://github.com/user-attachments/assets/1efe17bd-2396-4d95-8953-60b50b1e27c8">


