### PR TITLE
Alignement à gauche du CTA s'il n'a pas de texte

### DIFF
--- a/assets/sass/_theme/blocks/call_to_action.sass
+++ b/assets/sass/_theme/blocks/call_to_action.sass
@@ -185,7 +185,7 @@ $button-selector: "a:first-child"
                 grid-column: 8/13
                 figcaption
                     margin-top: $spacing-2
-        .call_to_action--without-image
+        .call_to_action--without-image:not(.call_to_action--without_text)
             display: block
             > div
                 @include grid

--- a/layouts/partials/blocks/templates/call_to_action.html
+++ b/layouts/partials/blocks/templates/call_to_action.html
@@ -6,7 +6,7 @@
   <div class="{{ $block_class }}">
     <div class="container">
       <div class="block-content">
-        <div class="call_to_action call_to_action--with{{ if not .image }}out{{ end }}-image {{ if $block.title }}call_to_action--with-title{{ end }}">
+        <div class="call_to_action call_to_action--with{{ if not .image }}out{{ end }}-image {{ if $block.title }}call_to_action--with-title{{ end }} {{- if not .top.description }} call_to_action--without_text {{ end -}}">
           <div>
             {{ partial "blocks/top.html" $block.top }}
             {{- if .buttons }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

On ajoute une class `call_to_action--without-text` (sur le modèle de `...--without-image`) pour empêcher la mise en page avec une grille, de sorte à ce que le bouton soit à gauche.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/852

## URL de test sur example.osuny.org

`/fr/blocks/blocks-narratifs/appels-a-action/`

## URL de test du site Communication Publique

`http://localhost:1313/` (accueil)

## Screenshots
<img width="1470" alt="Capture d’écran 2025-01-14 à 09 47 46" src="https://github.com/user-attachments/assets/a7ae5da6-abeb-494d-81f4-847afccf293c" />
<img width="1470" alt="Capture d’écran 2025-01-14 à 09 45 08" src="https://github.com/user-attachments/assets/b59db292-4fde-40de-a91c-45b00d39b7c6" />
<img width="377" alt="Capture d’écran 2025-01-14 à 09 47 57" src="https://github.com/user-attachments/assets/f5f760bf-a99d-46bb-afce-95ff878ef466" />

![Capture d’écran 2025-01-16 à 10 18 05](https://github.com/user-attachments/assets/133b7c81-eb5e-42f2-b86c-ce92e761ffdc)
![Capture d’écran 2025-01-16 à 10 17 58](https://github.com/user-attachments/assets/2e9c3297-1a71-416b-8d5b-87d81b1c908b)

