### PR TITLE
Ajustement des tailles d'image pour les événements en large

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -352,7 +352,7 @@ params:
         large:
           mobile:   400
           tablet:   360
-          desktop:  255
+          desktop:  645
         list:
           mobile:   90
           tablet:   360
@@ -378,7 +378,7 @@ params:
         large:
           mobile:   400
           tablet:   360
-          desktop:  255
+          desktop:  645
         list:
           mobile:   90
           tablet:   360


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Les images des blocs d'événements en large avaient une taille erronée.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/868

## URL de test sur example.osuny.org

`/fr/blocks/blocs-de-liste/les-projets/`

## URL de test du site [Maison noesya](https://github.com/osunyorg/noesya-maison) 

Accueil