### PR TITLE
Ajouter une vérification pour l'affichage en carte du bloc organisations

### DIFF
--- a/layouts/partials/blocks/templates/organizations/map.html
+++ b/layouts/partials/blocks/templates/organizations/map.html
@@ -4,9 +4,7 @@
 {{ $id_transcription := printf "block-%d-transcription" $block_index }}
 
 {{/*  In map layout, all organization should have .path to get coordinates  */}}
-{{ $organizations := where .organizations "path" "ne" nil }}
-
-{{ if $organizations }}
+{{ if $organizations := where (default slice .organizations) "path" "ne" nil  }}
   <div class="transcription">
     <details id="{{- $id_transcription -}}" class="map-transcription">
       <summary aria-controls="{{- $id_transcription -}}" aria-expanded="false" data-describedby=".block-title">

--- a/layouts/partials/blocks/templates/organizations/map.html
+++ b/layouts/partials/blocks/templates/organizations/map.html
@@ -4,7 +4,9 @@
 {{ $id_transcription := printf "block-%d-transcription" $block_index }}
 
 {{/*  In map layout, all organization should have .path to get coordinates  */}}
-{{ if $organizations := where (default slice .organizations) "path" "ne" nil  }}
+{{ $organizations := where (default slice .organizations) "path" "ne" nil }}
+
+{{ if $organizations }}
   <div class="transcription">
     <details id="{{- $id_transcription -}}" class="map-transcription">
       <summary aria-controls="{{- $id_transcription -}}" aria-expanded="false" data-describedby=".block-title">


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Suite de https://github.com/osunyorg/theme/pull/864 → on ne vérifiait pas le fait qu'il y ait ou non des orgas dans `.organizations`, ce qui faisait notamment crash EPV.

On check d'abord s'il y a des orga, puis s'il y a un path : 
`{{ $organizations := where (default slice .organizations) "path" "ne" nil }}`

On ajoute un slice pour que la valeur par défaut soit une liste vide pour éviter que le `where` crash quand il n'y a aucune organisation renseignée.

En relisant/comparant, je me cale sur la précédente version : d'abord une variable, puis la condition, pas tout sur une ligne.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱