### PR TITLE
Bloc contact : utiliser le `rank.children` pour les niveaux de titre

### DIFF
--- a/layouts/partials/blocks/templates/contact.html
+++ b/layouts/partials/blocks/templates/contact.html
@@ -11,10 +11,7 @@
           "description" .description
         )}}
 
-        {{ $heading_rank := $block.ranks.self }}
-        {{ if $block.title }}
-          {{ $heading_rank = $block.ranks.self | add 1 }}
-        {{ end }}
+        {{ $heading_rank := $block.ranks.children }}
 
         {{ $heading_name := partial "GetHeadingTag" ( dict 
             "level" $heading_rank


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [x] Rangement

## Description

Ne pas s'appuyer sur le `rank.self` pour calculer les niveaux de titres en dessous mais utiliser le `rank.children` fourni par la data.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


