### PR TITLE
Visionneuse : ajustements

### DIFF
--- a/assets/js/theme/design-system/Popup.js
+++ b/assets/js/theme/design-system/Popup.js
@@ -40,9 +40,8 @@ window.osuny.Popup.prototype = {
         }.bind(this));
     },
 
-    toggle (open, triggerElement) {
-        var classAction,
-            closeEvent = new Event('extendable-close');
+    toggle: function (open, triggerElement) {
+        var classAction;
         this.state.opened = typeof open !== 'undefined' ? open : !this.state.opened;
         classAction = this.state.opened ? 'add' : 'remove';
 
@@ -52,10 +51,7 @@ window.osuny.Popup.prototype = {
         this.element.classList[classAction](CLASSES.popupIsOpened);
 
         if (!this.state.opened) {
-            // Close extendables boxes
-            this.extendables.forEach(function (extendable) {
-                extendable.dispatchEvent(closeEvent);
-            });
+            this.closeExtendables();
         }
 
         this.updateDocumentAccessibility();
@@ -69,6 +65,14 @@ window.osuny.Popup.prototype = {
         if (!this.state.opened && this.lastTriggerElement) {
             this.lastTriggerElement.focus();
         }
+    },
+
+    closeExtendables: function () {
+        // Close extendables boxes
+        var closeEvent = new Event('extendable-close');
+        this.extendables.forEach(function (extendable) {
+            extendable.dispatchEvent(closeEvent);
+        });
     },
 
     updateDocumentAccessibility: function () {

--- a/assets/js/theme/design-system/lightbox.js
+++ b/assets/js/theme/design-system/lightbox.js
@@ -103,6 +103,7 @@ window.osuny.Lightbox.prototype._clear = function () {
 
     setButtonEnability(this.contentElements.previousButton, false);
     setButtonEnability(this.contentElements.nextButton, false);
+    this.closeExtendables();
 };
 
 window.osuny.Lightbox.prototype._update = function (data) {

--- a/assets/sass/_theme/components/lightbox.sass
+++ b/assets/sass/_theme/components/lightbox.sass
@@ -46,9 +46,13 @@
             &.lightbox-button-credit
                 &::before
                     content: '©' / ''
+                &:disabled
+                    display: none
             &.lightbox-button-information
                 &::before
                     content: 'i' / ''
+                &:disabled
+                    display: none
             &.lightbox-button-close
                 @include icon(close-line, before)
             &[aria-expanded='true']

--- a/assets/sass/_theme/components/lightbox.sass
+++ b/assets/sass/_theme/components/lightbox.sass
@@ -16,11 +16,13 @@
         display: flex
         height: 100%
         width: 100%
+        pointer-events: none
         img
             display: block
             margin: auto
             max-height: 100%
             outline-color: $lightbox-focus-outline-color
+            pointer-events: auto
     &-controls
         bottom: $spacing-2
         display: flex


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Fermeture de la visionneuse en cliquant sur le fond.
Masquage des boutons "crédits" et "informations" si le contenu n'est pas renseigné pour l'image courante.
Fermeture des petites popup lors du changement de slide.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

