### PR TITLE
Publications : affichage du titre de journal et de l'année

### DIFF
--- a/assets/sass/_theme/sections/publications.sass
+++ b/assets/sass/_theme/sections/publications.sass
@@ -82,6 +82,9 @@
     .hero
         h1, hgroup
             width: 100%
+            span + span
+                &::before
+                    content: ', '
     .document-content > .container
         @include media-breakpoint-up(desktop)
             @include grid

--- a/assets/sass/_theme/sections/publications.sass
+++ b/assets/sass/_theme/sections/publications.sass
@@ -29,13 +29,16 @@
     .publication-content
         display: flex
         flex-direction: column
-        .publication-authors
-            margin-bottom: space()
-            order: -1
         .publication-title
             a
                 @include stretched-link(after)
         .publication-meta
+            margin-bottom: space()
+            order: -1
+            * + *
+                &::before
+                    content: ', '
+        .publication-ref
             @include meta
             color: var(--color-text-alt)
             margin-top: $spacing-1
@@ -68,9 +71,9 @@
                 .publication-title
                     order: -1
                 .publication-title,
-                .publication-meta
+                .publication-ref
                     width: columns(8)
-                .publication-authors
+                .publication-meta
                     @include meta
                     margin-bottom: 0
                     flex: 1

--- a/layouts/partials/publications/hero-single.html
+++ b/layouts/partials/publications/hero-single.html
@@ -1,6 +1,19 @@
+{{ $subtitle := "" }}
+{{ if or .Params.journal_title .Params.date .Params.authors_list }}
+  {{- with .Params.journal_title -}}
+    {{ $subtitle = printf "<span>%s</span>" .}}
+  {{- end -}}
+  {{- with .Params.date -}}
+    {{ $subtitle = printf "%s<span>%s</span>" $subtitle ( .Format "2006" ) }}
+  {{- end -}}
+  {{- with .Params.authors_list -}}
+    {{ $subtitle = printf "%s<span>%s</span>" $subtitle . }}
+  {{- end -}}
+{{ end }}
+
 {{- partial "header/hero.html"
       (dict
         "title" .Title
-        "subtitle" (printf "<p>%s</p>" .Params.authors_list)
+        "subtitle" (partial "PrepareHTML" $subtitle)
         "context" .
       ) -}}

--- a/layouts/partials/publications/publication.html
+++ b/layouts/partials/publications/publication.html
@@ -16,17 +16,25 @@
         <a href="{{ .Permalink }}" title="{{ safeHTML (i18n "commons.more_aria" (dict "Title" $title)) }}">{{ $title }}</a>
       {{ $heading_tag.close }}
 
-      {{ with .Params.authors_list }}
-        <div class="publication-authors">
-          <span itemprop="author">{{ partial "PrepareHTML" . }}</span>
+      {{ if or .Params.journal_title .Params.date .Params.authors_list }}
+        <div class="publication-meta">
+          {{- with .Params.journal_title -}}
+            <span>{{ partial "PrepareHTML" . }}</span>
+          {{- end -}}
+          {{- with .Params.date -}}
+            <span>{{ .Format "2006" }}</span>
+          {{- end -}}
+          {{- with .Params.authors_list -}}
+            <span itemprop="author">{{ partial "PrepareHTML" . }}</span>
+          {{- end -}}
         </div>
       {{ end }}
 
       {{ with .Params.ref }}
-        <div class="publication-meta" itemprop="isPartOf" itemscope itemtype="http://schema.org/PublicationIssue">
+        <div class="publication-ref" itemprop="isPartOf" itemscope itemtype="http://schema.org/PublicationIssue">
           <span itemprop="name">{{ partial "PrepareHTML" . }}</span>
         </div>
       {{ end }}
     </div>
-  </article>  
+  </article>
 {{ end }}

--- a/layouts/publications/single.html
+++ b/layouts/publications/single.html
@@ -7,9 +7,11 @@
   <div class="container">
     <div class="document-sidebar">
       {{ partial "publications/researchers.html" . }}
-      <div class="paper-ref">
-        <p>{{ partial "PrepareHTML" .Params.ref }}</p>
-      </div>
+      {{ with .Params.ref }}
+        <div class="paper-ref">
+          <p>{{ partial "PrepareHTML" . }}</p>
+        </div>
+      {{ end }}
     </div>
     <div class="content">
       <div class="rich-text">


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Gestion et affichage du titre du journal et de l'année de publication.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots

<img width="1137" alt="image" src="https://github.com/user-attachments/assets/eaa30817-7494-4652-9137-89b891576af1">

<img width="1186" alt="image" src="https://github.com/user-attachments/assets/6c75ffc4-4e5b-47b7-b0e0-57d534890fc4">




