### PR TITLE
Search : fix de la fermeture avec le bouton et de l'overlay

### DIFF
--- a/assets/js/theme/design-system/search.js
+++ b/assets/js/theme/design-system/search.js
@@ -2,7 +2,7 @@
 import { focusTrap } from '../utils/focus-trap';
 
 const CLASSES = {
-    modalOpened: 'has-modal-opened'
+    modalOpened: 'has-search-opened'
 };
 
 class Search {
@@ -97,8 +97,10 @@ class Search {
             message = this.element.querySelector('.pagefind-ui__message'),
             results = this.element.querySelector('.pagefind-ui__results');
 
-        this.input.value = '';
-        this.searchInstance.triggerSearch(false);
+        if (this.input) {
+            this.input.value = '';
+            this.searchInstance.triggerSearch(false);
+        }
 
         if (message) {
             message.innerText = '';

--- a/assets/sass/_theme/design-system/header.sass
+++ b/assets/sass/_theme/design-system/header.sass
@@ -34,7 +34,7 @@ header#document-header
     &.is-sticky
         .pagefind-ui__toggle
             color: $header-sticky-color
-    html.is-scrolling-down:not(.has-menu-opened, .has-modal-opened) &
+    html.is-scrolling-down:not(.has-menu-opened, .has-modal-opened, .has-search-opened) &
         @include media-breakpoint-down(desktop)
             transform: translateY(-100%)
         @include media-breakpoint-up(desktop)
@@ -136,6 +136,7 @@ body
 
     html.has-menu-opened &,
     html.has-modal-opened &,
+    html.has-offcanvas-opened &,
     html.has-offcanvas-opened &
         overflow: hidden
         height: 100%


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

2 soucis : 
- L'overlay prend le dessus à cause du z-index du header → j'ai ajouté une class `has-search-opened` pour ne pas dépendre des autres (auparavant c'était `has-modal-opened`, mais le z-index est trop haut).
- Plus possible de fermer la recherche avec le bouton "Fermer" → Il manquait une vérification de présence/absence du bouton, qui ne peut être détecté directement comme PageFind charge au compte goutte le dom)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱