### PR TITLE
Champs de contacts et réseaux sociaux : uniformisation

### DIFF
--- a/assets/sass/_theme/blocks/contact.sass
+++ b/assets/sass/_theme/blocks/contact.sass
@@ -25,7 +25,7 @@
             @extend %underline-on-hover
         .contacts
             margin-top: $spacing-3
-            h3, h4, h5, h6
+            h2, h3, h4, h5, h6
                 @include meta
             @include media-breakpoint-down(desktop)
                 > div 

--- a/assets/sass/_theme/design-system/footer.sass
+++ b/assets/sass/_theme/design-system/footer.sass
@@ -25,7 +25,8 @@ footer#document-footer
         &-site
             @include small
             > * + *,
-            p + address
+            p + address,
+            address + p
                 margin-top: $spacing-2
         &-social, &-legals, &-credit
             @include meta

--- a/assets/sass/_theme/design-system/hero.sass
+++ b/assets/sass/_theme/design-system/hero.sass
@@ -136,14 +136,15 @@
                 @include media-breakpoint-down(md)
                     padding-bottom: 0
             dd
+                display: flex
+                flex-wrap: wrap
+                column-gap: $spacing-2
                 grid-column: 3/7
                 @include media-breakpoint-down(md)
                     padding-top: 0
                 a
                     @include link($hero-color)
-                    display: inline-block
-                    + a
-                        margin-left: $spacing-2
+                    white-space: nowrap
         .buttons
             @include meta
             display: flex

--- a/layouts/partials/blocks/templates/contact.html
+++ b/layouts/partials/blocks/templates/contact.html
@@ -20,6 +20,7 @@
             "level" $heading_rank
             "attributes" "itemprop='name'"
           ) }}
+        {{ $a11y_name := .name | default (i18n "commons.contact.empty_name") }}
         
         {{ if .name }}
           {{ $heading_rank = $heading_rank | add 1 }}
@@ -45,7 +46,15 @@
           {{ end }}
           <div class="contacts">
             {{ with .contact_details }}
+              {{ $has_address := false}}
               {{ with .postal_address }}
+                {{ with .data }}
+                  {{ if or .address_name .address .address_additional .zipcode .city .country.name }}
+                    {{ $has_address = true}}
+                  {{ end }}
+                {{ end }}
+              {{ end }}
+              {{ if $has_address }}
                 <div class="address">
                   {{ $heading_items.open }}
                     {{- i18n "commons.contact.address" -}}
@@ -53,7 +62,7 @@
                   {{ partial "commons/address.html" . }}
                 </div>
               {{ end }}
-              {{ if or .url .emails }}
+              {{ if or .websites.website .emails.list }}
                 <div>
                   {{ $heading_items.open }}
                     {{ if .url }}
@@ -62,15 +71,15 @@
                       {{- i18n "commons.contact.email.label" -}}
                     {{ end }}
                   {{ $heading_items.close }}
-                  {{ range .emails }}
+                  {{ range .emails.list }}
                     <p><a itemprop="email" href="{{ chomp .value | safeURL }}" title="{{ safeHTML (i18n "commons.contact.email.a11y_label" (dict "email" .label )) }}">{{ .label }}</a></p>
                   {{ end }}
-                  {{ with .url }}
+                  {{ with .websites.website }}
                     <p><a href="{{ chomp .value | safeURL }}" target="_blank" rel="noreferrer">{{ .label }}</a></p>
                   {{ end }}
                 </div>
               {{ end }}
-              {{ with .phone_numbers }}
+              {{ with .phone_numbers.list }}
                 <div>
                   {{ $heading_items.open }}
                     {{- i18n "commons.contact.phone.label" -}}
@@ -80,8 +89,7 @@
                   {{ end }}
                 </div>
               {{ end }}
-              {{ $a11y_name := .name | default (i18n "commons.contact.empty_name") }}
-              {{ with .social_networks }}
+              {{ if .social_networks }}
                 <div>
                   {{ $heading_items.open }}
                     {{- i18n "commons.contact.socials.title" -}}
@@ -97,7 +105,8 @@
             {{ end }}
               {{ if .timetable }}
                 {{ $time_size := "full-size" }}
-                {{ if and (or .emails .url) .phone_numbers .socials }}
+                {{ $contacts := .contact_details }}
+                {{ if and (or $contacts.emails.list $contacts.websites.website) $contacts.phone_numbers.list $contacts.social_networks }}
                   {{ $time_size = "reduced" }}
                 {{ end}}
                 <div class="schedule-table {{ $time_size -}}">

--- a/layouts/partials/blocks/templates/organizations/map.html
+++ b/layouts/partials/blocks/templates/organizations/map.html
@@ -30,7 +30,7 @@
                   {{ end -}}
                   </p>
               {{ end -}}
-              {{ with .Params.contact_details.postal_address }}
+              {{ with .Params.contact_details }}
                 {{ partial "commons/address.html" . }}
               {{ end }}
               {{ if and $options.summary .Params.summary }}

--- a/layouts/partials/blocks/templates/projects/list.html
+++ b/layouts/partials/blocks/templates/projects/list.html
@@ -6,7 +6,9 @@
 
 <div class="list">
   {{ range $project := .projects -}}
-    {{ with site.GetPage .file }}
+  {{ .permalink }}
+
+  {{ with site.GetPage "/projects/2023-bonnes-notes" }}
     {{ $heading_tag := (dict 
         "open" ((printf "<%s class='project-title' itemprop='name'>" $heading) | safeHTML)
         "close" ((printf "</%s>" $heading) | safeHTML)

--- a/layouts/partials/commons/address.html
+++ b/layouts/partials/commons/address.html
@@ -1,9 +1,9 @@
 {{ $address := .address | default . }}
 
-{{ with $address }}
-  {{ with .html }}
+{{ with $address.postal_address }}
+  {{/*  {{ with .html }}
     {{ partial "PrepareHTML" . }}
-  {{ else }}
+  {{ else }}  */}}
     {{ with .data }}
       <address itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
         {{ with .address }}
@@ -21,12 +21,12 @@
             {{ partial "PrepareHTML" . }}
           </span>
         {{ end }}
-        {{ with .country }}
+        {{ with .city }}
           <span itemprop="addressCountry">
             {{ partial "PrepareHTML" . }}
           </span>
         {{ end }}
       </address>
     {{ end }}
-  {{ end }}
+  {{/*  {{ end }}  */}}
 {{ end }}

--- a/layouts/partials/commons/contact-details.html
+++ b/layouts/partials/commons/contact-details.html
@@ -1,11 +1,29 @@
 {{ $name := .Title }}
-
 {{ with .Params.contact_details }}
-  {{ if or .website .linkedin .twitter .email .phone .address .city .zipcode .country }}
+  {{ $contacts := slice 
+    .websites.website 
+    .social_networks.linkedin 
+    .social_networks.twitter 
+    .emails 
+    .phone_numbers.list 
+    .postal_address.data.address 
+    .postal_address.data.city 
+    .postal_address.data.zipcode 
+    .postal_address.data.country 
+  }}
+
+  {{ $has_contacts := false }}
+  {{ range $contacts }}
+    {{ if . }}
+      {{ $has_contacts = true }}
+    {{ end }}
+  {{ end }}
+
+  {{ if $has_contacts }}
     <div class="contacts-details contacts-details--person">
-      {{ if or .website .linkedin .twitter .email .phone }}
+      {{ if or .websites.website .socials_networks.linkedin .social_networks.twitter .emails.email .phone_numbers.list.phone }}
         <ul>
-          {{ with .website }}
+          {{ with .websites.website }}
             <li>
               <span>{{ i18n "commons.contact.website" }}</span>
               <a href="{{ chomp .value | safeURL }}" target="_blank" rel="noopener" itemprop="url" title="{{ safeHTML (i18n "commons.contact.socials.label.website" (dict "name" $name )) }}">
@@ -14,38 +32,39 @@
               </a>
             </li>
           {{ end }}
+          {{with .social_networks }}
+            {{ with .linkedin }}
+              <li>
+                <span>LinkedIn</span>
+                <a href="{{ chomp .value | safeURL }}" target="_blank" rel="noopener" itemprop="url" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "LinkedIn" "name" $name )) }}">
+                  {{ chomp .label }}
+                  <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+                </a>
+              </li>
+            {{ end }}
 
-          {{ with .linkedin }}
-            <li>
-              <span>LinkedIn</span>
-              <a href="{{ chomp .value | safeURL }}" target="_blank" rel="noopener" itemprop="url" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "LinkedIn" "name" $name )) }}">
-                {{ chomp .label }}
-                <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
-              </a>
-            </li>
+            {{ with .mastodon }}
+              <li>
+                <span>Mastodon</span>
+                <a href="{{ chomp .value | safeURL }}" target="_blank" rel="noopener" itemprop="url" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Mastodon" "name" $name )) }}">
+                  {{ chomp .label }}
+                  <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+                </a>
+              </li>
+            {{ end }}
+
+            {{ with .twitter }}
+              <li>
+                <span>X (ex-Twitter)</span>
+                <a href="{{ chomp .value | safeURL }}" target="_blank" rel="noopener" itemprop="url" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "X (ex-Twitter)" "name" $name )) }}">
+                  {{ chomp .label }}
+                  <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
+                </a>
+              </li>
+            {{ end }}
           {{ end }}
 
-          {{ with .mastodon }}
-            <li>
-              <span>Mastodon</span>
-              <a href="{{ chomp .value | safeURL }}" target="_blank" rel="noopener" itemprop="url" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Mastodon" "name" $name )) }}">
-                {{ chomp .label }}
-                <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
-              </a>
-            </li>
-          {{ end }}
-
-          {{ with .twitter }}
-            <li>
-              <span>X (ex-Twitter)</span>
-              <a href="{{ chomp .value | safeURL }}" target="_blank" rel="noopener" itemprop="url" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "X (ex-Twitter)" "name" $name )) }}">
-                {{ chomp .label }}
-                <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
-              </a>
-            </li>
-          {{ end }}
-
-          {{ with .email }}
+          {{ with .emails.email }}
             <li>
               <span>{{ i18n "commons.contact.email.label" }}</span>
               <a href="{{ chomp .value | safeURL }}" itemprop="email" title='{{ safeHTML (i18n "commons.contact.email.a11y_label" (dict "email" .label )) }}'>
@@ -54,23 +73,23 @@
               </a>
             </li>
           {{ end }}
-          {{ with .phone }}
-            <li>
-              <span>{{ i18n "commons.contact.phone.label" }}</span>
-              <a href="{{ chomp .value | safeURL }}" itemprop="telephone" title='{{ safeHTML (i18n "commons.contact.phone.a11y_label" (dict "phone_number" .label )) }}'>{{ .label }}</a>
-            </li>
-          {{ end }}
-          {{ with .phone_professional }}
-            <li>
-              <span>{{ i18n "commons.contact.phone_professional.label" }}</span>
-              <a href="{{ chomp .value | safeURL }}" itemprop="telephone" title='{{ safeHTML (i18n "commons.contact.phone_professional.a11y_label" (dict "phone_number" .label )) }}'>{{ .label }}</a>
-            </li>
+          {{ with .phone_numbers }}
+            {{ with or .phone_mobile .phone }}
+              <li>
+                <span>{{ i18n "commons.contact.phone.label" }}</span>
+                <a href="{{ chomp .value | safeURL }}" itemprop="telephone" title='{{ safeHTML (i18n "commons.contact.phone.a11y_label" (dict "phone_number" .label )) }}'>{{ .label }}</a>
+              </li>
+            {{ end }}
+            {{ with .phone_professional }}
+              <li>
+                <span>{{ i18n "commons.contact.phone_professional.label" }}</span>
+                <a href="{{ chomp .value | safeURL }}" itemprop="telephone" title='{{ safeHTML (i18n "commons.contact.phone_professional.a11y_label" (dict "phone_number" .label )) }}'>{{ .label }}</a>
+              </li>
+            {{ end }}
           {{ end }}
         </ul>
       {{ end }}
-      {{ with .postal_address }}
-        {{ partial "commons/address.html" . }}
-      {{ end }}
+      {{ partial "commons/address.html" . }}
     </div>
   {{ end }}
 {{ end }}

--- a/layouts/partials/commons/contact-details.html
+++ b/layouts/partials/commons/contact-details.html
@@ -9,7 +9,7 @@
     .postal_address.data.address 
     .postal_address.data.city 
     .postal_address.data.zipcode 
-    .postal_address.data.country 
+    .postal_address.data.country.name
   }}
 
   {{ $has_contacts := false }}

--- a/layouts/partials/commons/socials.html
+++ b/layouts/partials/commons/socials.html
@@ -1,63 +1,65 @@
 {{ $name := .name | default (htmlUnescape site.Title) }}
 {{ $context := .context | default . }}
 
-{{ with $context.email }}
+{{ with $context.emails.email }}
   <li class="email">
-    <a href="mailto:{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.email" (dict "name" $name )) }}" target="_blank">{{ i18n "commons.contact.email.label" }}</a>
+    <a href="mailto:{{ chomp .value | safeURL }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.email" (dict "name" $name )) }}" target="_blank">{{ i18n "commons.contact.email.label" }}</a>
   </li>
 {{ end}}
-{{ with $context.rss }}
-  <li class="rss">
-    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.rss" (dict "name" $name )) }}" target="_blank">RSS</a>
-  </li>
-{{ end}}
-{{ with $context.mastodon }}
-  <li class="mastodon">
-    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Mastodon" "name" $name )) }}" target="_blank">Mastodon</a>
-  </li>
-{{ end}}
-{{ with $context.peertube }}
-  <li class="peertube">
-    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Peertub" "name" $name )) }}" target="_blank">Peertube</a>
-  </li>
-{{ end}}
-{{ with $context.github }}
-  <li class="github">
-    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Github" "name" $name )) }}" target="_blank">GitHub</a>
-  </li>
-{{ end}}
-{{ with $context.linkedin }}
-  <li class="linkedin">
-    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "LinkedIn" "name" $name )) }}" target="_blank">LinkedIn</a>
-  </li>
-{{ end}}
-{{ with $context.youtube }}
-  <li class="youtube">
-    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "YouTube" "name" $name )) }}" target="_blank">YouTube</a>
-  </li>
-{{ end}}
-{{ with $context.vimeo }}
-  <li class="vimeo">
-    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Vimeo" "name" $name )) }}" target="_blank">Vimeo</a>
-  </li>
-{{ end}}
-{{ with $context.instagram }}
-  <li class="instagram">
-    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Instagram" "name" $name )) }}" target="_blank">Instagram</a>
-  </li>
-{{ end}}
-{{ with $context.facebook }}
-  <li class="facebook">
-    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Facebook" "name" $name )) }}" target="_blank">Facebook</a>
-  </li>
-{{ end}}
-{{ with $context.tiktok }}
-  <li class="tiktok">
-    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "TikTok" "name" $name )) }}" target="_blank">TikTok</a>
-  </li>
-{{ end}}
-{{ with $context.x }}
-  <li class="x">
-    <a href="{{ . }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "X, ex-twitter" "name" $name )) }}" target="_blank">X (ex-Twitter)</a>
-  </li>
-{{ end}}
+{{ with $context.social_networks }}
+  {{ with .rss }}
+    <li class="rss">
+      <a href="{{ chomp .value | safeURL }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.rss" (dict "name" $name )) }}" target="_blank">RSS</a>
+    </li>
+  {{ end}}
+  {{ with .mastodon }}
+    <li class="mastodon">
+      <a href="{{ chomp .value | safeURL }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Mastodon" "name" $name )) }}" target="_blank">Mastodon</a>
+    </li>
+  {{ end}}
+  {{ with .peertube }}
+    <li class="peertube">
+      <a href="{{ chomp .value | safeURL }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Peertub" "name" $name )) }}" target="_blank">Peertube</a>
+    </li>
+  {{ end}}
+  {{ with .github }}
+    <li class="github">
+      <a href="{{ chomp .value | safeURL }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Github" "name" $name )) }}" target="_blank">GitHub</a>
+    </li>
+  {{ end}}
+  {{ with .linkedin }}
+    <li class="linkedin">
+      <a href="{{ chomp .value | safeURL }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "LinkedIn" "name" $name )) }}" target="_blank">LinkedIn</a>
+    </li>
+  {{ end}}
+  {{ with .youtube }}
+    <li class="youtube">
+      <a href="{{ chomp .value | safeURL }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "YouTube" "name" $name )) }}" target="_blank">YouTube</a>
+    </li>
+  {{ end}}
+  {{ with .vimeo }}
+    <li class="vimeo">
+      <a href="{{ chomp .value | safeURL }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Vimeo" "name" $name )) }}" target="_blank">Vimeo</a>
+    </li>
+  {{ end}}
+  {{ with .instagram }}
+    <li class="instagram">
+      <a href="{{ chomp .value | safeURL }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Instagram" "name" $name )) }}" target="_blank">Instagram</a>
+    </li>
+  {{ end}}
+  {{ with .facebook }}
+    <li class="facebook">
+      <a href="{{ chomp .value | safeURL }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "Facebook" "name" $name )) }}" target="_blank">Facebook</a>
+    </li>
+  {{ end}}
+  {{ with .tiktok }}
+    <li class="tiktok">
+      <a href="{{ chomp .value | safeURL }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "TikTok" "name" $name )) }}" target="_blank">TikTok</a>
+    </li>
+  {{ end}}
+  {{ with .x }}
+    <li class="x">
+      <a href="{{ chomp .value | safeURL }}" rel="noreferrer" title="{{ safeHTML (i18n "commons.contact.socials.label.social_media" (dict "media" "X, ex-twitter" "name" $name )) }}" target="_blank">X (ex-Twitter)</a>
+    </li>
+  {{ end}}
+{{ end }}

--- a/layouts/partials/footer/site.html
+++ b/layouts/partials/footer/site.html
@@ -4,15 +4,13 @@
   <div itemscope itemtype="https://schema.org/CollegeOrUniversity">
     <meta itemprop="logo" content="{{ $logo }}">
     <p itemprop="name">{{ htmlUnescape (trim .name "\n") }}</p>
-    {{ with .contact_details.postal_address }}
-        {{ partial "commons/address.html" . }}
-    {{ end }}
-    {{- if .phone -}}
-      <p>
-        {{- $phone := trim .phone "\n " -}}
-        {{- $phone_href := replace $phone " " "" -}}
-        <a itemprop="telephone" href="tel:{{ $phone_href }}">{{ $phone }}</a>
-      </p>
+    {{ with .contact_details }} 
+      {{ partial "commons/address.html" . }}
+      {{- with .phone_numbers.phone -}}
+        <p>
+          <a itemprop="telephone" href="{{.value}}">{{ .label }}</a>
+        </p>
+      {{- end }}
     {{- end }}
   </div>
 {{- end -}}
@@ -20,15 +18,13 @@
   <div itemscope itemtype="https://schema.org/ResearchOrganization">
     <meta itemprop="logo" content="{{ $logo }}">
     <p itemprop="name">{{ htmlUnescape (trim .name "\n") }}</p>
-    {{ with .contact_details.postal_address }}
-        {{ partial "commons/address.html" . }}
-    {{ end }}
-    {{- if .phone -}}
-      <p>
-        {{- $phone := trim .phone "\n " -}}
-        {{- $phone_href := replace $phone " " "" -}}
-        <a itemprop="telephone" href="tel:{{ $phone_href }}">{{ $phone }}</a>
-      </p>
+    {{ with .contact_details }} 
+    {{ partial "commons/address.html" . }}
+      {{- with .phone_numbers.phone -}}
+          <p>
+            <a itemprop="telephone" href="{{.value}}">{{ .label }}</a>
+          </p>
+      {{- end }}
     {{- end }}
   </div>
 {{- end -}}

--- a/layouts/partials/footer/social.html
+++ b/layouts/partials/footer/social.html
@@ -9,7 +9,7 @@
   )}}
 {{ end }}
 
-{{ with (or site.Params.social site.Data.website.social) }}
+{{ with (or site.Params.contact_details site.Data.website.social) }}
   {{ $site_social_links := . }}
   {{ if $site_social_links }}
     <ul class="footer-social site-links">

--- a/layouts/partials/locations/hero-address.html
+++ b/layouts/partials/locations/hero-address.html
@@ -1,3 +1,3 @@
-{{ with .Params.contact_details.postal_address }}
+{{ with .Params.contact_details }}
   {{ partial "commons/address" . }}
 {{ end }}

--- a/layouts/partials/locations/location.html
+++ b/layouts/partials/locations/location.html
@@ -13,7 +13,7 @@
       {{ $heading_tag.open }}
         <a href="{{ .Permalink }}" title="{{ safeHTML (i18n "commons.more_aria" (dict "Title" $title)) }}">{{ $title }}</a>
       {{ $heading_tag.close }}
-      {{ with .Params.contact_details.postal_address }}
+      {{ with .Params.contact_details }}
         {{ partial "commons/address" . }}
       {{ end }}
       <div class="location-description" itemprop="description">

--- a/layouts/partials/locations/map.html
+++ b/layouts/partials/locations/map.html
@@ -23,7 +23,7 @@
                   </a>
                 {{ end -}}
               </p>
-              {{ with .Params.contact_details.postal_address }}
+              {{ with .Params.contact_details }}
                 {{ partial "commons/address" . }}
               {{ end }}
             </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [X] Rangement

## Description

Partie thème de https://github.com/osunyorg/admin/pull/2459

On a des changements dans plusieurs partials : 
- `commons/socials.html` : on ajoute une clé de vérification pour accéder à l'email + on met à jour chaque champ avec .value
- Pour l'appel du partial `commons/address `, on enlève le niveau `.postal_address` pour ne garder que `Params.contact_details` car `.html` n'est plus à l'intérieur de `.data`
- Dans le partial `blocks/templates/contact.html` on remet à niveau les différentes clés  
- Dans `commons/contact-details.html` on ajoute une vérification des champs disponibles

Et en bonus, j'ai vu que sur les héros d'une formation listant les campus, on avait une `margin-left` qui décalait le texte (cf. screens plus bas), c'est réparé.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [X] Incidence forte 😱


## URL de test sur recette

Pages de personne, orga, footer, block contact...

## Screenshots

![Capture d’écran 2024-12-06 à 14 27 29](https://github.com/user-attachments/assets/f4038576-cdef-4f75-9366-fc1379949fa6)
![Capture d’écran 2024-12-06 à 14 27 18](https://github.com/user-attachments/assets/27337d7d-bd4c-482d-80c4-e3634603568e)

