### PR TITLE
[a11y] Remplacement du `inert` par un `aria-hidden`

### DIFF
--- a/assets/js/theme/design-system/Popup.js
+++ b/assets/js/theme/design-system/Popup.js
@@ -1,4 +1,4 @@
-import { inertBodyChildren } from '../utils/a11y';
+import { ariaHideBodyChildren } from '../utils/a11y';
 import { focusTrap } from '../utils/focus-trap';
 
 var CLASSES = {
@@ -77,7 +77,7 @@ window.osuny.Popup.prototype = {
     },
 
     updateDocumentAccessibility: function () {
-        inertBodyChildren(this.element, this.state.opened);
+        ariaHideBodyChildren(this.element, this.state.opened);
     },
 
     isOpen: function () {

--- a/assets/js/theme/design-system/mainMenu.js
+++ b/assets/js/theme/design-system/mainMenu.js
@@ -1,6 +1,6 @@
 import { focusTrap } from '../utils/focus-trap';
 import { isMobile } from '../utils/breakpoints';
-import { a11yClick, inertBodyChildren } from '../utils/a11y';
+import { a11yClick, ariaHideBodyChildren } from '../utils/a11y';
 
 const CLASSES = {
     mainMenuOpened: 'is-opened',
@@ -117,7 +117,7 @@ class MainMenu {
         this.updateOverlay();
 
         if (this.state.isMobile) {
-            inertBodyChildren(this.element, open);
+            ariaHideBodyChildren(this.element, open);
         }
     }
 

--- a/assets/js/theme/design-system/search.js
+++ b/assets/js/theme/design-system/search.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import { a11yClick, inertBodyChildren } from '../utils/a11y';
+import { a11yClick, ariaHideBodyChildren } from '../utils/a11y';
 import { isMobile } from '../utils/breakpoints';
 import { focusTrap } from '../utils/focus-trap';
 
@@ -154,7 +154,7 @@ class Search {
         } else {
             document.body.style.overflow = 'unset';
         }
-        inertBodyChildren(this.element, open);
+        ariaHideBodyChildren(this.element, open);
     }
 }
 

--- a/assets/js/theme/utils/a11y.js
+++ b/assets/js/theme/utils/a11y.js
@@ -5,7 +5,7 @@ var actionKeys = [
     a11yClick,
     setButtonEnability,
     setAriaVisibility,
-    inertBodyChildren;
+    ariaHideBodyChildren;
 
 a11yClick = function (element, action) {
     element.addEventListener('click', action);
@@ -34,14 +34,13 @@ setAriaVisibility = function (element, enable, isChild) {
     }
 };
 
-inertBodyChildren = function (element, inert) {
+ariaHideBodyChildren = function (element, inert) {
     var bodyChildren = document.body.children,
         action = inert ? 'setAttribute' : 'removeAttribute',
         ignoredElements = ['SCRIPT', 'STYLE'];
 
     Array.prototype.forEach.call(bodyChildren, function (child) {
         if (element !== child && !child.contains(element) && ignoredElements.indexOf(child.nodeName) === -1) {
-            child[action]('inert', '');
             child[action]('aria-hidden', 'true');
         }
     }.bind(this));
@@ -51,5 +50,5 @@ export {
     a11yClick,
     setButtonEnability,
     setAriaVisibility,
-    inertBodyChildren
+    ariaHideBodyChildren
 };

--- a/assets/js/theme/utils/a11y.js
+++ b/assets/js/theme/utils/a11y.js
@@ -36,11 +36,13 @@ setAriaVisibility = function (element, enable, isChild) {
 
 inertBodyChildren = function (element, inert) {
     var bodyChildren = document.body.children,
-        action = inert ? 'setAttribute' : 'removeAttribute';
+        action = inert ? 'setAttribute' : 'removeAttribute',
+        ignoredElements = ['SCRIPT', 'STYLE'];
 
     Array.prototype.forEach.call(bodyChildren, function (child) {
-        if (element !== child && !child.contains(element)) {
+        if (element !== child && !child.contains(element) && ignoredElements.indexOf(child.nodeName) === -1) {
             child[action]('inert', '');
+            child[action]('aria-hidden', 'true');
         }
     }.bind(this));
 };


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Avec la méthode de focus trap, un aria-hidden sur les enfants directs du `body` suffit à bloquer le lecteur d'écran dans la zone ouverte (menu, search, popup).

On remplace le `inert` : 
- pour limiter le risque de bloquer l'accès au reste du site à toutes les personnes en cas d'erreur js. 
- le `aria-hidden` est mieux supporté par les TA

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/747
