### PR TITLE
Ajout de l'option des sous-titres des projets dans la config

### DIFF
--- a/assets/sass/_theme/sections/projects.sass
+++ b/assets/sass/_theme/sections/projects.sass
@@ -7,7 +7,8 @@
             flex: 1
         p
             line-height: $small-line-height
-        .project-title
+        .project-title,
+        .project-subtitle
             @include article-title
         .project-subtitle
             color: var(--color-text-alt)
@@ -42,8 +43,10 @@
                     justify-content: space-between
                     .project-description
                         max-width: columns(6)
-                    .project-title
+                    .project-title,
+                    .project-subtitle
                         @include h2
+                    .project-title
                         @include icon(arrow-right-line, after, true)
                             color: transparent
                         @include hover-translate-icon(after)

--- a/config.yaml
+++ b/config.yaml
@@ -187,6 +187,7 @@ params:
         categories: true
         summary: true
         year: false
+        subtitle: true
     # share_links: # Optional
     #   enabled: true
     #   email: false

--- a/layouts/partials/projects/project.html
+++ b/layouts/partials/projects/project.html
@@ -28,7 +28,7 @@
           <a href="{{ .Permalink }}" itemprop="url" title="{{ safeHTML (i18n "commons.more_aria" (dict "Title" $title)) }}">{{ $title }}</a>
         {{ $heading_tag.close }}
         {{ if and $options.subtitle .Params.subtitle }}
-          <p class="project-subtitle h3">{{ partial "PrepareHTML" .Params.subtitle }}</p>
+          <p class="project-subtitle">{{ partial "PrepareHTML" .Params.subtitle }}</p>
         {{ end }}
         {{ if and $options.subtitle .Params.subtitle }}
           </hgroup>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Tout comme pour l'index des posts, l'index des projets n'avait pas l'option "subtitle" dans la config !
Il y avait aussi la class h3 qui était encore présente

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱