### PR TITLE
Enlever le patch pour les blocs personnes

### DIFF
--- a/assets/sass/_theme/blocks/persons.sass
+++ b/assets/sass/_theme/blocks/persons.sass
@@ -39,7 +39,7 @@
             @include media-breakpoint-up(md)
                 .avatar
                     width: columns(2)
-    &--grid, &:not(.block-persons--list), &:not(.block-persons--large)
+    &--grid
         .persons
             @include grid(1)
             @include grid(2, md)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Maintenant que les blocs personnes ont des layout, on peut retirer le patch.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
