### PR TITLE
Correction de la troncature des textes

### DIFF
--- a/layouts/partials/GetRichSummary
+++ b/layouts/partials/GetRichSummary
@@ -1,3 +1,13 @@
-{{ $length := default 150 (index site.Params .kind "index" "truncate_description") }}
-{{ $summary := .summary | safeHTML | truncate $length }}
-{{ $summary}}
+{{ $length := 150 }}
+{{ $option := index site.Params .kind "index" "truncate_description" }}
+
+{{ if eq (printf "%T" $option) "int" }}
+  {{ $length = $option }}
+{{ end }}
+
+{{ $summary := .summary | safeHTML }}
+{{ if gt $length 0 }}
+  {{ $summary = $summary | truncate $length }}
+{{ end }}
+
+{{ $summary }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

La valeur 0 dans la config pour ne pas tronquer les textes ne fonctionnait pas.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
