### PR TITLE
[validator] balises `<p>` doublées

### DIFF
--- a/layouts/partials/blocks/templates/pages.html
+++ b/layouts/partials/blocks/templates/pages.html
@@ -31,8 +31,6 @@
   {{ end -}}
 
   {{ if $main_summary }}
-    {{/*  SHOULD BE FIXED WITH ORTHOTYPO  */}}
-    {{ $main_summary = $main_summary }}
     {{ $block_class = printf "%s %s" $block_class "with-description" }}
   {{ end }}
   {{ if $options.image }}

--- a/layouts/partials/blocks/templates/pages.html
+++ b/layouts/partials/blocks/templates/pages.html
@@ -32,7 +32,7 @@
 
   {{ if $main_summary }}
     {{/*  SHOULD BE FIXED WITH ORTHOTYPO  */}}
-    {{ $main_summary = printf "<p>%s</p>" $main_summary }}
+    {{ $main_summary = $main_summary }}
     {{ $block_class = printf "%s %s" $block_class "with-description" }}
   {{ end }}
   {{ if $options.image }}

--- a/layouts/partials/persons/person.html
+++ b/layouts/partials/persons/person.html
@@ -21,7 +21,7 @@
     {{ if and $options.summary (or $role $person.Params.summary) }}
       <div itemprop="jobTitle">
         {{ if (partial "GetTextFromHTML" $role) }}
-          {{ partial "PrepareHTML" $role }}
+          <p>{{ partial "PrepareHTML" $role }}</p>
         {{ else if $person.Params.summary }}
           {{ partial "PrepareHTML" $person.Params.summary }}
         {{ end }}

--- a/layouts/partials/persons/person.html
+++ b/layouts/partials/persons/person.html
@@ -19,13 +19,13 @@
       {{ end }}
     {{ $heading_tag.close }}
     {{ if and $options.summary (or $role $person.Params.summary) }}
-      <p itemprop="jobTitle">
+      <div itemprop="jobTitle">
         {{ if (partial "GetTextFromHTML" $role) }}
           {{ partial "PrepareHTML" $role }}
         {{ else if $person.Params.summary }}
-          {{ safeHTML $person.Params.summary }}
+          {{ partial "PrepareHTML" $person.Params.summary }}
         {{ end }}
-      </p>
+      </div>
     {{ end }}
   </div>
   {{ if $options.image }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

On a des balises `<p>` dans d'autres, du fait de l'ajout du résumé encapsulé dans des `<p>`. 
Cela se produit sur : 
- les personnes (jobTitle)
- les pages en mode liste avec un "main summary"

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/754

## URL de test sur example.osuny.org

http://localhost:1314/fr/blocks/blocs-de-mise-en-page/#les-personnes
https://example.osuny.org/fr/