### PR TITLE
Correction du hero des formations

### DIFF
--- a/layouts/partials/programs/hero-essential.html
+++ b/layouts/partials/programs/hero-essential.html
@@ -7,12 +7,12 @@
         {{ $duration = $duration | default $diploma.Params.duration }}
       {{ end }}
       <dl class="essential">
-        {{ if $diploma }}
+        {{ with $diploma }}
           <dt>{{ i18n "programs.diploma" }}</dt>
-          <dd><a href="{{ .Permalink }}">{{ partial "PrepareHTML" $diploma.Title }}</a></dd>
-          {{- if $diploma.Params.level -}}
+          <dd><a href="{{ .Permalink }}">{{ partial "PrepareHTML" .Title }}</a></dd>
+          {{- if .Params.level -}}
             <dt>{{ i18n "programs.level" }}</dt>
-            <dd>{{ partial "PrepareHTML" $diploma.Params.level }}</dd>
+            <dd>{{ partial "PrepareHTML" .Params.level }}</dd>
           {{- end -}}
         {{- end -}}
         {{- with .Params.parent -}}

--- a/layouts/partials/programs/hero-essential.html
+++ b/layouts/partials/programs/hero-essential.html
@@ -1,36 +1,40 @@
 <div class="essential-container" id="#{{ urlize (i18n "programs.toc.essential") }}">
   <div class="container">
+    {{ $program := . }}
     {{ $parent := .Params.parent }}
-    {{ $locations := .Params.locations}}
-    {{- with .Params.diplomas -}}
-      {{- $diploma := site.GetPage (printf "/diplomas/%s" .) -}}
-      {{- with $diploma -}}
-        <dl class="essential">
-          <dt>{{ i18n "programs.diploma" }}</dt>
-          <dd><a href="{{ .Permalink }}">{{ partial "PrepareHTML" .Title }}</a></dd>
-          {{- if .Params.level -}}
-            <dt>{{ i18n "programs.level" }}</dt>
-            <dd>{{ partial "PrepareHTML" .Params.level }}</dd>
-          {{- end -}}
-          {{- with $parent -}}
-            <dt>{{ i18n "programs.mention" }}</dt>
-            <dd><a href="{{ .url }}">{{ partial "PrepareHTML" .title }}</a></dd>
-          {{- end -}}
-          {{- if .Params.duration -}}
-            <dt>{{ i18n "programs.duration" }}</dt>
-            <dd>{{ partial "PrepareHTML" .Params.duration }}</dd>
-          {{- end -}}
-          {{- with $locations -}}
-            <dt>{{ i18n "programs.location" ( len . ) }}</dt>
-            <dd>
-              {{- range . -}}
-                {{- $locationpage := site.GetPage ( printf "/locations/%s" .slug ) -}}
-                <a href="{{ .path }}">{{ $locationpage.Params.title }}</a>
-              {{- end -}}
-            </dd>
-          {{- end -}}
-        </dl>
-      {{- end -}}
+    {{ $locations := .Params.locations }}
+    {{ $duration := .Params.duration }}
+    {{ $diploma := site.GetPage (printf "/diplomas/%s" .Params.diplomas) }}
+    {{- if or $diploma $locations $parent $duration -}}
+      {{ if $diploma }}
+        {{ $duration = $duration | default $diploma.Params.duration }}
+      {{ end }}
+      <dl class="essential">
+        <dt>{{ i18n "programs.diploma" }}</dt>
+        <dd><a href="{{ .Permalink }}">{{ partial "PrepareHTML" .Title }}</a></dd>
+        {{- if and $diploma $diploma.Params.level -}}
+          <dt>{{ i18n "programs.level" }}</dt>
+          <dd>{{ partial "PrepareHTML" $diploma.Params.level }}</dd>
+        {{- end -}}
+        {{- with $parent -}}
+          <dt>{{ i18n "programs.mention" }}</dt>
+          <dd><a href="{{ .url }}">{{ partial "PrepareHTML" .title }}</a></dd>
+        {{- end -}}
+        {{- with $duration -}}
+          <dt>{{ i18n "programs.duration" }}</dt>
+          <dd>{{ partial "PrepareHTML" . }}</dd>
+        {{- end -}}
+        {{- with $locations -}}
+          <dt>{{ i18n "programs.location" ( len . ) }}</dt>
+          <dd>
+            {{- range . -}}
+              {{- $locationpage := site.GetPage ( printf "/locations/%s" .slug ) -}}
+              <a href="{{ .path }}">{{ $locationpage.Params.title }}</a>
+            {{- end -}}
+          </dd>
+        {{- end -}}
+      </dl>
+
     {{- end -}}
     
     <div class="buttons">

--- a/layouts/partials/programs/hero-essential.html
+++ b/layouts/partials/programs/hero-essential.html
@@ -7,11 +7,13 @@
         {{ $duration = $duration | default $diploma.Params.duration }}
       {{ end }}
       <dl class="essential">
-        <dt>{{ i18n "programs.diploma" }}</dt>
-        <dd><a href="{{ .Permalink }}">{{ partial "PrepareHTML" .Title }}</a></dd>
-        {{- if and $diploma $diploma.Params.level -}}
-          <dt>{{ i18n "programs.level" }}</dt>
-          <dd>{{ partial "PrepareHTML" $diploma.Params.level }}</dd>
+        {{ if $diploma }}
+          <dt>{{ i18n "programs.diploma" }}</dt>
+          <dd><a href="{{ .Permalink }}">{{ partial "PrepareHTML" $diploma.Title }}</a></dd>
+          {{- if $diploma.Params.level -}}
+            <dt>{{ i18n "programs.level" }}</dt>
+            <dd>{{ partial "PrepareHTML" $diploma.Params.level }}</dd>
+          {{- end -}}
         {{- end -}}
         {{- with .Params.parent -}}
           <dt>{{ i18n "programs.mention" }}</dt>

--- a/layouts/partials/programs/hero-essential.html
+++ b/layouts/partials/programs/hero-essential.html
@@ -1,11 +1,8 @@
 <div class="essential-container" id="#{{ urlize (i18n "programs.toc.essential") }}">
   <div class="container">
-    {{ $program := . }}
-    {{ $parent := .Params.parent }}
-    {{ $locations := .Params.locations }}
     {{ $duration := .Params.duration }}
     {{ $diploma := site.GetPage (printf "/diplomas/%s" .Params.diplomas) }}
-    {{- if or $diploma $locations $parent $duration -}}
+    {{- if or $diploma $duration .Params.parent .Params.locations -}}
       {{ if $diploma }}
         {{ $duration = $duration | default $diploma.Params.duration }}
       {{ end }}
@@ -16,7 +13,7 @@
           <dt>{{ i18n "programs.level" }}</dt>
           <dd>{{ partial "PrepareHTML" $diploma.Params.level }}</dd>
         {{- end -}}
-        {{- with $parent -}}
+        {{- with .Params.parent -}}
           <dt>{{ i18n "programs.mention" }}</dt>
           <dd><a href="{{ .url }}">{{ partial "PrepareHTML" .title }}</a></dd>
         {{- end -}}
@@ -24,7 +21,7 @@
           <dt>{{ i18n "programs.duration" }}</dt>
           <dd>{{ partial "PrepareHTML" . }}</dd>
         {{- end -}}
-        {{- with $locations -}}
+        {{- with .Params.locations -}}
           <dt>{{ i18n "programs.location" ( len . ) }}</dt>
           <dd>
             {{- range . -}}
@@ -34,7 +31,6 @@
           </dd>
         {{- end -}}
       </dl>
-
     {{- end -}}
     
     <div class="buttons">


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Actuellement le tableau "essentiel" d'une formation ne s'affiche que si un diplôme est associé à la formation. Un autre problème est que la formation affiche uniquement la durée du diplôme. 

La règle a appliquer : afficher toutes les informations disponibles (de formation et diplômes) dans ce tableau. Afficher la durée de la formation si elle est précisée, sinon afficher la durée du diplôme.


## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱
