### PR TITLE
Homogénéisation entre les backlinks et les indexs

### DIFF
--- a/layouts/partials/contents/backlinks.html
+++ b/layouts/partials/contents/backlinks.html
@@ -11,7 +11,7 @@
             "children" 3
           )
           "data" (dict
-            "layout" "grid"
+            "layout" site.Params.events.index.layout
             "events" .events
             "options" site.Params.events.index.options
           )
@@ -28,7 +28,7 @@
             "children" 3
           )
           "data" (dict 
-            "layout" "grid"
+            "layout" site.Params.pages.index.layout
             "options" ( dict
               "main_summary" false
               "summaries" true
@@ -68,7 +68,7 @@
             "children" 3
           )
           "data" (dict
-            "layout" "grid"
+            "layout" site.Params.posts.index.layout
             "posts" $posts
             "options" site.Params.posts.index.options
           )


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Arnaud a vu sur Communication Publique que ça n'avait pas trop de sens de se caler littéralement sur la maquette en imposant le layout grille. On utilise donc le layout des index (ce qu'on faisait déjà pour les projets).

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

http://localhost:1313/fr/equipe/magali-angles/

## URL de test du site [Communication Publique](https://github.com/osunyorg/communicationpublique-site)

http://localhost:1314/equipe/bruno-jeudy/
