### PR TITLE
Ajustement du bloc projet en layout "grand"

### DIFF
--- a/assets/sass/_theme/blocks/projects.sass
+++ b/assets/sass/_theme/blocks/projects.sass
@@ -87,8 +87,9 @@
                 line-height: $body-size
                 margin-bottom: $spacing-2
                 margin-top: $spacing-2
-                time::after
-                    content: ' —'
+                time
+                    + .project-categories::after
+                        content: ' — '
             time,
             ul.project-categories
                 align-self: baseline

--- a/assets/sass/_theme/blocks/projects.sass
+++ b/assets/sass/_theme/blocks/projects.sass
@@ -88,7 +88,7 @@
                 margin-bottom: $spacing-2
                 margin-top: $spacing-2
                 time
-                    + .project-categories::after
+                    + .project-categories::before
                         content: ' — '
             time,
             ul.project-categories


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Le sélecteur du tiret était mal fait, il ne prenait pas en compte l'absence ou la présence de catégories après la date.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱