### PR TITLE
Remplacement de la clé de titre ranks.self par ranks.base

### DIFF
--- a/layouts/partials/blocks/templates/agenda.html
+++ b/layouts/partials/blocks/templates/agenda.html
@@ -17,7 +17,7 @@
         
         {{ partial "blocks/top.html" (dict
           "title" $block.title
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
           "description" .description
           "link" $link
         )}}

--- a/layouts/partials/blocks/templates/call_to_action.html
+++ b/layouts/partials/blocks/templates/call_to_action.html
@@ -10,7 +10,7 @@
           <div>
             {{ partial "blocks/top.html" (dict
               "title" $block.title
-              "heading_level" $block.ranks.self
+              "heading_level" $block.ranks.base
               "description" .text
             )}}
 

--- a/layouts/partials/blocks/templates/chapter.html
+++ b/layouts/partials/blocks/templates/chapter.html
@@ -15,7 +15,7 @@
           <div class="text">
             {{ partial "blocks/top.html" (dict
               "title" $block.title
-              "heading_level" $block.ranks.self
+              "heading_level" $block.ranks.base
             )}}
 
             {{ if (partial "GetTextFromHTML" .text) -}}

--- a/layouts/partials/blocks/templates/contact.html
+++ b/layouts/partials/blocks/templates/contact.html
@@ -7,7 +7,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
           "title" $block.title
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
           "description" .description
         )}}
 

--- a/layouts/partials/blocks/templates/datatable.html
+++ b/layouts/partials/blocks/templates/datatable.html
@@ -7,7 +7,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
           "title" $block.title
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
           "description" .description
         )}}
 

--- a/layouts/partials/blocks/templates/definitions.html
+++ b/layouts/partials/blocks/templates/definitions.html
@@ -9,7 +9,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
           "title" $block.title
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
           "description" .description
         )}}
         <div class="definitions">

--- a/layouts/partials/blocks/templates/embed.html
+++ b/layouts/partials/blocks/templates/embed.html
@@ -8,7 +8,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
           "title" $block.title
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
         )}}
 
         {{- if .code }}

--- a/layouts/partials/blocks/templates/features.html
+++ b/layouts/partials/blocks/templates/features.html
@@ -8,7 +8,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
           "title" $block.title
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
           "description" .description
         )}}
 

--- a/layouts/partials/blocks/templates/files.html
+++ b/layouts/partials/blocks/templates/files.html
@@ -7,7 +7,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
           "title" $block.title
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
           "description" .description
         )}}
         

--- a/layouts/partials/blocks/templates/gallery.html
+++ b/layouts/partials/blocks/templates/gallery.html
@@ -14,7 +14,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
           "title" $block.title
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
           "description" .description
         ) }}
 

--- a/layouts/partials/blocks/templates/image.html
+++ b/layouts/partials/blocks/templates/image.html
@@ -12,7 +12,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
           "title" $block.title
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
         )}}
         
         <!-- TODO Peut etre aligner la stucture des données avec les autres cas d'images -->

--- a/layouts/partials/blocks/templates/key_figures.html
+++ b/layouts/partials/blocks/templates/key_figures.html
@@ -9,7 +9,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
           "title" $block.title
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
           "description" .description
         )}}
 

--- a/layouts/partials/blocks/templates/license.html
+++ b/layouts/partials/blocks/templates/license.html
@@ -7,7 +7,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
           "title" $block.title
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
         )}}
 
         {{ with .creative_commons }}

--- a/layouts/partials/blocks/templates/links.html
+++ b/layouts/partials/blocks/templates/links.html
@@ -7,7 +7,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
           "title" $block.title
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
           "description" .description
         )}}
         

--- a/layouts/partials/blocks/templates/locations.html
+++ b/layouts/partials/blocks/templates/locations.html
@@ -11,7 +11,7 @@
         {{ partial "blocks/top.html" (dict
           "title" $block.title
           "description" .description
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
         )}}
 
         {{ $locations := slice }}

--- a/layouts/partials/blocks/templates/organizations.html
+++ b/layouts/partials/blocks/templates/organizations.html
@@ -17,7 +17,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
             "title" $block.title
-            "heading_level" $block.ranks.self
+            "heading_level" $block.ranks.base
             "description" .description
           )}}
 

--- a/layouts/partials/blocks/templates/pages.html
+++ b/layouts/partials/blocks/templates/pages.html
@@ -43,7 +43,7 @@
         {{ partial "blocks/top.html" (dict
           "title" $title
           "link" $page_link
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
           "description" $main_summary
         ) }}
 

--- a/layouts/partials/blocks/templates/papers.html
+++ b/layouts/partials/blocks/templates/papers.html
@@ -13,7 +13,7 @@
 
           {{ partial "blocks/top.html" (dict
             "title" $block.title
-            "heading_level" $block.ranks.self
+            "heading_level" $block.ranks.base
             "link" $link
             "description" .description
           )}}

--- a/layouts/partials/blocks/templates/persons.html
+++ b/layouts/partials/blocks/templates/persons.html
@@ -25,7 +25,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
           "title" $block.title
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
           "description" .description
         )}}
 

--- a/layouts/partials/blocks/templates/posts.html
+++ b/layouts/partials/blocks/templates/posts.html
@@ -29,7 +29,7 @@
 
           {{ partial "blocks/top.html" (dict
             "title" $block.title
-            "heading_level" $block.ranks.self
+            "heading_level" $block.ranks.base
             "link" $link
           )}}
         {{- end }}

--- a/layouts/partials/blocks/templates/programs.html
+++ b/layouts/partials/blocks/templates/programs.html
@@ -14,7 +14,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
           "title" $block.title
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
         )}}
 
         {{ if eq $block.data.layout "grid" }}

--- a/layouts/partials/blocks/templates/projects.html
+++ b/layouts/partials/blocks/templates/projects.html
@@ -9,7 +9,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
           "title" $block_title
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
         ) }}
         {{ if eq .mode "categories" }}
           <ul class="categories categories--grid">

--- a/layouts/partials/blocks/templates/publications.html
+++ b/layouts/partials/blocks/templates/publications.html
@@ -11,7 +11,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
           "title" $block.title
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
           "description" .description
         )}}
 

--- a/layouts/partials/blocks/templates/sound.html
+++ b/layouts/partials/blocks/templates/sound.html
@@ -10,7 +10,7 @@
         <div>
           {{ partial "blocks/top.html" (dict
             "title" $block.title
-            "heading_level" $block.ranks.self
+            "heading_level" $block.ranks.base
           )}}
 
           {{ if .file }}

--- a/layouts/partials/blocks/templates/testimonials.html
+++ b/layouts/partials/blocks/templates/testimonials.html
@@ -7,7 +7,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
             "title" $block.title
-            "heading_level" $block.ranks.self
+            "heading_level" $block.ranks.base
             "sr_only" true
         )}}
         <div class="testimonials" data-slider="{{ site.Params.blocks.testimonials.slider | encoding.Jsonify }}">

--- a/layouts/partials/blocks/templates/timeline.html
+++ b/layouts/partials/blocks/templates/timeline.html
@@ -7,7 +7,7 @@
     <div class="block-content">
       {{ partial "blocks/top.html" (dict
         "title" $block.title
-        "heading_level" $block.ranks.self
+        "heading_level" $block.ranks.base
       )}}
       {{ $template := printf "blocks/templates/timeline/%s.html" $layout }}
       {{ partial $template (dict "block" $block ) }}

--- a/layouts/partials/blocks/templates/video.html
+++ b/layouts/partials/blocks/templates/video.html
@@ -9,7 +9,7 @@
       <div class="block-content">
         {{ partial "blocks/top.html" (dict
           "title" $block.title
-          "heading_level" $block.ranks.self
+          "heading_level" $block.ranks.base
           "description" .description
         )}}
 

--- a/layouts/partials/blocks/templates/volumes.html
+++ b/layouts/partials/blocks/templates/volumes.html
@@ -20,7 +20,7 @@
 
           {{ partial "blocks/top.html" (dict
             "title" $block.title
-            "heading_level" $block.ranks.self
+            "heading_level" $block.ranks.base
             "link" $link
           )}}
         {{- end }}

--- a/layouts/partials/programs/admission.html
+++ b/layouts/partials/programs/admission.html
@@ -5,42 +5,42 @@
       <h2>{{ i18n "programs.toc.admission" }}</h2>
       <div>
         {{- if partial "GetTextFromHTML" .Params.prerequisites -}}
-          <section class="rich-text" id="{{ urlize (i18n "programs.prerequisites") }}">
+          <section class="rich-text program-admission-prerequisites" id="{{ urlize (i18n "programs.prerequisites") }}">
             <h3>{{ i18n "programs.prerequisites" }}</h3>
             {{- partial "PrepareHTML" .Params.prerequisites -}}
           </section>
         {{- end -}}
 
         {{- if partial "GetTextFromHTML" .Params.pricing -}}
-          <section class="rich-text" id="{{ urlize (i18n "programs.pricing") }}">
+          <section class="rich-text program-admission-pricing" id="{{ urlize (i18n "programs.pricing") }}">
             <h3>{{ i18n "programs.pricing" }}</h3>
             {{- partial "PrepareHTML" .Params.pricing -}}
           </section>
         {{- end -}}
 
         {{- if partial "GetTextFromHTML" .Params.pricing_initial -}}
-          <section class="rich-text" id="{{ urlize (i18n "programs.pricing_initial") }}">
+          <section class="rich-text program-admission-pricing-initial" id="{{ urlize (i18n "programs.pricing_initial") }}">
             <h3>{{ i18n "programs.pricing_initial" }}</h3>
             {{- partial "PrepareHTML" .Params.pricing_initial -}}
           </section>
         {{- end -}}
 
         {{- if partial "GetTextFromHTML" .Params.pricing_continuing -}}
-          <section class="rich-text" id="{{ urlize (i18n "programs.pricing_continuing") }}">
+          <section class="rich-text program-admission-pricing-continuing" id="{{ urlize (i18n "programs.pricing_continuing") }}">
             <h3>{{ i18n "programs.pricing_continuing" }}</h3>
             {{- partial "PrepareHTML" .Params.pricing_continuing -}}
           </section>
         {{- end -}}
 
         {{- if partial "GetTextFromHTML" .Params.pricing_apprenticeship -}}
-          <section class="rich-text" id="{{ urlize (i18n "programs.pricing_apprenticeship") }}">
+          <section class="rich-text program-admission-pricing-apprenticeship" id="{{ urlize (i18n "programs.pricing_apprenticeship") }}">
             <h3>{{ i18n "programs.pricing_apprenticeship" }}</h3>
             {{- partial "PrepareHTML" .Params.pricing_apprenticeship -}}
           </section>
         {{- end -}}
 
         {{- if partial "GetTextFromHTML" .Params.registration -}}
-          <section class="rich-text" id="{{ urlize (i18n "programs.registration") }}">
+          <section class="rich-text program-admission-registration" id="{{ urlize (i18n "programs.registration") }}">
             <h3>{{ i18n "programs.registration" }}</h3>
             {{- partial "PrepareHTML" .Params.registration -}}
             {{- if partial "GetTextFromHTML" .Params.registration_url -}}
@@ -50,14 +50,14 @@
         {{- end -}}
 
         {{- if partial "GetTextFromHTML" .Params.accessibility -}}
-          <section class="rich-text" id="{{ urlize (i18n "programs.accessibility") }}">
+          <section class="rich-text program-admission-accessibility" id="{{ urlize (i18n "programs.accessibility") }}">
             <h3>{{ i18n "programs.accessibility" }}</h3>
             {{- partial "PrepareHTML" .Params.accessibility -}}
           </section>
         {{- end -}}
 
         {{- if partial "GetTextFromHTML" .Params.other -}}
-          <section class="rich-text" id="{{ urlize (i18n "programs._other") }}">
+          <section class="rich-text program-admission-other" id="{{ urlize (i18n "programs._other") }}">
             <h3>{{ i18n "programs._other" }}</h3>
             {{- partial "PrepareHTML" .Params.other -}}
           </section>

--- a/layouts/partials/programs/toc.html
+++ b/layouts/partials/programs/toc.html
@@ -10,6 +10,9 @@
 
 {{ $prerequisites := partial "GetTextFromHTML" .context.Params.prerequisites }}
 {{ $pricing := partial "GetTextFromHTML" .context.Params.pricing }}
+{{ $pricing_initial := partial "GetTextFromHTML" .context.Params.pricing }}
+{{ $pricing_continuing := partial "GetTextFromHTML" .context.Params.pricing }}
+{{ $pricing_apprenticeship := partial "GetTextFromHTML" .context.Params.pricing }}
 {{ $registration := partial "GetTextFromHTML" .context.Params.registration }}
 {{ $accessibility := partial "GetTextFromHTML" .context.Params.accessibility }}
 {{ $other := partial "GetTextFromHTML" .context.Params.other }}

--- a/layouts/partials/programs/toc.html
+++ b/layouts/partials/programs/toc.html
@@ -88,6 +88,15 @@
         {{- if $pricing -}}
           <li><a href="#{{ urlize (i18n "programs.pricing") }}">{{ i18n "programs.pricing" }}</a></li>
         {{- end -}}
+        {{- if $pricing_initial -}}
+          <li><a href="#{{ urlize (i18n "programs.pricing_initial") }}">{{ i18n "programs.pricing_initial" }}</a></li>
+        {{- end -}}
+        {{- if $pricing_continuing -}}
+          <li><a href="#{{ urlize (i18n "programs.pricing_continuing") }}">{{ i18n "programs.pricing_continuing" }}</a></li>
+        {{- end -}}
+        {{- if $pricing_apprenticeship -}}
+          <li><a href="#{{ urlize (i18n "programs.pricing_apprenticeship") }}">{{ i18n "programs.pricing_apprenticeship" }}</a></li>
+        {{- end -}}
         {{- if $registration -}}
           <li><a href="#{{ urlize (i18n "programs.registration") }}">{{ i18n "programs.registration" }}</a></li>
         {{- end -}}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Utiliser le `base` au lieu de `self`.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱


