### PR TITLE
[a11y] Recherche : focus sur bouton et nettoyage

### DIFF
--- a/assets/js/theme/design-system/search.js
+++ b/assets/js/theme/design-system/search.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-undef */
-import { a11yClick, ariaHideBodyChildren } from '../utils/a11y';
-import { isMobile } from '../utils/breakpoints';
+import { ariaHideBodyChildren } from '../utils/a11y';
 import { focusTrap } from '../utils/focus-trap';
 
 const CLASSES = {
@@ -153,6 +152,8 @@ class Search {
             this.input.focus();
         } else {
             document.body.style.overflow = 'unset';
+            this.button.focus();
+            this.accessibleMessageContainer.innerHTML = '';
         }
         ariaHideBodyChildren(this.element, open);
     }


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

- Focus le bouton d'ouverture de la recherche à la fermeture
- Vider le message du `aria-live` à la fermeture de la recherche

https://github.com/osunyorg/theme/issues/748

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/748

