### PR TITLE
Hotfix : fermeture du tag de pagination

### DIFF
--- a/layouts/partials/commons/pagination.html
+++ b/layouts/partials/commons/pagination.html
@@ -14,93 +14,93 @@
 
 <!-- If there's more than one page. -->
 {{- if gt $paginator.TotalPages 1 -}}
-<nav aria-label="{{ i18n "commons.pagination.label" }}">
-  <ul class="pagination">
+  <nav aria-label="{{ i18n "commons.pagination.label" }}">
+    <ul class="pagination">
 
-    <!-- First page. -->
-    <li{{ if eq $paginator.PageNumber 1 }} class="disabled"{{ end }}>
-      <a href="{{ $paginator.First.URL }}"
-          aria-label="{{ i18n "commons.pagination.first" }}"
-          {{- if eq $paginator.PageNumber 1 }} aria-disabled="true" role="button" tabindex="-1"{{ end }}>
-      </a>
-    </li>
+      <!-- First page. -->
+      <li{{ if eq $paginator.PageNumber 1 }} class="disabled"{{ end }}>
+        <a href="{{ $paginator.First.URL }}"
+            aria-label="{{ i18n "commons.pagination.first" }}"
+            {{- if eq $paginator.PageNumber 1 }} aria-disabled="true" role="button" tabindex="-1"{{ end }}>
+        </a>
+      </li>
 
-    <!-- Previous page. -->
-    <li{{ if eq $paginator.HasPrev false }} class="disabled"{{ end }}>
-      <a href="{{ if $paginator.HasPrev }}{{ $paginator.Prev.URL }}{{ else }}{{ $paginator.First.URL }}{{ end }}"
-          aria-label="{{ i18n "commons.pagination.previous" }}"
-          {{- if eq $paginator.HasPrev false }} aria-disabled="true" role="button" tabindex="-1"{{ end }}>
-      </a>
-    </li>
+      <!-- Previous page. -->
+      <li{{ if eq $paginator.HasPrev false }} class="disabled"{{ end }}>
+        <a href="{{ if $paginator.HasPrev }}{{ $paginator.Prev.URL }}{{ else }}{{ $paginator.First.URL }}{{ end }}"
+            aria-label="{{ i18n "commons.pagination.previous" }}"
+            {{- if eq $paginator.HasPrev false }} aria-disabled="true" role="button" tabindex="-1"{{ end }}>
+        </a>
+      </li>
 
-    <!-- Page numbers. -->
-    {{- range $paginator.Pagers -}}
-      {{- $.Scratch.Set "page_number_flag" false -}}
+      <!-- Page numbers. -->
+      {{- range $paginator.Pagers -}}
+        {{- $.Scratch.Set "page_number_flag" false -}}
 
-      <!-- Advanced page numbers. -->
-      {{- if gt $paginator.TotalPages $max_links -}}
+        <!-- Advanced page numbers. -->
+        {{- if gt $paginator.TotalPages $max_links -}}
 
-        <!-- Lower limit pages. -->
-        <!-- If the user is on a page which is in the lower limit.  -->
-        {{- if le $paginator.PageNumber $lower_limit -}}
+          <!-- Lower limit pages. -->
+          <!-- If the user is on a page which is in the lower limit.  -->
+          {{- if le $paginator.PageNumber $lower_limit -}}
 
-          <!-- If the current loop page is less than max_links. -->
-          {{- if le .PageNumber $max_links -}}
-            {{- $.Scratch.Set "page_number_flag" true -}}
+            <!-- If the current loop page is less than max_links. -->
+            {{- if le .PageNumber $max_links -}}
+              {{- $.Scratch.Set "page_number_flag" true -}}
+            {{- end -}}
+
+          <!-- Upper limit pages. -->
+          <!-- If the user is on a page which is in the upper limit. -->
+          {{- else if ge $paginator.PageNumber $upper_limit -}}
+
+            <!-- If the current loop page is greater than total pages minus $max_links -->
+            {{- if gt .PageNumber (sub $paginator.TotalPages $max_links) -}}
+              {{- $.Scratch.Set "page_number_flag" true -}}
+            {{- end -}}
+
+          <!-- Middle pages. -->
+          {{- else -}}
+
+            {{- if and ( ge .PageNumber (sub $paginator.PageNumber $adjacent_links) ) ( le .PageNumber (add $paginator.PageNumber $adjacent_links) ) -}}
+              {{- $.Scratch.Set "page_number_flag" true -}}
+            {{- end -}}
+
           {{- end -}}
 
-        <!-- Upper limit pages. -->
-        <!-- If the user is on a page which is in the upper limit. -->
-        {{- else if ge $paginator.PageNumber $upper_limit -}}
-
-          <!-- If the current loop page is greater than total pages minus $max_links -->
-          {{- if gt .PageNumber (sub $paginator.TotalPages $max_links) -}}
-            {{- $.Scratch.Set "page_number_flag" true -}}
-          {{- end -}}
-
-        <!-- Middle pages. -->
+        <!-- Simple page numbers. -->
         {{- else -}}
 
-          {{- if and ( ge .PageNumber (sub $paginator.PageNumber $adjacent_links) ) ( le .PageNumber (add $paginator.PageNumber $adjacent_links) ) -}}
-            {{- $.Scratch.Set "page_number_flag" true -}}
-          {{- end -}}
+          {{- $.Scratch.Set "page_number_flag" true -}}
 
         {{- end -}}
 
-      <!-- Simple page numbers. -->
-      {{- else -}}
-
-        {{- $.Scratch.Set "page_number_flag" true -}}
+        <!-- Output page numbers. -->
+        {{- if eq ($.Scratch.Get "page_number_flag") true -}}
+          <li{{ if eq . $paginator }} class="active"{{ end }}>
+            <a href="{{ .URL }}" aria-label="{{ i18n "commons.pagination.page" (dict "Number" .PageNumber) }}">
+              {{- .PageNumber -}}
+            </a>
+          </li>
+        {{- end -}}
 
       {{- end -}}
 
-      <!-- Output page numbers. -->
-      {{- if eq ($.Scratch.Get "page_number_flag") true -}}
-        <li{{ if eq . $paginator }} class="active"{{ end }}>
-          <a href="{{ .URL }}" aria-label="{{ i18n "commons.pagination.page" (dict "Number" .PageNumber) }}">
-            {{- .PageNumber -}}
-          </a>
-        </li>
-      {{- end -}}
+      <!-- Next page. -->
+      <li{{ if eq $paginator.HasNext false }} class="disabled"{{ end }}>
+        <a href="{{ if $paginator.HasNext }}{{ $paginator.Next.URL }}{{else}}{{ $paginator.Last.URL }}{{ end }}"
+            aria-label="{{ i18n "commons.pagination.next" }}"
+            {{- if eq $paginator.HasNext false }} aria-disabled="true" role="button" tabindex="-1"{{ end }}>
+        </a>
+      </li>
 
-    {{- end -}}
+      <!-- Last page. -->
+      <li{{ if eq $paginator.PageNumber $paginator.TotalPages }} class="disabled"{{ end }}>
+        <a href="{{ $paginator.Last.URL }}"
+            aria-label="{{ i18n "commons.pagination.last" }}"
+            {{- if eq $paginator.PageNumber $paginator.TotalPages }} aria-disabled="true" role="button" tabindex="-1"{{ end }}>
+        </a>
+      </li>
 
-    <!-- Next page. -->
-    <li{{ if eq $paginator.HasNext false }} class="disabled"{{ end }}>
-      <a href="{{ if $paginator.HasNext }}{{ $paginator.Next.URL }}{{else}}{{ $paginator.Last.URL }}{{ end }}"
-          aria-label="{{ i18n "commons.pagination.next" }}"
-          {{- if eq $paginator.HasNext false }} aria-disabled="true" role="button" tabindex="-1"{{ end }}>
-      </a>
-    </li>
-
-    <!-- Last page. -->
-    <li{{ if eq $paginator.PageNumber $paginator.TotalPages }} class="disabled"{{ end }}>
-      <a href="{{ $paginator.Last.URL }}"
-          aria-label="{{ i18n "commons.pagination.last" }}"
-          {{- if eq $paginator.PageNumber $paginator.TotalPages }} aria-disabled="true" role="button" tabindex="-1"{{ end }}>
-      </a>
-    </li>
-
-  </ul><!-- .pagination -->
+    </ul><!-- .pagination -->
+  </nav>
 {{- end -}}
-</nav>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Correction d'une fermeture de la `<nav>` de la pagination s'il n'y a pas de pagination.


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


