### PR TITLE
Couleur du crédit du hero : utilisation de la variable existante et gestion desktop/mobile

### DIFF
--- a/assets/sass/_theme/_variables.sass
+++ b/assets/sass/_theme/_variables.sass
@@ -10,6 +10,7 @@
   --color-border: #{$color-border}
   --color-background-alt: #{$color-background-alt}
   --color-background: #{$color-background}
+  --hero-credit-color: #{$hero-credit-color}
 
   @if $has-dark-mode
     @media (prefers-color-scheme: dark)

--- a/assets/sass/_theme/_variables.sass
+++ b/assets/sass/_theme/_variables.sass
@@ -11,6 +11,7 @@
   --color-background-alt: #{$color-background-alt}
   --color-background: #{$color-background}
   --hero-credit-color: #{$hero-credit-color}
+  --hero-credit-color-desktop: #{$hero-credit-color-desktop}
 
   @if $has-dark-mode
     @media (prefers-color-scheme: dark)

--- a/assets/sass/_theme/_variables.sass
+++ b/assets/sass/_theme/_variables.sass
@@ -10,8 +10,6 @@
   --color-border: #{$color-border}
   --color-background-alt: #{$color-background-alt}
   --color-background: #{$color-background}
-  --hero-credit-color: #{$hero-credit-color}
-  --hero-credit-color-desktop: #{$hero-credit-color-desktop}
 
   @if $has-dark-mode
     @media (prefers-color-scheme: dark)

--- a/assets/sass/_theme/configuration/components.sass
+++ b/assets/sass/_theme/configuration/components.sass
@@ -93,6 +93,7 @@ $hero-height-desktop: 500px !default
 $hero-color: var(--color-text) !default
 $hero-background-color: var(--color-background-alt) !default
 $hero-credit-color: var(--color-text-alt) !default
+$hero-credit-color-desktop: $hero-credit-color !default
 
 // Breadcrumb
 $breadcrumb-color: $hero-color !default

--- a/assets/sass/_theme/configuration/components.sass
+++ b/assets/sass/_theme/configuration/components.sass
@@ -92,7 +92,7 @@ $hero-height: 300px !default
 $hero-height-desktop: 500px !default
 $hero-color: var(--color-text) !default
 $hero-background-color: var(--color-background-alt) !default
-$hero-credit-color: var(--color-text-alt) !default
+$hero-credit-color: $color-text-alt !default
 $hero-credit-color-desktop: $hero-credit-color !default
 
 // Breadcrumb

--- a/assets/sass/_theme/utils/shame.sass
+++ b/assets/sass/_theme/utils/shame.sass
@@ -125,7 +125,7 @@
 @mixin collapsed-figcaption
     figcaption
         @include meta
-        color: var(--color-text-alt)
+        color: var(--hero-credit-color)
         position: absolute
         display: block
         left: 0

--- a/assets/sass/_theme/utils/shame.sass
+++ b/assets/sass/_theme/utils/shame.sass
@@ -125,7 +125,7 @@
 @mixin collapsed-figcaption
     figcaption
         @include meta
-        color: var(--color-text-alt)
+        color: var(--hero-credit-color)
         position: absolute
         display: block
         left: 0
@@ -157,7 +157,7 @@
             .credit
                 display: block
         @include media-breakpoint-up(desktop)
-            color: var(--hero-credit-color)
+            color: var(--hero-credit-color-desktop)
             &:before
                 padding-right: 0
         @include media-breakpoint-down(desktop)

--- a/assets/sass/_theme/utils/shame.sass
+++ b/assets/sass/_theme/utils/shame.sass
@@ -125,7 +125,7 @@
 @mixin collapsed-figcaption
     figcaption
         @include meta
-        color: var(--hero-credit-color)
+        color: var(--color-text-alt)
         position: absolute
         display: block
         left: 0
@@ -157,6 +157,7 @@
             .credit
                 display: block
         @include media-breakpoint-up(desktop)
+            color: var(--hero-credit-color)
             &:before
                 padding-right: 0
         @include media-breakpoint-down(desktop)

--- a/assets/sass/_theme/utils/shame.sass
+++ b/assets/sass/_theme/utils/shame.sass
@@ -123,9 +123,10 @@
             width: columns(8)
 
 @mixin collapsed-figcaption
+    // TODO: remove hero specifics variables
     figcaption
         @include meta
-        color: var(--hero-credit-color)
+        color: $hero-credit-color
         position: absolute
         display: block
         left: 0
@@ -157,7 +158,7 @@
             .credit
                 display: block
         @include media-breakpoint-up(desktop)
-            color: var(--hero-credit-color-desktop)
+            color: $hero-credit-color-desktop
             &:before
                 padding-right: 0
         @include media-breakpoint-down(desktop)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Arnaud avait repéré qu'on n'utilisait jamais `$hero-credit-color`. Or il y a clairement un besoin sur A11y Universités (https://www.a11yuniversites.org/actualites/), et sans doute ailleurs (IUT Bdx Montaigne sans doute).

On part ici sur 2 valeurs, pour s'assurer que même avec un hero très coloré, le mobile puisse être aussi contrôlé, si besoin est (par ex le mettre de la même couleur que le hero, plutôt qu'en alt), mais peut-être n'est-ce pas réellement pertinent.

Par défaut, la couleur de base est celle du texte alternatif, tandis que celle desktop se cale sur la base mobile : 
```
$hero-credit-color: var(--color-text-alt) !default
$hero-credit-color-desktop: $hero-credit-color !default
```

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

http://localhost:1313/fr/actualites/2024-11-18-la-nouvelle-visionneuse-dosuny/

## URL de test du site A11Y Universités

http://localhost:1313/actualites/

## Screenshots
### Le problème (ok que en mobile) : 
![Capture d’écran 2025-01-06 à 10 44 42](https://github.com/user-attachments/assets/e29fab85-4564-4bdc-ac97-2acb4cb4b6fa)
![Capture d’écran 2025-01-06 à 10 46 46](https://github.com/user-attachments/assets/1476deaf-c8c4-4727-b072-f651475e7c9a)

### Avec 2 variables : 
![Capture d’écran 2025-01-06 à 10 42 35](https://github.com/user-attachments/assets/44bbb8e2-8c38-47df-9b25-c5881bc79d85)
![Capture d’écran 2025-01-06 à 10 48 24](https://github.com/user-attachments/assets/57c51fc8-837a-4d21-89cf-14226cf51927)