### PR TITLE
[A11Y] Ajout d'une balise textuelle aux timeline horizontales

### DIFF
--- a/layouts/partials/blocks/templates/timeline/horizontal.html
+++ b/layouts/partials/blocks/templates/timeline/horizontal.html
@@ -8,6 +8,6 @@
       {{ .title | safeHTML }}
     {{ $heading_tag.close -}}
     <div class="line"></div>
-    <div class="description text" itemprop="text">{{- partial "PrepareHTML" .text | markdownify -}}</div>
+    <p class="description text" itemprop="text">{{- partial "PrepareHTML" .text | markdownify -}}</p>
   </article>
 {{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

<img width="615" alt="Capture d’écran 2024-10-10 à 16 02 35" src="https://github.com/user-attachments/assets/47e7920d-af8b-4d1d-8553-c46a83e86d7d">

**ATTENTION :** vérifier que ça ne bouge rien côté js

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

/fr/blocks/blocks-narratifs/frise/#frise-horizontal-avec-et-sans-texte
