### PR TITLE
Ajout d'options aux enfants d'une page

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -120,6 +120,10 @@ params:
     index:
       truncate_description: 200 # Set to 0 to disable truncate
       layout: grid # grid | list
+      options:
+        image: true
+        main_summary: false
+        summary: true
   papers:
     default_image: false
     sidebar:

--- a/layouts/partials/pages/children.html
+++ b/layouts/partials/pages/children.html
@@ -1,3 +1,4 @@
+{{ $options := site.Params.pages.index.options }}
 {{ $page_class := "" }}
 {{ if .Params.bodyclass }}
   {{- $page_class = printf "block-page-%s" .Params.bodyclass }}
@@ -9,10 +10,7 @@
       {{- partial (printf "blocks/templates/pages/%s.html" site.Params.pages.index.layout) (dict 
           "pages" .Params.children
           "heading_level" 2
-          "options" (dict
-            "summary" true
-            "image" (eq site.Params.pages.index.layout "grid")
-          )
+          "options" $options
         ) }}
     </div>
   </div>


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

On ajoute des options à l'index des pages, sur le modèle des blocs : 

```
options:
        image: true
        main_summary: false
        summary: true
```

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/835

## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/blocs-de-liste/`

## Screenshots

![Capture d’écran 2024-12-20 à 12 48 38](https://github.com/user-attachments/assets/71906e22-9c37-4dab-b36b-afd230c9203c)
