### PR TITLE
Rich text dans les blocs de fonctionnalités et de définitions

### DIFF
--- a/layouts/partials/blocks/templates/definitions.html
+++ b/layouts/partials/blocks/templates/definitions.html
@@ -17,7 +17,7 @@
             {{ $id := printf "block-%d-element-%d" $block_index $index }}
             <details id="{{$id}}" itemscope itemtype="https://schema.org/DefinedTerm">
               <summary itemprop="name" aria-controls="#{{ $id }}" aria-expanded="false">{{ $element.title | safeHTML }}</summary>
-              <p itemprop="description">{{ $element.description | safeHTML }}</p>
+              <div itemprop="description">{{ partial "PrepareHTML" $element.description }}</div>
             </details>
           {{ end -}}
         </div>

--- a/layouts/partials/blocks/templates/features.html
+++ b/layouts/partials/blocks/templates/features.html
@@ -18,13 +18,13 @@
               <li>
                 <div>
                   {{- $heading_tag := partial "GetHeadingTag" (dict 
-                  "level" $block.ranks.children
-                  "attributes" "class='name' itemprop='name'"
+                      "level" $block.ranks.children
+                      "attributes" "class='name'"
                   ) -}}
                   {{ $heading_tag.open -}}
                     {{ .title | safeHTML }}
                   {{ $heading_tag.close -}}
-                  <p>{{ .description | safeHTML }}</p>
+                  <div>{{ partial "PrepareHTML" .description }}</div>
                 </div>
                 {{- if .image -}}
                   <figure role="figure" {{- with or .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Suite côté thème de la https://github.com/osunyorg/admin/pull/2149

J'utilise le partial `{{ partial "PrepareHTML" $element.description }}` pour récupérer le rich text envoyé dans ces blocs.

J'ai enlevé un `itemprop='name'` qui était seul sans balisage schema autre.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [X] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

Suite des PR https://github.com/osunyorg/theme/pull/582 et https://github.com/osunyorg/theme/pull/583.

## URL de test sur example.osuny.org

http://localhost:1313/fr/blocks/blocks-techniques/definitions/
http://localhost:1313/fr/blocks/blocks-narratifs/les-fonctionnalites/