### PR TITLE
Couleur du bouton play/pause du slider

### DIFF
--- a/assets/sass/_theme/components/slider.sass
+++ b/assets/sass/_theme/components/slider.sass
@@ -80,6 +80,7 @@
             align-items: center
             border: 1px solid var(--color-border)
             border-radius: 50%
+            color: var(--color-border)
             display: flex
             height: $minimum-accessible-size
             justify-content: center

--- a/assets/sass/_theme/components/slider.sass
+++ b/assets/sass/_theme/components/slider.sass
@@ -80,7 +80,7 @@
             align-items: center
             border: 1px solid var(--color-border)
             border-radius: 50%
-            color: var(--color-border)
+            color: var(--color-accent)
             display: flex
             height: $minimum-accessible-size
             justify-content: center


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Le bouton play/pause n'a pas de couleur, il apparaît donc en noir :
![Capture d’écran 2025-01-21 à 22 30 21](https://github.com/user-attachments/assets/0bb8ad37-000b-4ca6-aa2b-f61520284723)
![Capture d’écran 2025-01-21 à 22 30 57](https://github.com/user-attachments/assets/83ff336c-5200-48eb-8eea-50d807f1df37)

On utilise la couleur d'accent par défaut, comme pour le reste des éléments interactifs du slider (faut-il prévoir une variable ?)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

http://localhost:1313/fr/blocks/blocks-narratifs/temoignages/

## URL de test du site FUTURs 

Accueil

## Screenshots
![Capture d’écran 2025-01-21 à 22 35 20](https://github.com/user-attachments/assets/3cdbb598-dbd2-45e9-8a4b-dc5b84cbce4f)
![Capture d’écran 2025-01-21 à 22 36 11](https://github.com/user-attachments/assets/4d601dc3-7270-4875-8f54-ebef0260ad51)
![Capture d’écran 2025-01-21 à 22 37 20](https://github.com/user-attachments/assets/805011c1-c80e-4857-bfcc-17cdf78ee178)
