### PR TITLE
Afficher les publications par groupes d'année

### DIFF
--- a/assets/sass/_theme/sections/publications.sass
+++ b/assets/sass/_theme/sections/publications.sass
@@ -58,6 +58,8 @@
     @include list-reset
 
 .publications__section
+    .publications-year + .publication
+        margin-top: $spacing-3
     .publication
         @include media-breakpoint-up(desktop)
             align-items: baseline

--- a/assets/sass/_theme/sections/publications.sass
+++ b/assets/sass/_theme/sections/publications.sass
@@ -60,6 +60,8 @@
 .publications__section
     .publications-year + .publication
         margin-top: $spacing-3
+    section + section
+        margin-top: $spacing-5
     .publication
         @include media-breakpoint-up(desktop)
             align-items: baseline

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -142,7 +142,7 @@ params:
       direction: start
   publications:
     index:
-      order_by_year: false
+      group_by_year: false
   volumes:
     default_image: false
   locations:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -142,7 +142,7 @@ params:
       direction: start
   publications:
     index:
-      order_by_year: true
+      order_by_year: false
   volumes:
     default_image: false
   locations:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -140,6 +140,9 @@ params:
     default_image: false
     sidebar:
       direction: start
+  publications:
+    index:
+      order_by_year: true
   volumes:
     default_image: false
   locations:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -142,7 +142,7 @@ params:
       direction: start
   publications:
     index:
-      order_by_year: false
+      order_by_year: true
   volumes:
     default_image: false
   locations:

--- a/layouts/partials/publications/publications.html
+++ b/layouts/partials/publications/publications.html
@@ -1,7 +1,7 @@
 <div class="publications">
   {{ if site.Params.publications.index.order_by_year }}
-    {{ $publicationsByYear := .Paginator.Pages.GroupByDate "2006" }}
-    {{ range $publicationsByYear }}
+    {{ $publications := .Paginator.Pages.GroupByDate "2006" }}
+    {{ range $publications }}
       <h2 class="publications-year">{{ .Key }}</h2>
       {{ range .Pages }}
         {{ partial "publications/publication.html" (dict "publication" . ) }}

--- a/layouts/partials/publications/publications.html
+++ b/layouts/partials/publications/publications.html
@@ -2,10 +2,12 @@
   {{ if site.Params.publications.index.order_by_year }}
     {{ $publications := .Paginator.Pages.GroupByDate "2006" }}
     {{ range $publications }}
-      <h2 class="publications-year">{{ .Key }}</h2>
-      {{ range .Pages }}
-        {{ partial "publications/publication.html" (dict "publication" . ) }}
-      {{ end }}
+      <section>
+        <h2 class="publications-year">{{ .Key }}</h2>
+        {{ range .Pages }}
+          {{ partial "publications/publication.html" (dict "publication" . ) }}
+        {{ end }}
+      </section>
     {{ end }}
   {{ else }}
     {{ range .Paginator.Pages }}

--- a/layouts/partials/publications/publications.html
+++ b/layouts/partials/publications/publications.html
@@ -1,5 +1,15 @@
 <div class="publications">
-  {{ range .Paginator.Pages }}
-    {{ partial "publications/publication.html" (dict "publication" . ) }}
+  {{ if site.Params.publications.index.order_by_year }}
+    {{ $publicationsByYear := .Paginator.Pages.GroupByDate "2006" }}
+    {{ range $publicationsByYear }}
+      <h2 class="publications-year">{{ .Key }}</h2>
+      {{ range .Pages }}
+        {{ partial "publications/publication.html" (dict "publication" . ) }}
+      {{ end }}
+    {{ end }}
+  {{ else }}
+    {{ range .Paginator.Pages }}
+      {{ partial "publications/publication.html" (dict "publication" . ) }}
+    {{ end }}
   {{ end }}
 </div>

--- a/layouts/partials/publications/publications.html
+++ b/layouts/partials/publications/publications.html
@@ -1,5 +1,5 @@
 <div class="publications">
-  {{ if site.Params.publications.index.order_by_year }}
+  {{ if site.Params.publications.index.group_by_year }}
     {{ $publications := .Paginator.Pages.GroupByDate "2006" }}
     {{ range $publications }}
       <section>


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Permettre en config d'ajouter la possibilité de séparer les publications par année (demande pour le Degrowth Journal).

Pour tester, passer à true ceci : 
```
publications:
    index:
      group_by_year: false
```

Les dates sont des h2.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test du site Degrowth Journal

`http://localhost:1313/publications/page/3/`

## Screenshots

Première page : 
![Capture d’écran 2025-01-14 à 12 37 54](https://github.com/user-attachments/assets/0959815d-1384-4284-a11e-767003427bfc)

Troisième page : 
![Capture d’écran 2025-01-14 à 12 47 20](https://github.com/user-attachments/assets/56063111-cdc7-442b-90f7-b263e11964dc)