### PR TITLE
Ajout d'une config pour désactiver les lightbox dans les blocs de galerie

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -249,8 +249,8 @@ params:
         mobile:   1920x2560
         tablet:   1920x2560
         desktop:  1920x2560
-      gallerylightbox:
-        disabled: false
+        in_gallery:
+          disabled: true
       hero:
         mobile:   400
         tablet:   800

--- a/layouts/partials/blocks/templates/gallery.html
+++ b/layouts/partials/blocks/templates/gallery.html
@@ -27,6 +27,7 @@
             {{ partial "commons/image-figure.html" (dict
                 "image"    .
                 "sizes"    $sizes
+                "gallery" true
               )}}
           {{ end -}}
         </div>

--- a/layouts/partials/commons/image-figure.html
+++ b/layouts/partials/commons/image-figure.html
@@ -1,16 +1,20 @@
+{{ $in_gallery := .gallery | default false }}
+
 {{ if .image.id }}
   {{ $sizes := .sizes }}
   {{ $lazy := default true .lazy }}
   {{ $image := partial "GetMedia" .image.id }}
   {{ $image_class := printf "image-%s" (partial "GetImageDirection" .image) }}
   {{ $is_lightbox := not site.Params.image_sizes.design_system.lightbox.disabled }}
+  {{ if and $is_lightbox $in_gallery }}
+    {{ $is_lightbox = not site.Params.image_sizes.design_system.lightbox.in_gallery.disabled }}
+  {{ end }}
 
   {{ if $image }}
     {{ with .image }}
       {{ $credit := partial "RemoveSrOnlyTag" .credit }}
       {{ $credit = cond $credit (printf "© %s" $credit) "" }}
-      <figure
-              class="{{ $image_class }}{{ if $is_lightbox }} lightbox-figure {{ end }}"
+      <figure class="{{ $image_class }}{{ if $is_lightbox }} lightbox-figure {{ end }}"
               {{- with or .text .alt $credit }}
                 role="figure"
                 aria-label="{{ . | plainify }}"


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Reprise de la config `gallerylightbox` pour clarifier et l'ajouter au partial `image-figure.html`.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

#760 

## URL de test sur example.osuny.org

https://example.osuny.org/fr/actualites/2024-11-18-la-nouvelle-visionneuse-dosuny/#avec-un-bloc-galerie-sans-visionneuse
