### PR TITLE
Ajustement de la liste des blocs sans marge inférieure lorsqu'ils sont à la fin de la liste

### DIFF
--- a/assets/sass/_theme/blocks/base.sass
+++ b/assets/sass/_theme/blocks/base.sass
@@ -23,7 +23,7 @@
     margin-top: var(--heading-margin-bottom)
 
 // Specific
-$backgrounded_blocks: ".block-call_to_action, .block-chapter--accent_background, .block-chapter--alt_background, .block-timeline--horizontal, .block-pages--cards"
+$backgrounded_blocks: ".block-call_to_action--accent_background, .block-chapter--accent_background, .block-chapter--alt_background, .block-timeline--horizontal, .block-pages--cards"
 .blocks
     .block:first-child
         margin-top: 0


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Nous n'avions pas pris en compte la nouveauté du layout sans fond pour le CTA, on réduit donc ici le scope pour ne cibler que le `.block-call_to_action--accent_background`.

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/812

## URL de test du site [Bee Learning](https://github.com/osunyorg/marionrebier-beelearning)

http://localhost:1313/ingenierie-pedagogique/

## Screenshots
![Capture d’écran 2024-12-10 à 10 11 56](https://github.com/user-attachments/assets/a79d13e1-7dfd-424e-bd09-970b6f08bf6b)
![Capture d’écran 2024-12-10 à 10 11 27](https://github.com/user-attachments/assets/31a8acac-70d2-4836-a55e-3ea6e0a80260)