### PR TITLE
Réparation de la timeline vertical en pleine largeur

### DIFF
--- a/assets/sass/_theme/blocks/timeline.sass
+++ b/assets/sass/_theme/blocks/timeline.sass
@@ -57,8 +57,6 @@
                 p
                     padding-left: var(--grid-gutter)
                     width: columns(7)
-                    &:first-child
-                        margin-left: columns(3)
 
     &--horizontal
         --min-title-height: 0px

--- a/assets/sass/_theme/blocks/timeline.sass
+++ b/assets/sass/_theme/blocks/timeline.sass
@@ -44,6 +44,7 @@
                 padding-left: 0
             .timeline-event
                 display: flex
+                align-items: baseline
                 &::before, &::after
                     left: columns(3)
                     margin-left: calc(var(--grid-gutter) / 2)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Suppression de l'espace trop large entre le point et le texte (effet de bord dû à la gestion du rich-text dans les timelines)

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

