### PR TITLE
Option pour forcer la pleine largeur des pages

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -51,6 +51,8 @@ params:
       display: true
   breadcrumb:
     position: hero-start #  hero-start |  hero-end | after-hero | none
+  design:
+    force_full_width: true
   summary:
     position: hero # hero | content
   search:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -52,7 +52,7 @@ params:
   breadcrumb:
     position: hero-start #  hero-start |  hero-end | after-hero | none
   design:
-    force_full_width: true
+    force_full_width: false
   summary:
     position: hero # hero | content
   search:

--- a/layouts/partials/GetBodyclass
+++ b/layouts/partials/GetBodyclass
@@ -2,7 +2,7 @@
 
 {{ $bodyclass = printf "%s__%s %s" .Type .Kind $bodyclass }}
 
-{{ if .Params.design.full_width }}
+{{ if or .Params.design.full_width site.Params.design.force_full_width }}
   {{ $bodyclass = printf "%s full-width" $bodyclass }}
 {{ end }}
 


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Dans certains cas de composition, comme le site Bonne Pioche ou Lilian Aoust, il faut désactiver la possibilité d'avoir des pages en sidebar.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


