### PR TITLE
Présentation des programmes en rich text

### DIFF
--- a/layouts/partials/programs/presentation.html
+++ b/layouts/partials/programs/presentation.html
@@ -10,7 +10,7 @@
           {{- if partial "GetTextFromHTML" .Params.presentation -}}
             <section class="rich-text" id="{{ urlize (i18n "programs.presentation") }}">
               <h3>{{ i18n "programs.presentation" }}</h3>
-              <p>{{- partial "PrepareHTML" .Params.presentation -}}</p>
+              {{- partial "PrepareHTML" .Params.presentation -}}
             </section>
           {{- end -}}
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Suppression de la balise `p` pour supporter le rich text dans les présentations des formations.


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱



