### PR TITLE
[A11Y] Ajout d'un texte alternatif générique aux images concernées par la visionneuses

### DIFF
--- a/assets/js/theme/design-system/Lightbox.js
+++ b/assets/js/theme/design-system/Lightbox.js
@@ -37,8 +37,9 @@ window.osuny.Lightbox.prototype._setup = function () {
 window.osuny.Lightbox.prototype._listen = function () {
     window.osuny.Popup.prototype._listen.call(this);
 
-    this.buttons.forEach(function (button) {
+    this.buttons.forEach(function (button, index) {
         button.addEventListener('click', this.open.bind(this, button));
+        this._setImageAltText(button, index);
     }.bind(this));
 
     this.contentElements.previousButton.addEventListener('click', this.navigateTo.bind(this, 'previousData'));
@@ -65,6 +66,16 @@ window.osuny.Lightbox.prototype._getData = function (button) {
     data.buttonElement = button;
     return data;
 };
+
+window.osuny.Lightbox.prototype._setImageAltText = function(button, index) {
+    var alt = this._getData(button).alt,
+        text = this._getData(button).information,
+        buttonText = button.querySelector('.sr-only');
+
+    if (!alt && !text) {
+        buttonText.innerHTML += ` ${index + 1}`;
+    }
+}
 
 window.osuny.Lightbox.prototype._setSiblings = function () {
     var figure = this.state.currentData.buttonElement.parentElement,

--- a/assets/js/theme/design-system/Lightbox.js
+++ b/assets/js/theme/design-system/Lightbox.js
@@ -68,12 +68,13 @@ window.osuny.Lightbox.prototype._getData = function (button) {
 };
 
 window.osuny.Lightbox.prototype._setImageAltText = function(button, index) {
-    var alt = this._getData(button).alt,
-        text = this._getData(button).information,
-        buttonText = button.querySelector('.sr-only');
+    var lightboxAlt = this._getData(button).alt,
+        image = button.querySelector('img'),
+        imageAlt = image.getAttribute('alt');
 
-    if (!alt && !text) {
-        buttonText.innerHTML += ` ${index + 1}`;
+    if (!lightboxAlt) {
+        imageAlt += ` ${index + 1}`;
+        image.setAttribute('alt', imageAlt);
     }
 }
 

--- a/assets/js/theme/design-system/Lightbox.js
+++ b/assets/js/theme/design-system/Lightbox.js
@@ -40,6 +40,7 @@ window.osuny.Lightbox.prototype._listen = function () {
     this.buttons.forEach(function (button, index) {
         button.addEventListener('click', this.open.bind(this, button));
         this._setImageAltText(button, index);
+        this._setFigcaptionId(button, index);
     }.bind(this));
 
     this.contentElements.previousButton.addEventListener('click', this.navigateTo.bind(this, 'previousData'));
@@ -67,7 +68,7 @@ window.osuny.Lightbox.prototype._getData = function (button) {
     return data;
 };
 
-window.osuny.Lightbox.prototype._setImageAltText = function(button, index) {
+window.osuny.Lightbox.prototype._setImageAltText = function (button, index) {
     var lightboxAlt = this._getData(button).alt,
         image = button.querySelector('img'),
         imageAlt = image.getAttribute('alt');
@@ -76,7 +77,17 @@ window.osuny.Lightbox.prototype._setImageAltText = function(button, index) {
         imageAlt += ` ${index + 1}`;
         image.setAttribute('alt', imageAlt);
     }
-}
+};
+
+window.osuny.Lightbox.prototype._setFigcaptionId = function (button, index) {
+    var parent = button.parentElement,
+        figcaption = parent.querySelector('figcaption');
+
+    if (figcaption) {
+        figcaption.id = 'image-figcaption-' + index;
+        button.setAttribute('aria-describedby', figcaption.id);
+    }
+};
 
 window.osuny.Lightbox.prototype._setSiblings = function () {
     var figure = this.state.currentData.buttonElement.parentElement,

--- a/assets/js/theme/design-system/navAccessibility.js
+++ b/assets/js/theme/design-system/navAccessibility.js
@@ -1,0 +1,28 @@
+var osuny = window.osuny || {};
+
+osuny.navAccessibility = {
+    init: function (element) {
+        this.element = element;
+
+        if (!this.element) {
+            return;
+        }
+
+        this.mainButton = this.element.querySelector('a[href="#main"]');
+
+        if (this.mainButton) {
+            this.mainButton.addEventListener('click', this.focusMain);
+        }
+    },
+    focusMain: function () {
+        var main = document.getElementById('main');
+        main.setAttribute('tabindex', '-1');
+    }
+};
+
+(function () {
+    var navAccessibilityElement = document.getElementById('nav-accessibility')
+    if (navAccessibilityElement) {
+        osuny.navAccessibility.init(navAccessibilityElement);
+    }
+}());

--- a/assets/js/theme/design-system/search.js
+++ b/assets/js/theme/design-system/search.js
@@ -48,8 +48,33 @@ class Search {
                 this.accessibleMessage = document.createElement('p');
                 this.accessibleMessageContainer.appendChild(this.accessibleMessage);
             }
-            setTimeout(this.updateAccessibilityMessageRole.bind(this), speakDelay);
+            clearTimeout(this.a11yTimeout);
+            this.a11yTimeout = setTimeout(this.updateAccessibility.bind(this), speakDelay);
         });
+    }
+
+    updateAccessibility () {
+        this.updateAccessibilityMessageRole();
+        this.updateAccessibilityTags();
+    }
+
+    updateAccessibilityTags () {
+        const results = this.element.querySelectorAll('.pagefind-ui__result');
+
+        results.forEach(this.updateAccessibilityResult);
+    }
+
+    updateAccessibilityResult (result) {
+        let image = result.querySelector('img'),
+            title = result.querySelector('.pagefind-ui__result-title');
+
+        if (image) {
+            image.setAttribute('alt', '');
+        }
+        if (title) {
+            title.setAttribute('role', 'heading');
+            title.setAttribute('aria-level', '2');
+        }
     }
 
     updateAccessibilityMessageRole () {

--- a/assets/js/theme/design-system/sliders/Arrows.js
+++ b/assets/js/theme/design-system/sliders/Arrows.js
@@ -20,6 +20,7 @@ osuny.SliderArrows = function (slider) {
 osuny.SliderArrows.prototype.create = function (direction) {
     var button = document.createElement('button');
     button.classList.add('slider-arrow', 'slider-arrow-' + direction);
+    button.setAttribute('aria-describedby', this.slider.titleId);
     osuny.utils.insertSROnly(button, osuny.i18n.slider[direction]);
     this.container.appendChild(button);
     return button;
@@ -34,12 +35,16 @@ osuny.SliderArrows.prototype.update = function () {
     setButtonEnability(this.previous, !this.slider.state.isFirst);
     setButtonEnability(this.next, !this.slider.state.isLast);
     if (this.progression) {
-        this.progression.innerText = this.slider.state.index + 1 + '/' + this.slider.slides.length;
+        this.updateProgression();
     }
 };
 
+osuny.SliderArrows.prototype.updateProgression = function () {
+    this.progression.innerHTML = this.slider.state.index + 1 + '<span class="sr-only"> sur </span><span aria-hidden="true">/</span>' + this.slider.slides.length;
+};
+
 osuny.SliderArrows.prototype.addProgression = function () {
-    this.progression = document.createElement('div');
+    this.progression = document.createElement('p');
     this.progression.classList.add('slider-progression');
     this.next.before(this.progression);
 };

--- a/assets/js/theme/design-system/sliders/Autoplayer.js
+++ b/assets/js/theme/design-system/sliders/Autoplayer.js
@@ -26,6 +26,7 @@ osuny.SliderAutoplayer.prototype.addToggler = function () {
     this.container.append(this.button);
     this.slider.controls.append(this.container);
 
+    this.button.setAttribute('aria-describedby', this.slider.titleId);
     this.a11ySpan = osuny.utils.insertSROnly(this.button, osuny.i18n.slider.pause);
 
     this.button.addEventListener('click', this.toggle.bind(this));

--- a/assets/js/theme/design-system/sliders/Pagination.js
+++ b/assets/js/theme/design-system/sliders/Pagination.js
@@ -6,8 +6,6 @@ osuny.SliderPagination = function (slider) {
     this.buttons = [];
     this.container = document.createElement('ul');
     this.container.classList.add('slider-pagination');
-    this.container.setAttribute('aria-label', osuny.i18n.slider.pagination_list);
-    this.container.setAttribute('aria-describedby', this.slider.titleId);
     this.slider.controls.appendChild(this.container);
     this.create();
 };

--- a/assets/js/theme/design-system/sliders/Slider.js
+++ b/assets/js/theme/design-system/sliders/Slider.js
@@ -190,7 +190,7 @@ osuny.Slider.prototype.focus = function () {
     var canFocus = this.components.autoplay ? !this.components.autoplay.state.isActive : true;
     clearTimeout(this.focusTimeout);
 
-    this.currentSlide.setAttribute('tabindex', '0');
+    this.currentSlide.setAttribute('tabindex', '-1');
 
     if (canFocus) {
         this.focusTimeout = setTimeout(function () {

--- a/assets/js/theme/index.js
+++ b/assets/js/theme/index.js
@@ -10,6 +10,7 @@ import './design-system/dropdowns';
 import './design-system/font';
 import './design-system/mainMenu';
 import './design-system/modal';
+import './design-system/navAccessibility';
 import './design-system/notes';
 import './design-system/search';
 import './design-system/toc';

--- a/assets/sass/_theme/blocks/image.sass
+++ b/assets/sass/_theme/blocks/image.sass
@@ -21,7 +21,7 @@
     @include in-page-with-sidebar
         picture
             margin-left: 0
-            margin-right: unset
+            margin-right: var(--grid-gutter-negative)
         img
             max-height: $block-image-max-height-with-sidebar
             width: auto

--- a/assets/sass/_theme/blocks/image.sass
+++ b/assets/sass/_theme/blocks/image.sass
@@ -21,7 +21,7 @@
     @include in-page-with-sidebar
         picture
             margin-left: 0
-            margin-right: var(--grid-gutter-negative)
+            margin-right: unset
         img
             max-height: $block-image-max-height-with-sidebar
             width: auto

--- a/assets/sass/_theme/blocks/image.sass
+++ b/assets/sass/_theme/blocks/image.sass
@@ -21,7 +21,9 @@
     @include in-page-with-sidebar
         picture
             margin-left: 0
-            margin-right: var(--grid-gutter-negative)
+        &.image-portrait
+            picture
+                margin-right: 0
         img
             max-height: $block-image-max-height-with-sidebar
             width: auto

--- a/assets/sass/_theme/blocks/image.sass
+++ b/assets/sass/_theme/blocks/image.sass
@@ -27,6 +27,7 @@
         img
             max-height: $block-image-max-height-with-sidebar
             width: auto
+            max-width: columns(6)
 
     @include in-page-without-sidebar
         figure

--- a/assets/sass/_theme/components/lightbox.sass
+++ b/assets/sass/_theme/components/lightbox.sass
@@ -113,9 +113,5 @@
 
 .lightbox-button
     @include button-reset
-    cursor: pointer
-    position: absolute
-    bottom: 0
-    left: 0
-    top: 0
-    right: 0
+    display: block
+    padding: 0

--- a/assets/sass/_theme/components/lightbox.sass
+++ b/assets/sass/_theme/components/lightbox.sass
@@ -115,3 +115,5 @@
     @include button-reset
     display: block
     padding: 0
+    &:focus-visible
+        outline-color: var(--color-text)

--- a/assets/sass/_theme/configuration/zindex.sass
+++ b/assets/sass/_theme/configuration/zindex.sass
@@ -1,6 +1,7 @@
 // Z-index
 $zindex-aside: 48 !default
 $zindex-body-overlay: 51 !default
+$zindex-dropdown: 3 !default
 $zindex-footer: 50 !default
 $zindex-header: 52 !default
 $zindex-lightbox: 80 !default

--- a/assets/sass/_theme/design-system/dropdown.sass
+++ b/assets/sass/_theme/design-system/dropdown.sass
@@ -15,7 +15,7 @@
         background-color: var(--dropdown-background)
         display: none
         position: absolute
-        z-index: 2
+        z-index: $zindex-dropdown
         @include media-breakpoint-down(desktop)
             right: var(--grid-gutter-negative)
             left: var(--grid-gutter-negative)

--- a/assets/sass/_theme/design-system/header.sass
+++ b/assets/sass/_theme/design-system/header.sass
@@ -176,7 +176,6 @@ header#document-header
             display: none
             padding: 0
             position: relative
-            text-transform: uppercase
             line-height: 1
             &:focus
                 box-shadow: none
@@ -191,6 +190,7 @@ header#document-header
             span:first-of-type
                 @include meta
                 font-size: pxToRem(14)
+                text-transform: uppercase
             span:last-of-type
                 background: none
                 @include icon-block(menu-line, before)

--- a/assets/sass/_theme/design-system/image.sass
+++ b/assets/sass/_theme/design-system/image.sass
@@ -20,7 +20,7 @@ img
             @include small
 
 figcaption
-    &.credit > p, .credit > p
+    &.credit > p:not(.sr-only), .credit > p:not(.sr-only)
         &::before
             content: '©' / ''
             margin-right: $spacing-1

--- a/assets/sass/_theme/design-system/image.sass
+++ b/assets/sass/_theme/design-system/image.sass
@@ -22,5 +22,5 @@ img
 figcaption
     &.credit > p, .credit > p
         &::before
-            content: '©'
+            content: '©' / ''
             margin-right: $spacing-1

--- a/assets/sass/_theme/sections/diplomas.sass
+++ b/assets/sass/_theme/sections/diplomas.sass
@@ -74,8 +74,8 @@ ul.diplomas
                 @include h4
 
 .diplomas-select
-    text-align: right
     @include dropdown
+    text-align: right
     .dropdown-menu
         a
             font-size: $body-size

--- a/assets/sass/_theme/utils/shame.sass
+++ b/assets/sass/_theme/utils/shame.sass
@@ -134,7 +134,7 @@
         z-index: 10
         &::before
             @include meta
-            content: '©'
+            content: '©' / ''
             position: absolute
             right: 0
             top: 0

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -317,7 +317,7 @@ params:
         grid:
           mobile:   170
           tablet:   350
-          desktop:  415
+          desktop:  555
         large:
           mobile:   400
           tablet:   800

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -131,6 +131,7 @@ commons:
   language: Langue
   lightbox:
     button: Agrandir l'image
+    button_without_alt: Agrandir image 
     close:
       a11y_credits: Fermer les crédits
       a11y_informations: Fermer les informations

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -85,6 +85,7 @@ commons:
     shortcut_navigation: Navigation d'accès rapide
     transcription: Transcription
     map_transcription : Données textuelles
+    credits: "Droits révervés : "
   search:
     label: Recherche
     title: Rechercher
@@ -130,8 +131,9 @@ commons:
   index: Accueil - {{ .Title }}
   language: Langue
   lightbox:
+    alternative_alt: Image 
     button: Agrandir l'image
-    button_without_alt: Agrandir image 
+    button_without_alt: Agrandir
     close:
       a11y_credits: Fermer les crédits
       a11y_informations: Fermer les informations

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -15,7 +15,7 @@
     {{- partial "header/accessibility.html" -}}
     {{- partial "hooks/before-header" . -}}
     {{- partial "header/header.html" . -}}
-    <main{{ if .Params.contents }} class="page-with-blocks"{{ end }} id="main" tabindex="-1">
+    <main{{ if .Params.contents }} class="page-with-blocks"{{ end }} id="main">
       {{ if and (site.Params.search.active) (eq site.Params.search.position "fixed")}}
         {{ partial "header/search.html"
           (dict

--- a/layouts/partials/RemoveSrOnlyTag
+++ b/layouts/partials/RemoveSrOnlyTag
@@ -1,0 +1,3 @@
+{{- $text := . -}}
+{{- $text = replaceRE "<span class=\"sr-only\">(.*?)</span>" "" $text -}}
+{{- return $text -}}

--- a/layouts/partials/commons/image-figure.html
+++ b/layouts/partials/commons/image-figure.html
@@ -7,9 +7,10 @@
 
   {{ if $image }}
     {{ with .image }}
+      {{ $credit := cond .credit (printf "© %s" .credit) "" }}
       <figure
-              class="{{ $image_class }}{{ if $is_lightbox }} lightbox-figure {{ end }}" 
-              {{- with or .text .alt .credit }}
+              class="{{ $image_class }}{{ if $is_lightbox }} lightbox-figure {{ end }}"
+              {{- with or .text .alt $credit }}
                 role="figure"
                 aria-label="{{ . | plainify }}"
               {{ end }}

--- a/layouts/partials/commons/image-figure.html
+++ b/layouts/partials/commons/image-figure.html
@@ -14,9 +14,14 @@
                 aria-label="{{ . | plainify }}"
               {{ end }}
       >
+      {{ $alt := .alt }}
+      {{ if and (not .alt) $is_lightbox }}
+        {{ $alt = i18n "commons.lightbox.alternative_alt" }}
+      {{ end }}
+
       {{ $image_tag := partial "commons/image.html" (dict
           "image" .id
-          "alt" .alt
+          "alt" $alt
           "sizes" $sizes
           "lazy" $lazy
       ) }}

--- a/layouts/partials/commons/image-figure.html
+++ b/layouts/partials/commons/image-figure.html
@@ -38,7 +38,10 @@
             {{ . | safeHTML }}
           {{ end }}
           {{ with .credit }}
-            <div class="credit">{{ . | safeHTML }}</div>
+            <div class="credit">
+              <p class="sr-only">{{ i18n "commons.accessibility.credits" }}</p>
+              {{ . | safeHTML }}
+            </div>
           {{ end }}
         </figcaption>
       {{ end }}

--- a/layouts/partials/commons/image-figure.html
+++ b/layouts/partials/commons/image-figure.html
@@ -7,7 +7,8 @@
 
   {{ if $image }}
     {{ with .image }}
-      {{ $credit := cond .credit (printf "© %s" .credit) "" }}
+      {{ $credit := partial "RemoveSrOnlyTag" .credit }}
+      {{ $credit = cond $credit (printf "© %s" $credit) "" }}
       <figure
               class="{{ $image_class }}{{ if $is_lightbox }} lightbox-figure {{ end }}"
               {{- with or .text .alt $credit }}

--- a/layouts/partials/commons/image-figure.html
+++ b/layouts/partials/commons/image-figure.html
@@ -29,7 +29,7 @@
       {{ if $is_lightbox }}
         {{- partial "commons/lightbox/button.html" (dict "image" $image_tag "context" .) }}
       {{ else }}
-        {{ $image_tag}}
+        {{ $image_tag }}
       {{ end }}
 
       {{ if or .text .credit }}

--- a/layouts/partials/commons/image-figure.html
+++ b/layouts/partials/commons/image-figure.html
@@ -14,15 +14,17 @@
                 aria-label="{{ . | plainify }}"
               {{ end }}
       >
-      {{ partial "commons/image.html" (dict
-        "image" .id
-        "alt" .alt
-        "sizes" $sizes
-        "lazy" $lazy
+      {{ $image_tag := partial "commons/image.html" (dict
+          "image" .id
+          "alt" .alt
+          "sizes" $sizes
+          "lazy" $lazy
       ) }}
 
       {{ if $is_lightbox }}
-        {{ partial "commons/lightbox/button.html" . }}
+        {{- partial "commons/lightbox/button.html" (dict "image" $image_tag "context" .) -}}
+      {{ else }}
+        {{ $image_tag }}
       {{ end }}
 
       {{ if or .text .credit }}

--- a/layouts/partials/commons/image-figure.html
+++ b/layouts/partials/commons/image-figure.html
@@ -22,9 +22,9 @@
       ) }}
 
       {{ if $is_lightbox }}
-        {{- partial "commons/lightbox/button.html" (dict "image" $image_tag "context" .) -}}
+        {{- partial "commons/lightbox/button.html" (dict "image" $image_tag "context" .) }}
       {{ else }}
-        {{ $image_tag }}
+        {{ $image_tag}}
       {{ end }}
 
       {{ if or .text .credit }}

--- a/layouts/partials/commons/lightbox/button.html
+++ b/layouts/partials/commons/lightbox/button.html
@@ -2,15 +2,10 @@
 
 {{ with .context }}
   {{ $title := i18n "commons.lightbox.button_without_alt" }}
-  {{ if .alt }}
-    {{ $title = i18n "commons.lightbox.button" }}
-  {{ end }}
-
   {{ $options := dict "imageSrc" ( partial "GetLightboxUrl" .id ) }}
 
   {{ with .text }}
     {{ $options = merge $options (dict "information" (partial "PrepareHTML" . )) }}
-    {{ $title = printf "%s %s" $title ( . | plainify ) }}
   {{ end }}
 
   {{ with .credit }}
@@ -19,7 +14,7 @@
 
   {{ with .alt }}
     {{ $options = merge $options (dict "alt" (. | plainify)) }}
-    {{ $title = printf "%s %s" $title ( . | plainify ) }}
+    {{ $title = i18n "commons.lightbox.button" }}
   {{ end }}
 
   <button class="lightbox-button" data-lightbox="{{ $options | encoding.Jsonify }}">

--- a/layouts/partials/commons/lightbox/button.html
+++ b/layouts/partials/commons/lightbox/button.html
@@ -1,5 +1,11 @@
-{{ with . }}
-  {{ $title := i18n "commons.lightbox.button" }}
+{{ $image := .image }}
+
+{{ with .context }}
+  {{ $title := i18n "commons.lightbox.button_without_alt" }}
+  {{ if .alt }}
+    {{ $title = i18n "commons.lightbox.button" }}
+  {{ end }}
+
   {{ $options := dict "imageSrc" ( partial "GetLightboxUrl" .id ) }}
 
   {{ with .text }}
@@ -13,9 +19,11 @@
 
   {{ with .alt }}
     {{ $options = merge $options (dict "alt" (. | plainify)) }}
+    {{ $title = printf "%s %s" $title ( . | plainify ) }}
   {{ end }}
 
   <button class="lightbox-button" data-lightbox="{{ $options | encoding.Jsonify }}">
     <span class="sr-only">{{ $title | plainify }}</span>
+    {{ $image }}
   </button>
 {{ end }}

--- a/layouts/partials/header/accessibility.html
+++ b/layouts/partials/header/accessibility.html
@@ -1,4 +1,4 @@
-<nav aria-label="{{ i18n "commons.accessibility.shortcut_navigation"}}" class="nav-accessibility">
+<nav aria-label="{{ i18n "commons.accessibility.shortcut_navigation"}}" class="nav-accessibility" id="nav-accessibility">
   <ul>
     <li><a href="#main">{{ i18n "commons.accessibility.main_content" }}</a></li>
     <li class="nav-accessibility__menu"><a href="#navigation">{{ i18n "commons.accessibility.menu" }}</a></li>

--- a/layouts/partials/header/search.html
+++ b/layouts/partials/header/search.html
@@ -11,4 +11,5 @@
   <button class="search__close" aria-label="{{ i18n "commons.search.close" }}">
     {{ i18n "commons.search.close" }}
   </button>
+  <p role="heading" aria-level="1" class="sr-only">{{ i18n "commons.search.title" }}</p>
 </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

- Dans les partials, on passe l'image _dans_ le bouton
- En js, on récupère l'index de tous les boutons détectés par la lightbox, on vient ensuite examiner la présence ou non d'un `alt`ou d'un `text`, et dans le cas d'une absence, on ajoute l'index (+1) pour permettre d'indentifier l'image

2 traductions : 
- Avec alt : "Agrandir" suivie de l'alt ou du text
- Sans alt/text : "Agrandir image x"
(fait en fr mais pas en pt/en)

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/760

## URL de test sur example.osuny.org

http://localhost:1313/fr/actualites/2024-11-18-la-nouvelle-visionneuse-dosuny/

## Screenshots
![Capture d’écran 2024-11-28 à 17 13 08](https://github.com/user-attachments/assets/b28e7329-5cdd-45c2-a7c3-981327a15d24)