### PR TITLE
Ajout de variables dans le upper menu

### DIFF
--- a/assets/sass/_theme/configuration/components.sass
+++ b/assets/sass/_theme/configuration/components.sass
@@ -54,7 +54,9 @@ $header-height-desktop: 96px !default
 $header-sticky-invert-logo: false !default
 $header-border-bottom-width: 1px !default
 $header-upper-menu-background: $header-background !default
+$header-upper-menu-color: $header-color !default
 $header-upper-menu-sticky-background: $header-sticky-background !default
+$header-upper-menu-sticky-color: $header-sticky-color !default
 $header-upper-menu-border-bottom-width: $header-border-bottom-width !default
 $header-upper-menu-padding-y: $header-nav-padding-y !default
 $header-upper-menu-padding-y-desktop: $header-upper-menu-padding-y !default

--- a/assets/sass/_theme/design-system/header.sass
+++ b/assets/sass/_theme/design-system/header.sass
@@ -56,6 +56,8 @@ header#document-header
         border-bottom: $header-upper-menu-border-bottom-width solid var(--color-border)
         transition: background $header-sticky-transition
         z-index: $zindex-header
+        &, a
+            color: $header-upper-menu-color
         ul
             @include list-reset
             @include meta
@@ -76,7 +78,7 @@ header#document-header
         @include media-breakpoint-down(desktop)
             background: transparent
             border-top: $header-upper-menu-border-bottom-width solid var(--color-border)
-            color: $header-sticky-color
+            color: $header-upper-menu-sticky-color
             display: none
             position: absolute
             top: var(--header-height)
@@ -120,7 +122,8 @@ header#document-header
     &.is-sticky
         .upper-menu
             background: $header-upper-menu-sticky-background
-            color: $header-sticky-color
+            &, a
+                color: $header-upper-menu-sticky-color
 
 // TODO : Est-ce au bon endroit ?
 body


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

On n'utilisait que la variable du header pour la couleur des liens/textes du upper menu, j'ai donc rajouté deux variables et les ai insérées dans le sass.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

- Accueil

## URL de test du site

- Communication publique
- CIDS/MIDS

## Screenshots
### Communication publique

![Capture d’écran 2024-11-22 à 11 53 09](https://github.com/user-attachments/assets/1f5545cc-93b4-43f6-a535-7f4960cbe101)
![Capture d’écran 2024-11-22 à 11 53 14](https://github.com/user-attachments/assets/d57136d8-170d-455a-a69c-be6922e1220a)

