### PR TITLE
Date des événements : correction

### DIFF
--- a/assets/sass/_theme/sections/events.sass
+++ b/assets/sass/_theme/sections/events.sass
@@ -85,20 +85,21 @@
         margin-top: $spacing-2
         display: flex
         flex-wrap: wrap
+        column-gap: $spacing-1
         position: relative
         z-index: 2
-        li + li
-            &::before
+        li:not(:last-child)
+            a::after
                 content: ', '
     &-schedule
         p + p
             margin-top: 0
     &-dates
-        > span:first-child
-            span + span
-                &::before
-                    content: ' — '
+        span + span
+            &::before
+                content: ' — '
     &-time
+        @include meta
         span
             white-space: nowrap
             + span
@@ -110,12 +111,6 @@
             display: none
         img
             display: block
-    @include media-breakpoint-down(desktop)
-        &-time
-            display: inline-flex
-            &::before
-                content: ' |'
-                margin-right: $spacing-1
     @include media-breakpoint-up(desktop)
         &-time
             display: flex
@@ -131,10 +126,8 @@
             position: relative
             &-title
                 @include h3
-            &-dates
+            &-schedule
                 @include h4
-                margin-top: $spacing-1
-                margin-bottom: $spacing-2
             &-content
                 order: 2
             @include media-breakpoint-down(desktop)
@@ -165,28 +158,26 @@
                 .media
                     order: 2
             @include in-page-without-sidebar
-                &-content
-                    width: columns(10)
+                &-schedule
+                    margin-bottom: $spacing-3
                 &-dates
-                    margin-top: 0
-                    order: 0
-                    grid-column: 1 / 5
-                    > span
-                        @include h3
-                        margin-bottom: $spacing-3
-                        span
-                            display: block
+                    @include h3
+                    span
+                        display: block
+                        + span
+                            &::before
+                                display: none
                 &-time
                     margin-top: $spacing-2
-                    @include meta
                 &-content
                     @include grid(10, desktop, 0)
                     order: 1
                     grid-column: 1 / 11
+                    width: columns(10)
                     > .event-title, > hgroup, .event-description, .event-categories, .event-status
                         grid-column: 5 / 11
-                    > .event-dates
-                        grid-column: 0 / 5
+                    > .event-schedule
+                        grid-column: 1 / 5
                         grid-row: 1 / 4
                 .media
                     width: columns(2)
@@ -196,6 +187,9 @@
                     order: 1
                     grid-column: 6 span
                     margin-top: $spacing-1
+                &-schedule
+                    margin-top: $spacing-1
+                    margin-bottom: $spacing-2
                 &-time
                     display: inline
                 .media
@@ -207,7 +201,7 @@
             display: flex
             flex-direction: column
             position: relative
-            &-dates
+            &-schedule
                 @include meta
                 margin-top: $spacing-2
             &-content

--- a/assets/sass/_theme/sections/events.sass
+++ b/assets/sass/_theme/sections/events.sass
@@ -90,11 +90,21 @@
         li + li
             &::before
                 content: ', '
+    &-schedule
+        p + p
+            margin-top: 0
+    &-dates
+        > span:first-child
+            span + span
+                &::before
+                    content: ' — '
     &-time
-        span + span
-            @include icon(arrow-right-line, before)
-                margin-left: space()
-                margin-right: space()
+        span
+            white-space: nowrap
+            + span
+                @include icon(arrow-right-line, before)
+                    margin-left: space()
+                    margin-right: space()
     .media
         &:empty
             display: none
@@ -164,6 +174,8 @@
                     > span
                         @include h3
                         margin-bottom: $spacing-3
+                        span
+                            display: block
                 &-time
                     margin-top: $spacing-2
                     @include meta
@@ -186,8 +198,6 @@
                     margin-top: $spacing-1
                 &-time
                     display: inline
-                    &::before
-                        content: ' — '
                 .media
                     grid-column: 2 span
 
@@ -259,7 +269,7 @@
                     margin-top: var(--grid-gutter)
                 .media
                     width: columns(4)
-                .event-dates
+                .event-schedule
                     margin-bottom: $spacing-4
             @include media-breakpoint-down(desktop)
                 flex-direction: column

--- a/config.yaml
+++ b/config.yaml
@@ -57,7 +57,11 @@ params:
         options: false # You can set options for programs layout (see programs.index.options)
   events:
     default_image: false
-    date_format: ":date_long"
+    # date_format: "01.02" # You can add date format to override the date from static (two_lines) 
+    # time_format: "3:04 pm" # You can add time format to override the time from static (from.hour & to.hour)
+    # date_format: false # You can add date format to override the date from static (two_lines) 
+    # time_format: false # You can add time format to override the time from static (from.hour & to.hour)
+    
     index:
       truncate_description: 200 # Set to 0 to disable truncate
       layout: list # grid | list

--- a/config.yaml
+++ b/config.yaml
@@ -57,11 +57,8 @@ params:
         options: false # You can set options for programs layout (see programs.index.options)
   events:
     default_image: false
-    # date_format: "01.02" # You can add date format to override the date from static (two_lines) 
-    # time_format: "3:04 pm" # You can add time format to override the time from static (from.hour & to.hour)
-    # date_format: false # You can add date format to override the date from static (two_lines) 
-    # time_format: false # You can add time format to override the time from static (from.hour & to.hour)
-    
+    date_format: false # You can add date format to override the date from static (two_lines) 
+    time_format: false # You can add time format to override the time from static (from.hour & to.hour)
     index:
       truncate_description: 200 # Set to 0 to disable truncate
       layout: list # grid | list

--- a/layouts/partials/events/event.html
+++ b/layouts/partials/events/event.html
@@ -24,34 +24,50 @@
         </hgroup>
       {{ end }}
 
-      {{ if and $options.dates (or .Params.dates.computed.short .Params.dates.computed.two_lines.short .Params.dates.from.hour .Params.dates.to.hour) }}
-        <p class="event-dates" itemprop="startDate" content="{{- if .Params.dates.from.day -}}{{ .Params.dates.from.day }}{{- end -}}{{- if .Params.dates.from.hour -}}T{{ .Params.dates.from.hour }}{{- end -}}">
-          <span>
-            {{ $date_format := .Params.dates.computed.two_lines.short }}
+      {{ $dates := .Params.dates }}
+      {{ if and $options.dates (or $dates.computed.short $dates.computed.two_lines.short $dates.from.hour $dates.to.hour) }}
+        <div class="event-schedule" itemprop="startDate" content="{{- if $dates.from.day -}}{{ $dates.from.day }}{{- end -}}{{- if $dates.from.hour -}}T{{ $dates.from.hour }}{{- end -}}">
+          <p class="event-dates">
+            {{ $formated_date := $dates.computed.two_lines.short }}
             {{ if ne $layout "list" }}
-              {{ $date_format = .Params.dates.computed.short }}
+              {{ $formated_date = $dates.computed.short }}
             {{ end }}
-            {{ partial "PrepareHTML" $date_format }}
-          </span>
-          {{- if (or .Params.dates.from.hour .Params.dates.to.hour) }}
-            <div class="event-time">
-              {{- if .Params.dates.from.hour }}
-                <span>{{ .Params.dates.from.hour }}</span>
+            {{ with site.Params.events.date_format }}
+              {{ $formated_date = time.Format . $dates.from.day }}
+              {{ if ne $dates.from.day $dates.to.day }}
+                {{ $formated_date = printf "<span>%s</span><span>%s</span>" $formated_date ( time.Format . $dates.to.day ) }}
+              {{ end }}
+            {{ end }}
+            {{ partial "PrepareHTML" $formated_date }}
+          </p>
+          {{- if (or $dates.from.hour $dates.to.hour) }}
+            <p class="event-time">
+              {{ $hour := "" }}
+              {{- with $dates.from.hour }}
+                {{ $hour = . }}
+                {{ with site.Params.events.time_format }}
+                  {{ $hour = time.Format . (printf "2021-09-01T%s:00" $hour) }}
+                {{ end }}
+                <span>{{ $hour }}</span>
               {{ end -}}
-              {{- if .Params.dates.to.hour }}
-                <span>{{ .Params.dates.to.hour }}</span>
+              {{- with $dates.to.hour }}
+              {{ $hour = . }}
+              {{ with site.Params.events.time_format }}
+                  {{ $hour = time.Format . (printf "2021-09-01T%s:00" $hour) }}
+                {{ end }}
+                <span>{{ $hour }}</span>
               {{ end -}}
-            </div>
+            </p>
           {{ end -}}
-        </p>
+        </div>
       {{ end }}
-      {{ if and .Params.dates.status $options.status }}
+      {{ if and $dates.status $options.status }}
         <p class="event-status">
-          {{ if eq .Params.dates.status "current"}}
+          {{ if eq $dates.status "current"}}
             {{- i18n "blocks.events.current" -}}
-          {{ else if eq .Params.dates.status "future" }}
+          {{ else if eq $dates.status "future" }}
             {{- i18n "blocks.events.future" -}}
-          {{ else if eq .Params.dates.status "archive" }}
+          {{ else if eq $dates.status "archive" }}
             {{- i18n "blocks.events.archive" -}}
           {{ end }}
         </p>

--- a/layouts/partials/events/event.html
+++ b/layouts/partials/events/event.html
@@ -41,21 +41,21 @@
             {{ partial "PrepareHTML" $formated_date }}
           </p>
           {{- if (or $dates.from.hour $dates.to.hour) }}
+            {{- $hour := "" -}}
             <p class="event-time">
-              {{ $hour := "" }}
-              {{- with $dates.from.hour }}
-                {{ $hour = . }}
-                {{ with site.Params.events.time_format }}
-                  {{ $hour = time.Format . (printf "2021-09-01T%s:00" $hour) }}
-                {{ end }}
-                <span>{{ $hour }}</span>
-              {{ end -}}
-              {{- with $dates.to.hour }}
-              {{ $hour = . }}
-              {{ with site.Params.events.time_format }}
-                  {{ $hour = time.Format . (printf "2021-09-01T%s:00" $hour) }}
-                {{ end }}
-                <span>{{ $hour }}</span>
+              {{ with $dates.from.hour }}
+                {{- $hour = . -}}
+                {{- with site.Params.events.time_format }}
+                  {{- $hour = time.Format . (printf "2021-09-01T%s:00" $hour) -}}
+                {{ end -}}
+                <span>{{- $hour -}}</span>
+              {{- end -}}
+              {{- with $dates.to.hour -}}
+                {{- $hour = . -}}
+                {{- with site.Params.events.time_format -}}
+                  {{- $hour = time.Format . (printf "2021-09-01T%s:00" $hour) -}}
+                {{- end -}}
+                <span>{{- $hour -}}</span>
               {{ end -}}
             </p>
           {{ end -}}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Correction du HTML des dates dans les événements. Ajout d'une configuration des formats des dates et heures.

```
events:
    date_format: false # You can add date format to override the date from static (two_lines) 
    time_format: false # You can add time format to override the time from static (from.hour & to.hour)
 ```

## Niveau d'incidence

- [ ] Incidence faible 😌
- [X] Incidence moyenne 😲
- [ ] Incidence forte 😱


