### PR TITLE
Formations enfants explicites

### DIFF
--- a/layouts/partials/programs/presentation.html
+++ b/layouts/partials/programs/presentation.html
@@ -21,13 +21,14 @@
             </section>
           {{- end -}}
           
-          {{ if .Pages }}
+          {{ with .Params.children }}
             <section id="programs">
               <h3>{{ i18n "programs.children" }}</h3>
               <ol class="programs programs--light">
-                {{- range .Pages -}}
+                {{- range . -}}
+                  {{ $child := site.GetPage .path }}
                   {{ partial "programs/program.html" (dict 
-                      "program" .
+                      "program" $child
                       "heading" "h4"
                       "options" site.Params.programs.single.children.options
                     )}}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [x] Rangement

## Description

Utilisation des nouvelles données `children` dans la formation, permettant de bénéficier du classement par slug et pas alpha de titre.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


