### PR TITLE
Ajout d'un rel"=norreferer" aux liens externes des appels à action

### DIFF
--- a/layouts/partials/blocks/templates/call_to_action.html
+++ b/layouts/partials/blocks/templates/call_to_action.html
@@ -23,6 +23,7 @@
                       {{ if .target_blank }}
                         title="{{ i18n "commons.link.blank_aria" (dict "Title" $title) }}"
                         target="_blank"
+                        rel="noreferrer"
                       {{ else }}
                         title="{{ $title }}"
                       {{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Tout est dans le titre

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

Pb remonté par Lighthouse sur epv