### PR TITLE
Visionneuse : bloquer le scroll

### DIFF
--- a/assets/js/theme/design-system/Popup.js
+++ b/assets/js/theme/design-system/Popup.js
@@ -1,7 +1,7 @@
 import { focusTrap } from '../utils/focus-trap';
 
 var CLASSES = {
-    popupOpened: 'has-popup-opened',
+    popupOpened: 'has-modal-opened',
     popupIsOpened: 'is-opened'
 };
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Empêcher le scroll quand la visionneuse est ouverte.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
