### PR TITLE
Ajout d'un style par défaut au bloc personnes

### DIFF
--- a/assets/sass/_theme/blocks/persons.sass
+++ b/assets/sass/_theme/blocks/persons.sass
@@ -39,7 +39,12 @@
             @include media-breakpoint-up(md)
                 .avatar
                     width: columns(2)
-    &--grid
+    &--grid, &:not(.block-persons--list), &:not(.block-persons--large)
+        .persons
+            @include grid(1)
+            @include grid(2, md)
+            @include grid(4, lg)
+            @include grid(6, xxl)
         @include in-page-with-sidebar
             .persons
                 @include grid(1, desktop)

--- a/assets/sass/_theme/sections/persons.sass
+++ b/assets/sass/_theme/sections/persons.sass
@@ -64,8 +64,7 @@ article.person
         .avatar
             width: 100%
 
-.persons--grid,
-.block-persons--grid .persons
+.persons--grid
     @include grid(1)
     @include grid(2, md)
     @include grid(4, lg)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

En attendant https://github.com/osunyorg/admin/pull/2518 il faut ajouter un style par défaut au bloc personnes.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱
