### PR TITLE
Bloc appel à action

### DIFF
--- a/assets/sass/_theme/blocks/call_to_action.sass
+++ b/assets/sass/_theme/blocks/call_to_action.sass
@@ -1,3 +1,8 @@
+// BUTTONS STYLE
+$button-selector: "a:first-child"
+@if $block-call-to-action-all-actions-as-buttons
+    $button-selector: "a"
+
 .block-call_to_action
     .top
         margin-bottom: 0
@@ -24,24 +29,25 @@
                     display: flex
                     flex-direction: column
             a
-                @include meta
-                @extend %underline-on-hover
-                color: $block-call-to-action-color
+                @if not $block-call-to-action-all-actions-as-buttons
+                    @include meta
+                    @extend %underline-on-hover
+                    text-decoration-color: alphaColor($block-call-to-action-color, 0.3)
+                    color: $block-call-to-action-color
                 margin-right: $spacing-3
                 margin-top: $spacing-3
                 display: inline-block
-                text-decoration-color: alphaColor($block-call-to-action-color, 0.3)
-                &:first-child
-                    --btn-background: #{$block-call-to-action-button-background}
-                    --btn-border: #{$block-call-to-action-button-border}
-                    --btn-color: #{$block-call-to-action-button-color}
-                    --btn-hover-background: #{$block-call-to-action-button-hover-background}
-                    --btn-hover-border: #{$block-call-to-action-button-hover-border}
-                    --btn-hover-color: #{$block-call-to-action-button-hover-color}
-                    --btn-min-width: #{columns(2)}
-                    @extend .button
                 &:last-child
                     margin-bottom: 0
+            #{$button-selector}
+                --btn-background: #{$block-call-to-action-button-background}
+                --btn-border: #{$block-call-to-action-button-border}
+                --btn-color: #{$block-call-to-action-button-color}
+                --btn-hover-background: #{$block-call-to-action-button-hover-background}
+                --btn-hover-border: #{$block-call-to-action-button-hover-border}
+                --btn-hover-color: #{$block-call-to-action-button-hover-color}
+                --btn-min-width: #{columns(2)}
+                @extend .button
         figure
             figcaption
                 @include meta
@@ -73,7 +79,7 @@
                     color: $block-call-to-action-accent-color
                     text-decoration-color: alphaColor($block-call-to-action-accent-color, 0.3)
             .actions
-                a:first-child
+                #{$button-selector}
                     --btn-background: #{$block-call-to-action-accent-button-background}
                     --btn-border: #{$block-call-to-action-accent-button-border}
                     --btn-color: #{$block-call-to-action-accent-button-color}

--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -27,7 +27,7 @@ $block-call-to-action-button-color: var(--color-background) !default
 $block-call-to-action-button-hover-background: var(--color-text-alt) !default
 $block-call-to-action-button-hover-border: pxToRem(1) solid $block-call-to-action-button-hover-background !default
 $block-call-to-action-button-hover-color: var(--color-background) !default
-$block-call-to-action-all-actions-as-buttons: true !default
+$block-call-to-action-all-actions-as-buttons: false !default
 
 $block-call-to-action-accent-background: var(--color-accent) !default
 $block-call-to-action-accent-color: var(--color-background) !default

--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -27,6 +27,7 @@ $block-call-to-action-button-color: var(--color-background) !default
 $block-call-to-action-button-hover-background: var(--color-text-alt) !default
 $block-call-to-action-button-hover-border: pxToRem(1) solid $block-call-to-action-button-hover-background !default
 $block-call-to-action-button-hover-color: var(--color-background) !default
+$block-call-to-action-all-actions-as-buttons: true !default
 
 $block-call-to-action-accent-background: var(--color-accent) !default
 $block-call-to-action-accent-color: var(--color-background) !default

--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -30,10 +30,11 @@
     &--list
         @include media-breakpoint-up(desktop)
             .location
-                border-bottom: 1px solid var(--color-border)
                 flex-direction: row-reverse
                 gap: var(--grid-gutter)
-                padding-bottom: $spacing-3
+                &:not(:last-child)
+                    border-bottom: 1px solid var(--color-border)
+                    padding-bottom: $spacing-3
                 + .location
                     margin-top: $spacing-3
                 &-content

--- a/layouts/partials/blocks/templates/contact.html
+++ b/layouts/partials/blocks/templates/contact.html
@@ -30,14 +30,14 @@
                       </span>
                       <br>
                     {{ end }}
-                    {{ if .city }}
-                      <span itemprop="addressLocality">
-                        {{ partial "PrepareHTML" .city }}
-                      </span>
-                    {{ end }}
                     {{ if .zipcode }}
                       <span itemprop="postalCode">
                         {{ partial "PrepareHTML" .zipcode }}
+                      </span>
+                    {{ end }}
+                    {{ if .city }}
+                      <span itemprop="addressLocality">
+                        {{ partial "PrepareHTML" .city }}
                       </span>
                     {{ end }}
                     {{ if .country }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout d'une configuration sass pour afficher tous les liens du bloc comme des boutons.

`$block-call-to-action-all-actions-as-buttons`

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


## Screenshots

![image](https://github.com/user-attachments/assets/e0160ad5-52a2-4ad6-97f3-275bac5d50fe)

![image](https://github.com/user-attachments/assets/623d48e2-2e71-4f2d-ab00-bfc1bb96104c)

