### PR TITLE
[a11y] Amélioration du menu

### DIFF
--- a/assets/js/theme/design-system/mainMenu.js
+++ b/assets/js/theme/design-system/mainMenu.js
@@ -1,3 +1,4 @@
+import { focusTrap } from '../utils/focus-trap';
 import { isMobile } from '../utils/breakpoints';
 import { a11yClick } from '../utils/a11y';
 
@@ -44,6 +45,12 @@ class MainMenu {
             });
         }
 
+        // window.addEventListener('focusin', (event) => {
+        //     if (!event.target.closest('#' + this.element.id)) {
+        //         this.toggleMainMenu(false);
+        //     }
+        // });
+
         // if (this.a11yButton) {
         //     a11yClick(this.a11yButton, (event) => {
         //         if (this.state.isMobile) {
@@ -67,6 +74,8 @@ class MainMenu {
         window.addEventListener('keydown', (event) => {
             if (event.keyCode === 27 || event.key === 'Escape') {
                 this.closeEverything();
+            } else if (event.key === 'Tab' && this.state.isOpened) {
+                focusTrap(event, this.element, true);
             }
         });
     }

--- a/assets/js/theme/design-system/mainMenu.js
+++ b/assets/js/theme/design-system/mainMenu.js
@@ -14,6 +14,7 @@ class MainMenu {
         this.element = document.querySelector(selector);
         this.menu = this.element.querySelector('.menu');
         this.mainButton = this.element.querySelector('button.header-button');
+        this.upperMenu = this.element.querySelector('.upper-menu');
         // this.a11yButton = document.querySelector('[href="#navigation"]');
 
         this.dropdownsButtons = this.element.querySelectorAll('.has-children [role="button"]');
@@ -92,6 +93,18 @@ class MainMenu {
         this.state.isMobile = isMobile();
 
         this.closeEverything();
+
+        if (this.upperMenu) {
+            this.updateUpperMenuPosition();
+        }
+    }
+
+    updateUpperMenuPosition () {
+        if (this.state.isMobile) {
+            this.element.append(this.upperMenu);
+        } else {
+            this.element.prepend(this.upperMenu);
+        }
     }
 
     toggleMainMenu (open = !this.state.isOpened) {

--- a/assets/js/theme/design-system/mainMenu.js
+++ b/assets/js/theme/design-system/mainMenu.js
@@ -46,12 +46,6 @@ class MainMenu {
             });
         }
 
-        // window.addEventListener('focusin', (event) => {
-        //     if (!event.target.closest('#' + this.element.id)) {
-        //         this.toggleMainMenu(false);
-        //     }
-        // });
-
         // if (this.a11yButton) {
         //     a11yClick(this.a11yButton, (event) => {
         //         if (this.state.isMobile) {

--- a/assets/js/theme/utils/focus-trap.js
+++ b/assets/js/theme/utils/focus-trap.js
@@ -24,7 +24,6 @@ function handleTabLoop(event, firstFocusable, lastFocusable, element) {
     const focusTarget = goingBackward ? lastFocusable : firstFocusable;
     // get focus position (we want first or last) to create the focus loop
     const focusOnLimit = isElementFocused(element, goingBackward ? firstFocusable : lastFocusable);
-    console.log(focusOnLimit);
     if (focusOnLimit) {
         event.preventDefault();
         focusTarget.focus();

--- a/assets/js/theme/utils/focus-trap.js
+++ b/assets/js/theme/utils/focus-trap.js
@@ -24,7 +24,7 @@ function handleTabLoop(event, firstFocusable, lastFocusable, element) {
     const focusTarget = goingBackward ? lastFocusable : firstFocusable;
     // get focus position (we want first or last) to create the focus loop
     const focusOnLimit = isElementFocused(element, goingBackward ? firstFocusable : lastFocusable);
-
+    console.log(focusOnLimit);
     if (focusOnLimit) {
         event.preventDefault();
         focusTarget.focus();

--- a/assets/sass/_theme/design-system/header.sass
+++ b/assets/sass/_theme/design-system/header.sass
@@ -90,9 +90,6 @@ header#document-header
             html.has-menu-opened &
                 background: $header-upper-menu-sticky-background
                 display: block
-                + nav
-                    .menu
-                        padding-top: $header-upper-menu-mobile-height
         .nav-level-1
             a
                 text-decoration: none
@@ -114,6 +111,9 @@ header#document-header
                     &.active
                         box-shadow: inset 0 -4px 0 0 var(--color-border)
     @include media-breakpoint-down(desktop)
+        &.has-upper-menu
+            .menu
+                padding-top: $header-upper-menu-mobile-height
         html.has-menu-opened &
             nav
                 padding-bottom: 0

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -141,7 +141,7 @@ commons:
     blank_aria: “{{ .Title }}” - external link
     download: “Download {{ .Title }}” - external link
   menu:
-    label: Toggle navigation
+    label: Menu
     legal: Legals menu
     main: Main menu
     secondary: Secondary menu

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -150,7 +150,7 @@ commons:
     blank_aria: “{{ .Title }}” - lien externe
     download: Télécharger “{{ .Title }}” - lien externe
   menu:
-    label: Ouvrir / Fermer le menu
+    label: Menu
     legal: Menu pages légales
     main: Menu principal
     secondary: Menu secondaire

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -1,7 +1,10 @@
 {{ $primary := partial "GetMenu" "primary" }}
 {{ $upper_menu := partial "GetMenu" "upper-menu" }}
 
-<header id="document-header" role="banner">
+<header id="document-header" role="banner"
+  {{ if $upper_menu.items }}
+    class="has-upper-menu"
+  {{ end }}>
   {{ if $upper_menu.items }}
     <nav class="upper-menu" aria-label="{{ i18n "commons.menu.upper" }}">
       <div class="container">


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

https://github.com/osunyorg/theme/issues/747

- Modifier le aria-label du bouton <button type="button" aria-controls="navigation" aria-expanded="false" aria-label="Ouvrir / Fermer le menu" class="header-button"> par “menu” 
- Faire boucler le focus dans le header jusqu'à fermeture du menu
- Quand utilisateur ouvre le menu déplacer dans l'ordre du code source le nav.upper-menu après le nav avec le aria-label menu principal
 
## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


