### PR TITLE
Correction du sous-titre des événements

### DIFF
--- a/layouts/partials/events/event.html
+++ b/layouts/partials/events/event.html
@@ -20,7 +20,7 @@
         <a href="{{ .Permalink }}" title="{{ safeHTML (i18n "commons.more_aria" (dict "Title" $title)) }}">{{ $title }}</a>
       {{ $heading_tag.close }}
       {{ if and $options.subtitle .Params.subtitle }}
-          <p class="event-subtitle">{{ .Params.subtitle }}</p>
+          <p class="event-subtitle">{{ partial "PrepareText" .Params.subtitle }}</p>
         </hgroup>
       {{ end }}
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Le sous-titre n'était html safe.


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots

Avant : 

![image](https://github.com/user-attachments/assets/b9b07b6e-e88a-4981-9912-c3e6775fe462)


Après : 

![image](https://github.com/user-attachments/assets/dbe338fa-c7fe-460b-a3e0-e01a13421282)

