### PR TITLE
added check for organization map transcription

### DIFF
--- a/layouts/partials/blocks/templates/organizations/map.html
+++ b/layouts/partials/blocks/templates/organizations/map.html
@@ -11,7 +11,7 @@
     </summary>
     <ul>
       {{ range .organizations }}
-        {{ with site.GetPage .path }}
+        {{ with and .slug (site.GetPage .path) }}
           {{ $address_geolocation := .Params.contact_details.postal_address.geolocation }}
           {{ if $address_geolocation }}
             <li>
@@ -44,8 +44,7 @@
     aria-label="{{ $aria_label }}"
     >
   {{- range .organizations }}
-    {{ if .slug }}
-      {{ with site.GetPage .path }}
+    {{ with and .slug (site.GetPage .path) }}
         {{ $address_geolocation := .Params.contact_details.postal_address.geolocation }}
         {{ if $address_geolocation }}
           {{ template "organization" dict
@@ -59,6 +58,5 @@
           }}
         {{ end }}
       {{ end }}
-    {{ end }}
   {{ end -}}
 </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Dans le bloc orga, en layout map, on n'avait pas de vérification pour la transcription : elle n'excluait donc pas les organisations sans slug, comme la carte.

Étant donné que les 2 doivent donner les mêmes informations, j'ai aussi exclu les organisations renseignées à la main et non enregistrées, mais ça peut se discuter !

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1314/fr/blocks/blocs-de-liste/partenaires/`