### PR TITLE
Ajout d'une option du `title` de la page

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -2,7 +2,7 @@ enableRobotsTXT: true
 removePathAccents: true
 ignoreLogs: ['warning-goldmark-raw-html']
 pagination:
-  pagerSize: 36
+  pagerSize: 3
 params:
   debug:
     active: false
@@ -11,7 +11,7 @@ params:
   plausible: false
   seo:
     title:
-      sitename: true
+      sitename: false
       separator: "|"
 
   # DESIGN SYSTEM

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -11,6 +11,7 @@ params:
   plausible: false
   seo:
     title:
+      sitename: true
       separator: "|"
 
   # DESIGN SYSTEM

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -2,7 +2,7 @@ enableRobotsTXT: true
 removePathAccents: true
 ignoreLogs: ['warning-goldmark-raw-html']
 pagination:
-  pagerSize: 3
+  pagerSize: 36
 params:
   debug:
     active: false

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -11,7 +11,7 @@ params:
   plausible: false
   seo:
     title:
-      sitename: false
+      sitename: true
       separator: "|"
 
   # DESIGN SYSTEM

--- a/layouts/partials/GetPaginateTitle
+++ b/layouts/partials/GetPaginateTitle
@@ -1,14 +1,14 @@
 {{ $seoTitle := .title }} 
-{{ $seoTitleSeparator := .separator}}
+{{ $seoTitleSeparator := .separator }}
 {{ $page := i18n "commons.pagination.title" }}
 
-{{if and (not .context.IsHome) (eq .kind "page") }}
-    {{ with .context.Paginator }}
-        {{ if or .HasPrev .HasNext }}
-            {{ $currentPageNumber := .PageNumber}}
-            {{ $seoTitle = printf "%s %s %s %d" $seoTitle $seoTitleSeparator $page $currentPageNumber }} 
-        {{ end }}
+{{ if and (not .context.IsHome) (eq .context.Kind "section") }}
+  {{ with .context.Paginator }}
+    {{ if or .HasPrev .HasNext }}
+      {{ $currentPageNumber := .PageNumber }}
+      {{ $seoTitle = printf "%s %s %s %d" $seoTitle $seoTitleSeparator $page $currentPageNumber }}
     {{ end }}
+  {{ end }}
 {{ end }}
 
 {{ return $seoTitle }}

--- a/layouts/partials/head/seo.html
+++ b/layouts/partials/head/seo.html
@@ -1,8 +1,12 @@
 {{- $title := chomp (htmlUnescape .Title) -}}
 {{- $seoTitle := htmlUnescape site.Title -}}
 {{- $seoTitleSeparator := htmlUnescape site.Params.seo.title.separator -}}
-{{- if .Title -}}
-  {{- $seoTitle = printf "%s %s %s" $title $seoTitleSeparator $seoTitle -}}
+{{- if $title -}}
+  {{- if site.Params.seo.title.sitename }}
+    {{- $seoTitle = printf "%s %s %s" $title $seoTitleSeparator $seoTitle -}}
+  {{ else -}}
+    {{- $seoTitle = $title -}}
+  {{ end -}}
 {{- end -}}
 {{- $seoTitle = partial "GetPaginateTitle" ( dict "title" $seoTitle "separator" $seoTitleSeparator "context" .) -}}
 {{- $seoDescription := "" -}}

--- a/layouts/partials/head/seo.html
+++ b/layouts/partials/head/seo.html
@@ -8,7 +8,7 @@
     {{- $seoTitle = $title -}}
   {{ end -}}
 {{- end -}}
-{{- $seoTitle = partial "GetPaginateTitle" ( dict "title" $seoTitle "separator" $seoTitleSeparator "context" .) -}}
+{{- $seoTitle = partial "GetPaginateTitle" ( dict "title" $seoTitle "separator" $seoTitleSeparator "context" . ) -}}
 {{- $seoDescription := "" -}}
 {{- if .Params.meta_description -}}
   {{- $seoDescription = partial "PrepareHTML" .Params.meta_description -}}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Mise en option de l'ajout du titre du site dans le titre de la page (balise `title`).

Option : 

```
  seo:
    title:
      sitename: true
```


Correction du numéro de la pagination dans le titre.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
