### PR TITLE
Ajout des formations enfantes à la présentation

### DIFF
--- a/layouts/partials/programs/presentation.html
+++ b/layouts/partials/programs/presentation.html
@@ -3,7 +3,7 @@
     <div class="content">
       <h2>{{ i18n "programs.toc.presentation" }}</h2>
 
-      {{ if or .Params.image .Params.presentation .Params.objectives }}
+      {{ if or .Params.image .Params.presentation .Params.objectives .Pages }}
         <div>
           {{- partial "programs/image.html" .Params.image -}}
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

La condition qui permet l'affichage de la partie "présentation" ne prennait pas en compte `.PAges` qui n'est vérifié qu'à l'intérieur. Elle n'était donc jamais affichée dans le cas où on n'a ni image, ni présentation, etc.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱