### PR TITLE
Transcription : correction de l'id d'aria-control

### DIFF
--- a/layouts/partials/commons/transcription.html
+++ b/layouts/partials/commons/transcription.html
@@ -3,8 +3,8 @@
   {{ $id := printf "block-%d-transcription" $block_index}}
   {{ $title := .title | default ( i18n "commons.accessibility.transcription" ) }}
   <div class="transcription">
-    <details id="{{$id}}">
-      <summary aria-controls="#{{ $id }}" aria-expanded="false">{{ $title }}</summary>
+    <details id="{{- $id -}}">
+      <summary aria-controls="{{- $id -}}" aria-expanded="false">{{ $title }}</summary>
       {{- $transcription := partial "PrepareHTML" .transcription -}}
       {{ safeHTML $transcription }}
     </details>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Enlever le `#` du aria-controls sur les transcription.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


