### PR TITLE
Retirer l'option `enableRobotsTXT` par défaut

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,4 +1,3 @@
-enableRobotsTXT: true
 removePathAccents: true
 ignoreLogs: ['warning-goldmark-raw-html']
 pagination:


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Actuellement, tous les sites sont référencés.

On laisse l'écriture du fichier `robots.txt` côté osuny : https://github.com/osunyorg/admin/issues/2578

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


