### PR TITLE
Fix upper menu

### DIFF
--- a/assets/sass/_theme/configuration/components.sass
+++ b/assets/sass/_theme/configuration/components.sass
@@ -56,6 +56,7 @@ $header-border-bottom-width: 1px !default
 $header-upper-menu-border-bottom-width: $header-border-bottom-width !default
 $header-upper-menu-padding-y: $header-nav-padding-y !default
 $header-upper-menu-padding-y-desktop: $header-upper-menu-padding-y !default
+$header-upper-menu-mobile-height: pxToRem(50) !default
 
 // Navs
 $body-overlay-color: rgba(0, 0, 0, 0.3) !default

--- a/assets/sass/_theme/design-system/header.sass
+++ b/assets/sass/_theme/design-system/header.sass
@@ -49,6 +49,61 @@ header#document-header
                 transition: filter $header-sticky-transition
             @include media-breakpoint-up(desktop)
                 height: $header-logo-height-desktop
+
+    // Top menu
+    .upper-menu
+        @include list-reset
+        @include meta
+        align-items: baseline
+        display: flex
+        justify-content: space-between
+        gap: $spacing-3
+        order: -1
+        position: relative
+        width: 100%
+        @include media-breakpoint-up(desktop)
+            justify-content: center
+            margin-top: -($header-nav-padding-y)
+            margin-bottom: $spacing-5
+            gap: $spacing-5
+            &::after
+                content: ''
+                border-bottom: $header-upper-menu-border-bottom-width solid var(--color-border)
+                bottom: -1px
+                left: var(--grid-gutter-negative)
+                position: absolute
+                right: var(--grid-gutter-negative)
+        @include media-breakpoint-down(desktop)
+            border-bottom: $header-upper-menu-border-bottom-width solid var(--color-border)
+            border-top: $header-upper-menu-border-bottom-width solid var(--color-border)
+            overflow-x: auto
+            scrollbar-width: none
+            &::-webkit-scrollbar
+                display: none
+        &.nav-level-1
+            a
+                text-decoration: none
+            li
+                line-height: 1
+                border: none
+            a,
+            span,
+            button
+                padding: 0
+                white-space: nowrap
+                padding-bottom: $spacing-2
+                padding-top: $spacing-2
+                &.active
+                    box-shadow: inset 0 -4px 0 0 var(--color-border)
+                @include media-breakpoint-up(desktop)
+                    padding-left: 0
+                    padding-right: 0
+                    padding-top: calc(#{$header-nav-padding-y} / 2)
+                    padding-bottom: $header-nav-padding-y
+            @include media-breakpoint-down(desktop)
+                padding-left: var(--grid-gutter)
+                padding-right: var(--grid-gutter)
+
     @include media-breakpoint-down(desktop)
         html.has-menu-opened &
             nav

--- a/assets/sass/_theme/design-system/header.sass
+++ b/assets/sass/_theme/design-system/header.sass
@@ -52,54 +52,57 @@ header#document-header
 
     // Top menu
     .upper-menu
-        @include list-reset
-        @include meta
-        align-items: baseline
-        display: flex
-        justify-content: space-between
-        gap: $spacing-3
-        order: -1
-        position: relative
-        width: 100%
-        @include media-breakpoint-up(desktop)
-            justify-content: center
-            margin-top: -($header-nav-padding-y)
-            margin-bottom: $spacing-5
-            gap: $spacing-5
-            &::after
-                content: ''
-                border-bottom: $header-upper-menu-border-bottom-width solid var(--color-border)
-                bottom: -1px
-                left: var(--grid-gutter-negative)
-                position: absolute
-                right: var(--grid-gutter-negative)
+        border-bottom: $header-upper-menu-border-bottom-width solid var(--color-border)
+        ul
+            @include list-reset
+            @include meta
+            display: flex
+            justify-content: space-between
+            gap: $spacing-3
+            width: 100%
+            @include media-breakpoint-up(desktop)
+                align-items: baseline
+                justify-content: center
+                gap: $spacing-5
+            // horizontal scroll for mobile
+            @include media-breakpoint-down(desktop)
+                height: $header-upper-menu-mobile-height
+                overflow-x: auto
+                scrollbar-width: none
+                &::-webkit-scrollbar
+                    display: none
         @include media-breakpoint-down(desktop)
-            border-bottom: $header-upper-menu-border-bottom-width solid var(--color-border)
             border-top: $header-upper-menu-border-bottom-width solid var(--color-border)
-            overflow-x: auto
-            scrollbar-width: none
-            &::-webkit-scrollbar
-                display: none
-        &.nav-level-1
+            display: none
+            padding-top: 0
+            position: absolute
+            top: var(--header-height)
+            width: 100%
+            html.has-menu-opened &
+                display: block
+                + nav
+                    .menu
+                        padding-top: $header-upper-menu-mobile-height
+        .nav-level-1
             a
                 text-decoration: none
             li
                 line-height: 1
                 border: none
+                @include media-breakpoint-down(desktop)
+                    height: 100%
             a,
             span,
             button
+                display: block
                 padding: 0
                 white-space: nowrap
-                padding-bottom: $spacing-2
-                padding-top: $spacing-2
+                @include media-breakpoint-up(desktop)
+                    padding: $header-upper-menu-padding-y 0
+                @include media-breakpoint-down(desktop)
+                    line-height: $header-upper-menu-mobile-height
                 &.active
                     box-shadow: inset 0 -4px 0 0 var(--color-border)
-                @include media-breakpoint-up(desktop)
-                    padding-left: 0
-                    padding-right: 0
-                    padding-top: calc(#{$header-nav-padding-y} / 2)
-                    padding-bottom: $header-nav-padding-y
             @include media-breakpoint-down(desktop)
                 padding-left: var(--grid-gutter)
                 padding-right: var(--grid-gutter)
@@ -108,9 +111,6 @@ header#document-header
         html.has-menu-opened &
             nav
                 padding-bottom: 0
-        .has-upper-menu
-            .menu .logo
-                display: none
 
 // TODO : Est-ce au bon endroit ?
 body
@@ -147,42 +147,17 @@ body
             opacity: 0
 
 header#document-header
-    nav
+    nav:not(.upper-menu)
         padding-bottom: $header-nav-padding-y
         padding-top: $header-nav-padding-y
-        &.upper-menu
-            padding-bottom: $header-upper-menu-padding-y
-            padding-top: $header-upper-menu-padding-y
         @include media-breakpoint-up(desktop)
             padding-bottom: $header-nav-padding-y-desktop
             padding-top: $header-nav-padding-y-desktop
-            &.upper-menu
-                padding-bottom: $header-upper-menu-padding-y-desktop
-                padding-top: $header-upper-menu-padding-y-desktop
         > .container
             align-items: center
             display: flex
             flex-wrap: wrap
             justify-content: space-between
-            // Upper menu : in dropdown in mobile | before logo/menu in desktop
-            &.has-upper-menu
-                @include media-breakpoint-up(desktop)
-                    .menu
-                        width: 100%
-                        display: flex
-                        flex-wrap: wrap
-                        justify-content: space-between
-                    > .logo
-                        display: none
-                @include media-breakpoint-down(desktop)
-                    .menu.is-opened
-                        display: flex
-                        flex-direction: column
-                        margin-left: var(--grid-gutter-negative)
-                        margin-right: var(--grid-gutter-negative)
-                        .nav-level-1:first-of-type
-                            margin-left: var(--grid-gutter)
-                            margin-right: var(--grid-gutter)
         .header-button
             @include button-reset
             border: 0

--- a/assets/sass/_theme/design-system/nav.sass
+++ b/assets/sass/_theme/design-system/nav.sass
@@ -203,60 +203,6 @@
         .nav-level-3
             padding-top: 0
 
-    // Top menu
-    .upper-menu
-        @include list-reset
-        @include meta
-        align-items: baseline
-        display: flex
-        justify-content: space-between
-        gap: $spacing-3
-        order: -1
-        position: relative
-        width: 100%
-        @include media-breakpoint-up(desktop)
-            justify-content: center
-            margin-top: -($header-nav-padding-y)
-            margin-bottom: $spacing-5
-            gap: $spacing-5
-            &::after
-                content: ''
-                border-bottom: $header-upper-menu-border-bottom-width solid var(--color-border)
-                bottom: -1px
-                left: var(--grid-gutter-negative)
-                position: absolute
-                right: var(--grid-gutter-negative)
-        @include media-breakpoint-down(desktop)
-            border-bottom: $header-upper-menu-border-bottom-width solid var(--color-border)
-            border-top: $header-upper-menu-border-bottom-width solid var(--color-border)
-            overflow-x: auto
-            scrollbar-width: none
-            &::-webkit-scrollbar
-                display: none
-        &.nav-level-1
-            a
-                text-decoration: none
-            li
-                line-height: 1
-                border: none
-            a,
-            span,
-            button
-                padding: 0
-                white-space: nowrap
-                padding-bottom: $spacing-2
-                padding-top: $spacing-2
-                &.active
-                    box-shadow: inset 0 -4px 0 0 var(--color-border)
-                @include media-breakpoint-up(desktop)
-                    padding-left: 0
-                    padding-right: 0
-                    padding-top: calc(#{$header-nav-padding-y} / 2)
-                    padding-bottom: $header-nav-padding-y
-            @include media-breakpoint-down(desktop)
-                padding-left: var(--grid-gutter)
-                padding-right: var(--grid-gutter)
-
 .share
     display: flex
     list-style: none

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -155,6 +155,7 @@ commons:
     label: Ouvrir / Fermer le menu
     legal: Menu pages légales
     main: Menu principal
+    upper: Menu d'accès rapide
     secondary: Menu secondaire
     social: Menu réseaux sociaux
     title: Menu

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -2,32 +2,30 @@
 {{ $upper_menu := partial "GetMenu" "upper-menu" }}
 
 <header id="document-header" role="banner">
-  <nav aria-label="{{ i18n "commons.menu.main" }}">
-    <div class="container {{ if $upper_menu.items -}} has-upper-menu {{- end }}">
-      {{ partial "header/logo.html" }}
-      {{ if $upper_menu.items }}
+  {{ if $upper_menu.items }}
+    <nav class="upper-menu" aria-label="{{ i18n "commons.menu.upper" }}">
         {{ partial "commons/menu.html" (dict
-            "class" "upper-menu"
             "context" .
             "ignore_externals" true
             "kind" "upper-menu"
             "level" 1
             "stop" 1
-        )}}
-      {{ end }}
+          )}}
+    </nav>
+  {{ end }}
+  <nav aria-label="{{ i18n "commons.menu.main" }}">
+    <div class="container">
+      {{ partial "header/logo.html" }}
       {{ if $primary.items }}
         {{ partial "header/button.html" }}
         <div class="menu" id="navigation">
-          {{ if $upper_menu.items }}
-            {{ partial "header/logo.html" }}
-          {{ end }}
           {{ partial "commons/menu.html"
               (dict
                 "kind" "primary"
                 "dropdown" true
                 "level" 1
                 "context" .
-          )}}
+            )}}
         </div>
       {{ end }}
     </div>

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -5,6 +5,16 @@
   <nav aria-label="{{ i18n "commons.menu.main" }}">
     <div class="container {{ if $upper_menu.items -}} has-upper-menu {{- end }}">
       {{ partial "header/logo.html" }}
+      {{ if $upper_menu.items }}
+        {{ partial "commons/menu.html" (dict
+            "class" "upper-menu"
+            "context" .
+            "ignore_externals" true
+            "kind" "upper-menu"
+            "level" 1
+            "stop" 1
+        )}}
+      {{ end }}
       {{ if $primary.items }}
         {{ partial "header/button.html" }}
         <div class="menu" id="navigation">
@@ -18,28 +28,7 @@
                 "level" 1
                 "context" .
           )}}
-          {{ if $upper_menu.items }}
-            {{ partial "commons/menu.html" (dict
-                "class" "upper-menu"
-                "context" .
-                "ignore_externals" true
-                "kind" "upper-menu"
-                "level" 1
-                "stop" 1
-            )}}
-          {{ end }}
         </div>
-      {{ else }}
-        {{ if $upper_menu.items }}
-          {{ partial "commons/menu.html" (dict
-              "class" "upper-menu"
-              "context" .
-              "ignore_externals" true
-              "kind" "upper-menu"
-              "level" 1
-              "stop" 1
-          )}}
-        {{ end }}
       {{ end }}
     </div>
   </nav>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Le upper menu présentait plusieurs problèmes, et surtout une complexité d'intégration dont on se passe volontiers.

1. J'ai sorti l'appel du partial `menu.html` de la nav principale, mais je l'ai laissé dans le header → j'ai ajouté un aria-label avec une locale `upper: Menu d'accès rapide`, si c'est validé j'ajoute l'anglais.
2. En desktop rien de sorcier, c'est en mobile qu'on doit ruser : on ajoute une variable de hauteur fixe (pas d'importance car les liens sont en `nowrap` via la variable `$header-upper-menu-mobile-height`), ça nous permet d'ajouter un padding au `.menu` dans la nav principale en mobile, tout en utilisant `var(--header-height)` pour placer notre upper menu entre les logos/boutons et le menu.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

Pour tester, créer un `upper-menu.yml` avec ceci : 
```
---
title: Upper menu
items:
- title: Offre de formation
  target: "/fr/offre-de-formation/"
  kind: page
  children: []
- title: Actualités
  target: "/fr/actualites/"
  kind: page
  children: []
- title: Équipe pédagogique
  target: "/fr/equipe/equipe-pedagogique/"
  kind: page
  children: []
- title: Projets
  target: "/fr/projets/"
  kind: page
  children: []
```

## Screenshots
![Capture d’écran 2024-11-08 à 11 10 16](https://github.com/user-attachments/assets/285e3bd0-c352-431c-8fa7-7bf79f7c65b0)
![Capture d’écran 2024-11-08 à 11 10 53](https://github.com/user-attachments/assets/4522a80d-639b-4509-a2cd-539fc9cf461b)