### PR TITLE
[A11Y] Masquer les icônes des lecteurs d'écran

### DIFF
--- a/assets/sass/_theme/blocks/title.sass
+++ b/assets/sass/_theme/blocks/title.sass
@@ -21,7 +21,6 @@
         @include icon(arrow-down-s-line, before)
             font-size: pxToRem(25)
             order: 2
-            speak: none
         // When collapse is closed
         &[aria-expanded="false"]
             &::after

--- a/assets/sass/_theme/utils/icons.sass
+++ b/assets/sass/_theme/utils/icons.sass
@@ -14,7 +14,7 @@
 
 @mixin icon($icon-name: '', $pseudo-element: before, $non-breaking: false)
     &::#{$pseudo-element}
-        content: map-get($icons, $icon-name)
+        content: map-get($icons, $icon-name) #{/ ""} // Add ‘ / ""‘ to hide from screen reader
         font-family: 'Icon'
         font-style: normal
         font-variant: normal

--- a/assets/sass/_theme/utils/icons.sass
+++ b/assets/sass/_theme/utils/icons.sass
@@ -14,7 +14,7 @@
 
 @mixin icon($icon-name: '', $pseudo-element: before, $non-breaking: false)
     &::#{$pseudo-element}
-        content: map-get($icons, $icon-name) #{/ ""} // Add ‘ / ""‘ to hide from screen reader
+        content: map-get($icons, $icon-name)  // Add ‘ / ""‘ to hide from screen reader
         font-family: 'Icon'
         font-style: normal
         font-variant: normal

--- a/assets/sass/_theme/utils/icons.sass
+++ b/assets/sass/_theme/utils/icons.sass
@@ -14,7 +14,7 @@
 
 @mixin icon($icon-name: '', $pseudo-element: before, $non-breaking: false)
     &::#{$pseudo-element}
-        content: map-get($icons, $icon-name)  // Add ‘ / ""‘ to hide from screen reader
+        content: map-get($icons, $icon-name) #{/ ""} // Add ‘ / ""‘ to hide from screen reader
         font-family: 'Icon'
         font-style: normal
         font-variant: normal


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Les lecteurs d'écran lisent le contenu des pseudo-elements. Comme nous nous appuyons sur des `::after` et `::before` pour afficher les icônes, nous devons ajouter au `content` la chaîne `/ ""` pour désactiver la lecture des icônes.

Source de la solution : https://www.sitelint.com/blog/hide-content-in-css-pseudo-elements-from-screen-readers

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


Avant : 

![image](https://github.com/user-attachments/assets/568c7822-11d6-4a02-8105-063dc647c043)

Après : 

![Capture d’écran 2024-10-22 à 11 42 57](https://github.com/user-attachments/assets/8ca2547c-91ec-44f4-8621-efb71608d70d)
