### PR TITLE
Ajout de locales pour les noms de réseaux sociaux

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -112,6 +112,18 @@ commons:
         email: Contact {{ .name }} by email
         rss: Read the RSS feed for {{ .name }}
         website: Visit the website of {{ .name }}
+      social_networks:
+        email: Email
+        facebook: Facebook
+        github: Github
+        instagram: Instagram
+        linkedin: LinkedIn
+        mastodon: Mastodon
+        peertube: Peertube
+        rss: RSS
+        tiktok: Tiktok
+        vimeo: Vimeo
+        x: X, ex-Twitter
   credit: A low impact website crafted with <a href="https://www.osuny.org/" title="Osuny - external link" target="_blank" rel="noreferrer">Osuny</a>
   date: Date
   download:

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -124,6 +124,7 @@ commons:
         tiktok: Tiktok
         vimeo: Vimeo
         x: X, ex-Twitter
+        youtube: YouTube
   credit: A low impact website crafted with <a href="https://www.osuny.org/" title="Osuny - external link" target="_blank" rel="noreferrer">Osuny</a>
   date: Date
   download:

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -122,6 +122,7 @@ commons:
         peertube: Peertube
         rss: RSS
         tiktok: Tiktok
+        twitter: X, ex-Twitter
         vimeo: Vimeo
         x: X, ex-Twitter
         youtube: YouTube

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -132,6 +132,7 @@ commons:
         tiktok: Tiktok
         vimeo: Vimeo
         x: X, ex-Twitter
+        youtube: YouTube
   credit: Un site éco-conçu produit avec <a href="https://www.osuny.org/" title="Osuny - lien externe" target="_blank" rel="noreferrer">Osuny</a>
   date: Date
   download:

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -120,6 +120,18 @@ commons:
         email: Contacter {{ .name }} par email
         rss: Consulter le flux RSS du site {{ .name }}
         website: Consultez le website de {{ .name }}
+      social_networks:
+        email: Email
+        facebook: Facebook
+        github: Github
+        instagram: Instagram
+        linkedin: LinkedIn
+        mastodon: Mastodon
+        peertube: Peertube
+        rss: RSS
+        tiktok: Tiktok
+        vimeo: Vimeo
+        x: X, ex-Twitter
   credit: Un site éco-conçu produit avec <a href="https://www.osuny.org/" title="Osuny - lien externe" target="_blank" rel="noreferrer">Osuny</a>
   date: Date
   download:

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -130,6 +130,7 @@ commons:
         peertube: Peertube
         rss: RSS
         tiktok: Tiktok
+        twitter: X, ex-Twitter
         vimeo: Vimeo
         x: X, ex-Twitter
         youtube: YouTube

--- a/i18n/pt.yml
+++ b/i18n/pt.yml
@@ -101,6 +101,18 @@ commons:
         email: Contactar {{ .name }} por correio eletrónico
         rss: Consultar o feed RSS do sítio {{ .name }}
         website: Visite o sítio Web de {{ .name }}
+      social_networks:
+        email: Email
+        facebook: Facebook
+        github: Github
+        instagram: Instagram
+        linkedin: LinkedIn
+        mastodon: Mastodon
+        peertube: Peertube
+        rss: RSS
+        tiktok: Tiktok
+        vimeo: Vimeo
+        x: X, ex-Twitter
   credit: Um site eco-responsável produzido com <a href="https://www.osuny.org/" title="Osuny - link externo" target="_blank" rel="noreferrer">Osuny</a>
   date: Data
   download:

--- a/i18n/pt.yml
+++ b/i18n/pt.yml
@@ -113,6 +113,7 @@ commons:
         tiktok: Tiktok
         vimeo: Vimeo
         x: X, ex-Twitter
+        youtube: YouTube
   credit: Um site eco-responsável produzido com <a href="https://www.osuny.org/" title="Osuny - link externo" target="_blank" rel="noreferrer">Osuny</a>
   date: Data
   download:

--- a/i18n/pt.yml
+++ b/i18n/pt.yml
@@ -111,6 +111,7 @@ commons:
         peertube: Peertube
         rss: RSS
         tiktok: Tiktok
+        twitter: X, ex-Twitter
         vimeo: Vimeo
         x: X, ex-Twitter
         youtube: YouTube

--- a/layouts/partials/commons/socials.html
+++ b/layouts/partials/commons/socials.html
@@ -20,7 +20,7 @@
 {{ end }}
 {{ range $key, $value := $context.social_networks }}
   <li class="{{ $key }}">
-    {{ $label := $key | title }}
+    {{ $label := i18n (printf "commons.contact.socials.social_networks.%s" $key) }}
     {{ if $with_labels }}
       <span>{{ $label }}</span>
     {{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Pour éviter d'avoir simplement "X" ou de permettre la modification du nom des réseaux sociaux, on ajoute une traduction (dans `contact/socials/social_networks`). On enlève aussi le `Title` qui permettait de rajouter des majuscules aux labels obtenus en minuscules auparavant.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots
Sans : 
![Capture d’écran 2024-12-30 à 16 38 20](https://github.com/user-attachments/assets/9889f1f6-1b6b-4601-893e-a93b6444ac9d)

Avec : 
![Capture d’écran 2024-12-30 à 16 37 07](https://github.com/user-attachments/assets/61d73ea1-73bd-4e95-ab2b-4ac4fbf862c8)
