### PR TITLE
Téléchargement de fichier avec le nom

### DIFF
--- a/layouts/partials/commons/download-link.html
+++ b/layouts/partials/commons/download-link.html
@@ -22,7 +22,7 @@
   {{ $title_with_size := printf "%s (%s)" $a11y_title $extension_with_size }}
   {{ $url := $file.url }}
   {{ if site.Params.keycdn }}
-    {{ $url = $file.direct_url }}
+    {{ $url = $file.download_url }}
   {{ end }}
   <a href="{{ $url }}" download="{{ partial "PrepareHTML" $file.name }}" target="_blank" title="{{ i18n "commons.link.download" (dict "Title" $title_with_size) }}">
     {{ $title }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

https://developer.mozilla.org/fr/docs/Web/HTML/Element/a#download

Les fichiers ne se téléchargent pas, mais s'ouvrent dans un nouvel onglet, et perdent leur nom.

On passe par l'app pour récupérer des fichiers avec leur nom.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/admin/pull/2384


## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


