### PR TITLE
Correction du lien vers les campus dans le hero des formations

### DIFF
--- a/layouts/partials/programs/hero-essential.html
+++ b/layouts/partials/programs/hero-essential.html
@@ -27,8 +27,8 @@
           <dt>{{ i18n "programs.location" ( len . ) }}</dt>
           <dd>
             {{- range . -}}
-              {{- $locationpage := site.GetPage ( printf "/locations/%s" .slug ) -}}
-              <a href="{{ .path }}">{{ $locationpage.Params.title }}</a>
+              {{- $locationpage := site.GetPage .path -}}
+              <a href="{{ .permalink }}">{{ $locationpage.Params.title }}</a>
             {{- end -}}
           </dd>
         {{- end -}}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Le lien "Périgueux" dans le `hero-essential` renvoie vers une 404 car cela prend le mauvais lien.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test du site : IUT Bordeaux Montaigne

`http://localhost:1314/formations/carrieres-sociales/animation-sociale-et-socioculturelle/`