### PR TITLE
Ajout de tailles d'image (config) en fonction des layouts aux projets et aux events

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -357,6 +357,32 @@ params:
           mobile:   90
           tablet:   360
           desktop:  255
+      projects:
+        alternate: 
+          mobile:   350
+          tablet:   709
+          desktop:  1019
+        grid:
+          mobile:   327
+          tablet:   555
+          desktop:  864
+        large:
+          mobile:   350
+          tablet:   555
+          desktop:  1019
+      events:
+        grid:
+          mobile:   90
+          tablet:   360
+          desktop:  255
+        large:
+          mobile:   400
+          tablet:   360
+          desktop:  255
+        list:
+          mobile:   90
+          tablet:   360
+          desktop:  255
       testimonials:
         mobile:   80
         tablet:   160

--- a/layouts/partials/blocks/templates/projects/alternate.html
+++ b/layouts/partials/blocks/templates/projects/alternate.html
@@ -8,7 +8,7 @@
       {{ partial "projects/project.html" (dict 
         "project" .
         "heading" $heading
-        "alternate" true
+        "layout" "alternate"
         "index" $i
         "options" $options
         ) }}

--- a/layouts/partials/blocks/templates/projects/alternate.html
+++ b/layouts/partials/blocks/templates/projects/alternate.html
@@ -9,7 +9,6 @@
         "project" .
         "heading" $heading
         "layout" "alternate"
-        "index" $i
         "options" $options
         ) }}
     {{ end }}

--- a/layouts/partials/blocks/templates/projects/large.html
+++ b/layouts/partials/blocks/templates/projects/large.html
@@ -57,7 +57,7 @@
               {{- partial "commons/image.html"
                   (dict
                     "image"    .Params.image
-                    "sizes"    site.Params.image_sizes.sections.projects.item
+                    "sizes"    site.Params.image_sizes.blocks.projects.large
                   ) -}}
             {{- else -}}
               {{- partial "commons/image-default.html" "projects" -}}

--- a/layouts/partials/events/event.html
+++ b/layouts/partials/events/event.html
@@ -66,10 +66,11 @@
     </div>
     <div class="media">
       {{- if and $options.image .Params.image -}}
+        {{ $sizes := index site.Params.image_sizes.blocks.events $layout }}
         {{- partial "commons/image.html"
             (dict
               "image"    .Params.image
-              "sizes"    site.Params.image_sizes.sections.events.item
+              "sizes"    $sizes
             ) -}}
       {{- else -}}
         {{- partial "commons/image-default.html" "events" -}}

--- a/layouts/partials/projects/project.html
+++ b/layouts/partials/projects/project.html
@@ -1,8 +1,7 @@
 {{ $project := .project }}
 {{ $heading := .heading | default "h2" }}
-{{- $direction := "" -}}
+{{ $direction := "" }}
 {{ $layout := .layout | default "grid" }}
-{{ $index := .index}}
 {{ $heading_tag := (dict 
     "open" ((printf "<%s class='project-title' itemprop='name'>" $heading) | safeHTML)
     "close" ((printf "</%s>" $heading) | safeHTML)
@@ -16,7 +15,7 @@
     {{- $direction = partial "GetImageDirection" .Params.image -}}
   {{ end }}
 
-  <article class="project {{ if eq $layout "alternate" }}{{ $direction }} {{if not (modBool $index 2)}}left{{ else}}right{{end}}{{end}}" itemscope itemtype="https://schema.org/CreativeWork">
+  <article class="project {{ $direction }}" itemscope itemtype="https://schema.org/CreativeWork">
 
     <div class="project-content">
       <div class="project-description">

--- a/layouts/partials/projects/project.html
+++ b/layouts/partials/projects/project.html
@@ -1,13 +1,13 @@
 {{ $project := .project }}
 {{ $heading := .heading | default "h2" }}
 {{- $direction := "" -}}
+{{ $layout := .layout | default "grid" }}
 {{ $index := .index}}
 {{ $heading_tag := (dict 
     "open" ((printf "<%s class='project-title' itemprop='name'>" $heading) | safeHTML)
     "close" ((printf "</%s>" $heading) | safeHTML)
     ) }}
 
-{{ $alternate := .alternate | default false }}
 {{ $options := .options | default site.Params.projects.index.options }}
 
 {{ with $project }}
@@ -16,7 +16,7 @@
     {{- $direction = partial "GetImageDirection" .Params.image -}}
   {{ end }}
 
-  <article class="project {{ if $alternate }}{{ $direction }} {{if not (modBool $index 2)}}left{{ else}}right{{end}}{{end}}" itemscope itemtype="https://schema.org/CreativeWork">
+  <article class="project {{ if eq $layout "alternate" }}{{ $direction }} {{if not (modBool $index 2)}}left{{ else}}right{{end}}{{end}}" itemscope itemtype="https://schema.org/CreativeWork">
 
     <div class="project-content">
       <div class="project-description">
@@ -59,10 +59,11 @@
 
     <div class="media">
       {{- if .Params.image -}}
+        {{ $sizes := index site.Params.image_sizes.blocks.projects $layout }}
         {{- partial "commons/image.html"
             (dict
               "image"    .Params.image
-              "sizes"    site.Params.image_sizes.sections.projects.item
+              "sizes"    $sizes
             ) -}}
       {{- else -}}
         {{- partial "commons/image-default.html" "projects" -}}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Sur la criée, on ne chargait pas les bonnes tailles d'image, c'était disproportionné. Cela venait du fait que events et projects n'avaient pas de taille d'image en fonction des layouts.

On ne gère pas `list` pour les projets car ça n'affiche pas d'image.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

À tester sur example et la criée