### PR TITLE
Ajout de variables pour les style des titres

### DIFF
--- a/assets/sass/_theme/configuration/typography.sass
+++ b/assets/sass/_theme/configuration/typography.sass
@@ -13,6 +13,7 @@ $h1-size: pxToRem(30) !default
 $h1-line-height: 120% !default
 $h1-line-height-desktop: $h1-line-height !default
 $h1-weight: bold !default
+$h1-style: normal !default
 $h1-text-transform: none !default
 
 // h2
@@ -22,7 +23,9 @@ $h2-size: pxToRem(24) !default
 $h2-line-height: 120% !default
 $h2-line-height-desktop: $h2-line-height !default
 $h2-weight: $heading-font-weight !default
+$h2-style: normal !default
 $h2-text-transform: none !default
+
 
 // h3
 $h3-font-family: $heading-font-family !default
@@ -31,6 +34,7 @@ $h3-size: pxToRem(20) !default
 $h3-line-height: 130% !default
 $h3-line-height-desktop: $h3-line-height !default
 $h3-weight: bold !default
+$h3-style: normal !default
 $h3-text-transform: none !default
 
 // h4
@@ -40,6 +44,7 @@ $h4-size: pxToRem(16) !default
 $h4-line-height: 130% !default
 $h4-line-height-desktop: $h4-line-height !default
 $h4-weight: bold !default
+$h4-style: normal !default
 $h4-text-transform: none !default
 
 // h5 or Section
@@ -49,6 +54,7 @@ $h5-size: pxToRem(20) !default
 $h5-line-height: 130% !default
 $h5-line-height-desktop: $h5-line-height !default
 $h5-weight: $heading-font-weight !default
+$h5-style: normal !default
 $h5-text-transform: uppercase !default
 
 // h6 or Tab
@@ -58,6 +64,7 @@ $h6-size: pxToRem(14) !default
 $h6-line-height: 130% !default
 $h6-line-height-desktop: $h6-line-height !default
 $h6-weight: $heading-font-weight !default
+$h6-style: normal !default
 $h6-text-transform: uppercase !default
 
 // Lead

--- a/assets/sass/_theme/design-system/typography.sass
+++ b/assets/sass/_theme/design-system/typography.sass
@@ -177,7 +177,7 @@ small, .small
 @mixin inherit-text
     font-family: inherit
     font-weight: inherit
-    font-font- inherit
+    font-style: inherit
     font-size: inherit
     line-height: inherit
 

--- a/assets/sass/_theme/design-system/typography.sass
+++ b/assets/sass/_theme/design-system/typography.sass
@@ -26,6 +26,7 @@ h1, h2, h3, h4, h5, h6
     font-size: var(--h1-size)
     font-weight: $h1-weight
     line-height: var(--h1-line-height)
+    font-style: $h1-style
     text-transform: $h1-text-transform
 
 h1, .h1
@@ -36,6 +37,7 @@ h1, .h1
     font-size: var(--h2-size)
     font-weight: $h2-weight
     line-height: var(--h2-line-height)
+    font-style: $h2-style
     text-transform: $h2-text-transform
 
 h2, .h2
@@ -46,6 +48,7 @@ h2, .h2
     font-size: var(--h3-size)
     font-weight: $h3-weight
     line-height: var(--h3-line-height)
+    font-style: $h3-style
     text-transform: $h3-text-transform
 
 h3, .h3
@@ -56,6 +59,7 @@ h3, .h3
     font-size: var(--h4-size)
     font-weight: $h4-weight
     line-height: var(--h4-line-height)
+    font-style: $h4-style
     text-transform: $h4-text-transform
 
 h4, .h4
@@ -66,6 +70,7 @@ h4, .h4
     font-size: var(--h5-size)
     font-weight: $h5-weight
     line-height: var(--h5-line-height)
+    font-style: $h5-style
     text-transform: $h5-text-transform
     // Todo : check that
     a
@@ -79,6 +84,7 @@ h5, .h5
     font-size: var(--h6-size)
     font-weight: $h6-weight
     line-height: var(--h6-line-height)
+    font-style: $h6-style
     text-transform: $h6-text-transform
 
 h6, .h6
@@ -171,7 +177,7 @@ small, .small
 @mixin inherit-text
     font-family: inherit
     font-weight: inherit
-    font-style: inherit
+    font-font- inherit
     font-size: inherit
     line-height: inherit
 


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout de variables pour modifier le style des titres dans le fichier de configuration `sass` :

```
$h1-style: normal
$h2-style: normal
$h3-style: normal
$h4-style: normal
$h5-style: normal
$h6-style: normal
```

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
