### PR TITLE
Ajout d'espace en bas d'une page diplôme avec block

### DIFF
--- a/assets/sass/_theme/sections/diplomas.sass
+++ b/assets/sass/_theme/sections/diplomas.sass
@@ -87,6 +87,8 @@ ul.diplomas
                 padding: $spacing-3
 
 .diplomas__term
+    .blocks + .container
+        margin-bottom: $spacing-6 // If blocks are present, add space before footer
     ol.programs
         li
             @include grid(2, desktop)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Ajout d'espace en bas d'une page diplôme avec block

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


## Screenshots

Avant : 

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/46dc1fd1-cfd2-4e2f-924c-eb557676db08">

Après : 

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/e4ece9bd-8815-49b6-8926-f0e3f0e33d9f">

