### PR TITLE
Ajustement des blocs liste

### DIFF
--- a/assets/sass/_theme/blocks/links.sass
+++ b/assets/sass/_theme/blocks/links.sass
@@ -12,6 +12,7 @@
         position: relative
         transition: background 0.3s ease
         .link-content
+            flex: 1
             line-height: 100%
             padding: space(4) space(4) space(8)
             min-height: pxToRem(130)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Quand le texte d'un bloc lien est trop long, ça réduit l'image.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)

https://site.frenchcraftguild.osuny.site/membres/atelier-lucile-viaud/

## Screenshots

Avant 
<img width="847" alt="Capture d’écran 2025-01-11 à 10 18 04" src="https://github.com/user-attachments/assets/2c231c1c-667a-4c1e-a680-100d0120de42" />

Après
<img width="853" alt="Capture d’écran 2025-01-11 à 10 19 39" src="https://github.com/user-attachments/assets/8db93c09-ca19-4fc1-8a62-0e771c9066ff" />
