### PR TITLE
Mise à niveau des backlinks

### DIFF
--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -167,3 +167,4 @@
 
     .locations__taxonomy &
         margin-top: $spacing-6
+        margin-bottom: -($spacing-5)

--- a/layouts/partials/blocks/templates/agenda.html
+++ b/layouts/partials/blocks/templates/agenda.html
@@ -17,7 +17,7 @@
                     "event" .
                     "layout" $layout
                     "options" $options
-                    "heading" (printf "h%d" $block.ranks.children)
+                    "heading_level" $block.ranks.children
                   ) }}
               {{ end }}
             {{ end }}

--- a/layouts/partials/blocks/templates/locations.html
+++ b/layouts/partials/blocks/templates/locations.html
@@ -13,7 +13,7 @@
         {{ $locations := slice }}
         {{ $location := "" }}
         {{ range .locations }}
-          {{ $location = site.GetPage ( printf "/locations/%s" .slug ) }}
+          {{ $location = site.GetPage .path }}
           {{ $locations = $locations | append $location }}
         {{ end }}
 

--- a/layouts/partials/blocks/templates/organizations/map.html
+++ b/layouts/partials/blocks/templates/organizations/map.html
@@ -11,7 +11,7 @@
     </summary>
     <ul>
       {{ range .organizations }}
-        {{ with site.GetPage ( printf "/organizations/%s" .slug ) }}
+        {{ with site.GetPage .path }}
           {{ $address_geolocation := .Params.contact_details.postal_address.geolocation }}
           {{ if $address_geolocation }}
             <li>
@@ -45,7 +45,7 @@
     >
   {{- range .organizations }}
     {{ if .slug }}
-      {{ with site.GetPage ( printf "/organizations/%s" .slug ) }}
+      {{ with site.GetPage .path }}
         {{ $address_geolocation := .Params.contact_details.postal_address.geolocation }}
         {{ if $address_geolocation }}
           {{ template "organization" dict

--- a/layouts/partials/contents/backlinks.html
+++ b/layouts/partials/contents/backlinks.html
@@ -4,11 +4,17 @@
     {{ with .events }}
       {{ partial "blocks/templates/agenda.html" (dict
         "block" (dict 
-          "title" (printf "%s %s" (i18n "persons.backlinks.events") $about)
+          "top" (dict
+            "active" true
+            "title" (dict
+              "value" (printf "%s %s" (i18n "persons.backlinks.events") $about)
+              "heading" "2"
+            )
+          )
           "template" "agenda"
           "ranks" (dict 
+            "base" 2
             "self" 2
-            "children" 3
           )
           "data" (dict
             "layout" site.Params.events.index.layout
@@ -21,11 +27,17 @@
     {{ with .pages }}
       {{ partial "blocks/templates/pages.html" (dict
         "block" (dict 
-          "title" (printf "%s %s" (i18n "persons.backlinks.pages") $about)
+          "top" (dict
+            "active" true
+            "title" (dict
+              "value" (printf "%s %s" (i18n "persons.backlinks.pages") $about)
+              "heading" 2
+            )
+          )
           "template" "pages"
           "ranks" (dict 
+            "base" 2
             "self" 2
-            "children" 3
           )
           "data" (dict 
             "layout" site.Params.pages.index.layout
@@ -42,11 +54,17 @@
     {{ with .projects }}
       {{ partial "blocks/templates/projects.html" (dict
         "block" (dict 
-          "title" (printf "%s %s" (i18n "persons.backlinks.projects") $about)
+          "top" (dict
+            "active" true
+            "title" (dict
+              "value" (printf "%s %s" (i18n "persons.backlinks.projects") $about)
+              "heading" 2
+            )
+          )
           "template" "projects"
           "ranks" (dict
+            "base" 2
             "self" 2
-            "children" 3
           )
           "data" (dict
             "projects" .
@@ -57,11 +75,17 @@
     {{ with .posts }}
       {{ partial "blocks/templates/posts.html" (dict
         "block" (dict 
-          "title" (printf "%s %s" (i18n "persons.backlinks.posts") $about)
+          "top" (dict
+            "active" true
+            "title" (dict
+              "value" (printf "%s %s" (i18n "persons.backlinks.posts") $about)
+              "heading" 2
+            )
+          )
           "template" "posts"
           "ranks" (dict 
+            "base" 2
             "self" 2
-            "children" 3
           )
           "data" (dict
             "layout" site.Params.posts.index.layout

--- a/layouts/partials/events/event.html
+++ b/layouts/partials/events/event.html
@@ -1,9 +1,10 @@
 {{ $event := .event }}
 {{ $layout := .layout | default "list" }}
-{{ $heading := .heading | default "h2" }}
+{{ $heading_level := .heading_level | default 3 }}
+
 {{ $heading_tag := (dict 
-    "open" ((printf "<%s itemprop='name' class='event-title'>" $heading) | safeHTML)
-    "close" ((printf "</%s>" $heading) | safeHTML)
+    "open" ((printf "<h%d itemprop='name' class='event-title'>" $heading_level) | safeHTML)
+    "close" ((printf "</h%d>" $heading_level) | safeHTML)
     ) }}
 {{ $index := .index }}
 {{ $alternate := .alternate }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Avec le nouveau fonctionnement de top et de rank, les backlinks n'affichaient plus les titres de chaque section. De plus, le partial appelant les événement ne fonctionnait plus, le niveau de titre des items dans le blocs était cassé.

J'ai oublié de faire deux branches, il y a donc aussi le fix de la carte dans l'index des locations (elle ne touchait plus le bord du footer)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

Pour une personne : `http://localhost:1313/fr/equipe/magali-angles/`
Pour une orga : `http://localhost:1313/fr/organisations/noesya/`