### PR TITLE
Style des liens actifs du `upper menu` : ajout de la possibilité de choisir entre site et page active

### DIFF
--- a/assets/sass/_theme/configuration/components.sass
+++ b/assets/sass/_theme/configuration/components.sass
@@ -53,6 +53,12 @@ $header-height: 87px !default
 $header-height-desktop: 96px !default
 $header-sticky-invert-logo: false !default
 $header-border-bottom-width: 1px !default
+$header-dropdown-title-summary-font-family: $lead-hero-font-family !default
+$header-dropdown-title-summary-font-size: $body-size !default
+$header-dropdown-title-summary-font-size-desktop: $lead-hero-size-desktop !default
+$header-dropdown-title-summary-line-height: 120% !default
+$header-dropdown-title-summary-line-height-desktop: $header-dropdown-title-summary-line-height !default
+// upper menu
 $header-upper-menu-background: $header-background !default
 $header-upper-menu-color: $header-color !default
 $header-upper-menu-sticky-background: $header-sticky-background !default
@@ -62,11 +68,7 @@ $header-upper-menu-padding-y: $header-nav-padding-y !default
 $header-upper-menu-padding-y-desktop: $header-upper-menu-padding-y !default
 $header-upper-menu-mobile-height: pxToRem(50) !default
 $header-upper-menu-active-style-for-sites: false !default // set to 'true' to target non external website instead of active page
-$header-dropdown-title-summary-font-family: $lead-hero-font-family !default
-$header-dropdown-title-summary-font-size: $body-size !default
-$header-dropdown-title-summary-font-size-desktop: $lead-hero-size-desktop !default
-$header-dropdown-title-summary-line-height: 120% !default
-$header-dropdown-title-summary-line-height-desktop: $header-dropdown-title-summary-line-height !default
+$header-upper-menu-active-box-shadow: inset 0 -4px 0 0 var(--color-border) !default
 
 // Navs
 $body-overlay-color: rgba(0, 0, 0, 0.3) !default

--- a/assets/sass/_theme/configuration/components.sass
+++ b/assets/sass/_theme/configuration/components.sass
@@ -61,6 +61,7 @@ $header-upper-menu-border-bottom-width: $header-border-bottom-width !default
 $header-upper-menu-padding-y: $header-nav-padding-y !default
 $header-upper-menu-padding-y-desktop: $header-upper-menu-padding-y !default
 $header-upper-menu-mobile-height: pxToRem(50) !default
+$header-upper-menu-active-style-for-sites: false !default // set to 'true' to target non external website instead of active page
 $header-dropdown-title-summary-font-family: $lead-hero-font-family !default
 $header-dropdown-title-summary-font-size: $body-size !default
 $header-dropdown-title-summary-font-size-desktop: $lead-hero-size-desktop !default

--- a/assets/sass/_theme/design-system/header.sass
+++ b/assets/sass/_theme/design-system/header.sass
@@ -116,7 +116,7 @@ header#document-header
                     @if $header-upper-menu-active-style-for-sites
                         $upper-menu-active-selector: ':not([href*="https://"], [href*="http://"])'
                     &#{$upper-menu-active-selector}
-                        box-shadow: inset 0 -4px 0 0 var(--color-border)
+                        box-shadow: $header-upper-menu-active-box-shadow
     @include media-breakpoint-down(desktop)
         &.has-upper-menu
             .menu

--- a/assets/sass/_theme/design-system/header.sass
+++ b/assets/sass/_theme/design-system/header.sass
@@ -110,7 +110,12 @@ header#document-header
                         padding: $header-upper-menu-padding-y 0
                     @include media-breakpoint-down(desktop)
                         line-height: $header-upper-menu-mobile-height
-                    &.active
+
+                    // apply active style to active page (default) or active site
+                    $upper-menu-active-selector: '.active'
+                    @if $header-upper-menu-active-style-for-sites
+                        $upper-menu-active-selector: ':not([href*="https://"], [href*="http://"])'
+                    &#{$upper-menu-active-selector}
                         box-shadow: inset 0 -4px 0 0 var(--color-border)
     @include media-breakpoint-down(desktop)
         &.has-upper-menu


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Actuellement on ciblait la classe `.active` dans le upper menu pour ajouter le style avec la bordure grise en bas du lien. Le problème est que plusieurs sites utilisent plutôt ce upper menu pour naviguer dans un éco-système, le sélecteur n'est donc plus approprié.

On ajoute une variable `$header-upper-menu-active-style-for-sites` à faux par défaut : si elle est `true`, alors notre sélecteur change et devient `:not(a[href*=“https://“], a[href*=“http://“]` (soit : tout ce qui n'est pas un lien externe) (nb : il faut impérativement mettre `/` en url du site actif)

Le style va s'adapter aux changements de la variable dans `header.sass`.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱