### PR TITLE
Bloc contact : correction de l'affichage d'un champ information avec plusieurs paragraphes

### DIFF
--- a/assets/sass/_theme/blocks/contact.sass
+++ b/assets/sass/_theme/blocks/contact.sass
@@ -19,7 +19,7 @@
                 gap: var(--grid-gutter)
                 [itemprop="name"]
                     width: columns(4)
-                p + p
+                > div
                     flex: 1
         a
             @extend %underline-on-hover

--- a/layouts/partials/blocks/templates/contact.html
+++ b/layouts/partials/blocks/templates/contact.html
@@ -38,7 +38,9 @@
           {{ end }}
 
           {{ with .information }}
-              {{ partial "PrepareHTML" . }}
+              <div>
+                {{ partial "PrepareHTML" . }}
+              </div>
             </div>
           {{ end }}
           <div class="contacts">


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

On avait un display flex sur toute la `div.informations`, or elle contenait à présent à la fois le titre et le ou les paragraphes d'informations, ce qui faisait qu'on pouvait avoir sur une même ligne titre + p1 + p2, j'ai donc ajouté une div pour englober le texte d'information (vaut-il mieux gérer le cas en style ?)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/blocks-techniques/contact/`

## URL de test du site [Pourparlers](https://github.com/osunyorg/pourparlers-site)

`http://localhost:1313/fr/mentions-legales/`

## Screenshots
![Capture d’écran 2024-12-03 à 09 48 07](https://github.com/user-attachments/assets/97c9828a-aea2-431a-b6f8-b18f92371269)
![Capture d’écran 2024-12-03 à 09 47 49](https://github.com/user-attachments/assets/c8728010-b9ee-47de-be33-935f04a54b17)