### PR TITLE
Masquer les signatures lorsqu'elles n'ont pas d'auteur ou autrice

### DIFF
--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -18,7 +18,7 @@
 
     {{ partial "posts/after-contents.html" . }}
 
-    {{ if site.Params.posts.single.author_signature }}
+    {{ if and site.Params.posts.single.author_signature .Params.authors }}
       {{ partial "posts/signature.html" . }}
     {{ end }}
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

On a une vérification de l'affichage ou non du système de signature, mais pas de la vérification de la présence d'un auteur ou d'une autrice, ce qui donne ça lorsqu'il n'y en a pas :

![Capture d’écran 2024-11-18 à 17 24 52](https://github.com/user-attachments/assets/6b9d0149-07c7-4299-8001-4e1c0ab513b9)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
## URL de test sur example.osuny.org

## URL de test

Sur CIDS : http://localhost:1313/about/news/2024-09-25-mids-alumni-scholarship-fund/
Sur MIDS : http://localhost:1315/posts/2024-10-31-mids-2025-2026-applications-open/

## Screenshots

![Capture d’écran 2024-11-18 à 17 25 01](https://github.com/user-attachments/assets/8e496617-27d3-4d3e-98a9-6eec06d62738)

![Capture d’écran 2024-11-18 à 17 25 05](https://github.com/user-attachments/assets/05a3a503-35c0-49ee-9662-06342ffb83f0)