### PR TITLE
Bloc vidéo : correction describedby

### DIFF
--- a/layouts/partials/blocks/templates/video.html
+++ b/layouts/partials/blocks/templates/video.html
@@ -30,7 +30,7 @@
 
         {{ if .video_title }}
           {{ $described_by_id = printf "block-video-title-%d" $block_index }}
-          <p aria-hidden="true">{{- partial "PrepareHTML" .video_title -}}</p>
+          <p aria-hidden="true" id="{{ $described_by_id }}">{{- partial "PrepareHTML" .video_title -}}</p>
         {{ end }}
 
         {{ partial "commons/transcription" ( dict


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Il manquait l'`id` sur le titre sr-only du bloc vidéo.


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


