### PR TITLE
Retrait du `role="figure"` des figures sans contenu textuel (crédit, alt ou texte)

### DIFF
--- a/layouts/partials/blocks/templates/call_to_action.html
+++ b/layouts/partials/blocks/templates/call_to_action.html
@@ -35,7 +35,7 @@
             {{- end -}}
           </div>
           {{ if .image }}
-            <figure role="figure" {{- with or .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>
+            <figure {{- with or .alt .credit }} role="figure" aria-label="{{ . | plainify }}" {{ end }}>
               {{ partial "commons/image.html"
                 (dict
                   "image"    .image.file

--- a/layouts/partials/blocks/templates/features.html
+++ b/layouts/partials/blocks/templates/features.html
@@ -27,7 +27,7 @@
                   <div>{{ partial "PrepareHTML" .description }}</div>
                 </div>
                 {{- if .image -}}
-                  <figure role="figure" {{- with or .alt .credit }} aria-label="{{ . | plainify }}" {{ end }}>
+                  <figure {{- with or .alt .credit }} role="figure" aria-label="{{ . | plainify }}" {{ end }}>
                     {{- partial "commons/image.html"
                       (dict
                         "image"    .image

--- a/layouts/partials/blocks/templates/testimonials/single.html
+++ b/layouts/partials/blocks/templates/testimonials/single.html
@@ -1,4 +1,4 @@
-<figure class="testimonial {{ if .params.photo }}with-picture{{ end }}">
+<figure class="testimonial {{ if .params.photo }}with-picture{{ end }}" {{ with .params.author -}} role="figure" aria-label="{{ . }}" {{- end }}>
   {{ with .params }}
     {{ $is_long := gt (len .text) 150 }}
     <blockquote {{- if $is_long }} class="is-long" {{- end }}>

--- a/layouts/partials/organizations/logo.html
+++ b/layouts/partials/organizations/logo.html
@@ -3,7 +3,7 @@
   {{ if site.Params.organizations.dark_logo_background }}
     {{ $logo_index = "logo_on_dark_background" }}
   {{ end }}
-  <figure class="organization-logo">
+  <figure class="organization-logo" {{ with .Title -}} role="figure" aria-label="{{ . }}" {{- end }}>
     {{- partial "commons/image.html"
         (dict
           "image"    (index .Params $logo_index)

--- a/layouts/partials/programs/image.html
+++ b/layouts/partials/programs/image.html
@@ -1,5 +1,5 @@
 {{ if . }}
-  <figure {{ with partial "GetTextFromHTML" .credit }} role="figure" aria-label="{{ . }}"{{ end }} class="featured-image">
+  <figure {{ with .credit }} role="figure" aria-label="{{ . | plainify }}"{{ end }} class="featured-image">
     {{ partial "commons/image.html"
           (dict
             "image"    .

--- a/layouts/partials/programs/image.html
+++ b/layouts/partials/programs/image.html
@@ -1,5 +1,5 @@
 {{ if . }}
-  <figure role="figure" class="featured-image">
+  <figure {{ with partial "GetTextFromHTML" .credit }} role="figure" aria-label="{{ . }}"{{ end }} class="featured-image">
     {{ partial "commons/image.html"
           (dict
             "image"    .
@@ -7,8 +7,8 @@
             "itemprop" true
             "crop"     true
           )}}
-    {{ if partial "GetTextFromHTML" .credit }}
-      <figcaption class="credit">{{ partial "PrepareHTML" .credit }}</figcaption>
+    {{ with partial "GetTextFromHTML" .credit }}
+      <figcaption class="credit">{{ . }}</figcaption>
     {{ end }}
   </figure>
 {{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Suite du contre-audit d'accessibilité fait par Temesis → https://github.com/osunyorg/theme/issues/699

On enlève le `role="figure"` aux `<figure>` qui n'ont pas de contenu textuel.

J'ai par ailleurs rajouté les roles et aria-label aux figures où cela manquait.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/699

## URL de test sur example.osuny.org

http://localhost:63556/fr/blocks/blocks-narratifs/
http://localhost:63556/fr/organisations/degrowth-journal/
http://localhost:63556/fr/blocks/blocks-narratifs/temoignages/