### PR TITLE
Ajustement des sélecteurs pour l'affichage en grille des personnes (layout large)

### DIFF
--- a/assets/sass/_theme/blocks/persons.sass
+++ b/assets/sass/_theme/blocks/persons.sass
@@ -28,10 +28,11 @@
         .top .description
             max-width: columns(8)
         &.block-with-long-text
-            .persons
-                @include grid(2)
-                article
-                    @include person-avatar-end
+            &:not(.block-persons--large)
+                .persons
+                    @include grid(2)
+                    article
+                        @include person-avatar-end
     @include in-page-with-sidebar
         article
             flex-direction: row


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

On a un niveau de grille qui est appliqué sur les blocs persons avec `.with-long-text`, ce qui provoque ceci : 
![Capture d’écran 2025-01-13 à 17 49 16](https://github.com/user-attachments/assets/aaed6d75-1551-496a-92c6-e0e03cca2aaa)

(la taille de l'avatar c'est côté thème communication publique, no souci)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

https://example.osuny.org/fr/blocks/blocs-de-liste/organigramme/ -> ajouter + de texte et une personne supplémentaire pour tester

## URL de test du site Parole Publique

Accueil

## Screenshots
![Capture d’écran 2025-01-13 à 17 48 50](https://github.com/user-attachments/assets/31f34d20-12f6-4478-a06b-39272ea07358)
