### PR TITLE
Faire chasser les longs liens dans les publications

### DIFF
--- a/assets/sass/_theme/sections/publications.sass
+++ b/assets/sass/_theme/sections/publications.sass
@@ -93,6 +93,8 @@
             grid-column: 1 / 9
         .document-sidebar
             margin-bottom: $spacing-5
+            .paper-ref p
+                word-break: break-all
             @include media-breakpoint-up(desktop)
                 grid-column: 9 / 13
                 order: 2


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

On a un petit souci d'affichage lorsque la donnée envoie un ensemble de données super long, ça casse le site en dessous du format desktop.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

#712 

## URL de test sur IUT Bordeaux Montaigne

`http://localhost:1313/notre-institut/recherche/publications/2023-cosma/`

## Screenshots

<img width="1469" alt="Capture d’écran 2024-11-18 à 18 34 39" src="https://github.com/user-attachments/assets/a16ac364-d39f-4f44-9879-2d43944e93b3">
<img width="373" alt="Capture d’écran 2024-11-18 à 18 34 30" src="https://github.com/user-attachments/assets/1f633d2e-9796-44f6-a063-4fb5f2ad6404">
