### PR TITLE
Correction du filtre des iframes

### DIFF
--- a/layouts/partials/FilterIframeLazy
+++ b/layouts/partials/FilterIframeLazy
@@ -1,6 +1,5 @@
 {{ $is_loading_present := strings.Contains . "loading" }}
 {{ $text := . }}
-
 {{ if not $is_loading_present }}
 	{{ $chunks := split . "<iframe" }}
 	{{ $text = delimit $chunks "<iframe loading=\"lazy\"" }}

--- a/layouts/partials/FilterIframeLazy
+++ b/layouts/partials/FilterIframeLazy
@@ -1,5 +1,10 @@
-{{ $chunks := split . "<iframe" }}
-{{ $text := delimit $chunks "<iframe loading=\"lazy\"" }}
-{{ $chunks = split $text "</iframe>" }}
-{{ $text = delimit $chunks "</iframe>" }}
+{{ $is_loading_present := strings.Contains . "loading" }}
+{{ $text := . }}
+
+{{ if not $is_loading_present }}
+	{{ $chunks := split . "<iframe" }}
+	{{ $text = delimit $chunks "<iframe loading=\"lazy\"" }}
+	{{ $chunks = split $text "</iframe>" }}
+	{{ $text = delimit $chunks "</iframe>" }}
+{{ end }}
 {{ return $text }}

--- a/layouts/partials/programs/certification.html
+++ b/layouts/partials/programs/certification.html
@@ -11,6 +11,7 @@
           {{- end -}}
         </section>
       </div>
+    </div>
   </div>
 </section>
 {{- end -}}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Si une iframe a déjà un attribut `loading`, il ne faut pas ajouter un second `loading="lazy"`.

Erreur W3C 

> Error: Duplicate attribute loading.


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Avant 

```HTML
        <iframe loading="lazy" src="https://www.google.com/maps/embed" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
```

## Après 

```HTML
        <iframe src="https://www.google.com/maps/embed" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
```


