### PR TITLE
Redirection automatique sur la langue du navigateur

### DIFF
--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -9,6 +9,8 @@
         <meta http-equiv="refresh" content="0; url={{ .Permalink }}"/>
     </noscript>
     <script>
+
+      // Thanks to nanmu42 : https://nanmu.me/en/posts/2020/hugo-i18n-automatic-language-redirection/
       ;(function () {
         // Only do i18n at root, 
         // otherwise, redirect immediately

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -49,15 +49,19 @@
           return 'en'
         }
 
-        var preferLang = getFirstBrowserLanguage();
+        var preferLang = getFirstBrowserLanguage(),
+            url = '{{ .Permalink }}'; // default url
+
         {{ with site.Languages }}
           {{ range site.Languages }}
             if (preferLang.indexOf('{{ . }}') > -1) {
-              window.location.replace('/{{ . }}/')
+              url = '/{{ . }}/';
             }
           {{ end }}
         {{ end }}
-      })()
+
+        window.location.replace(url);
+      })();
     </script>
 </head>
 <body>

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ .Permalink }}</title>
+    <link rel="canonical" href="{{ .Permalink }}"/>
+    <meta name="robots" content="noindex">
+    <meta charset="utf-8"/>
+    <noscript>
+        <meta http-equiv="refresh" content="0; url={{ .Permalink }}"/>
+    </noscript>
+    <script>
+      ;(function () {
+        // Only do i18n at root, 
+        // otherwise, redirect immediately
+        if (window.location.pathname !== '/') {
+          window.location.replace('{{ .Permalink }}')
+          return
+        }
+
+        // If site has only one language, redirect immediately
+        {{ if eq (len site.Languages) 1 }}
+          window.location.replace('{{ .Permalink }}')
+        {{ end }}
+
+        var getFirstBrowserLanguage = function () {
+          var nav = window.navigator,
+          browserLanguagePropertyKeys = ['language', 'browserLanguage', 'systemLanguage', 'userLanguage'],
+          i,
+          language
+
+          if (Array.isArray(nav.languages)) {
+            for (i = 0; i < nav.languages.length; i++) {
+              language = nav.languages[i]
+              if (language && language.length) {
+                return language
+              }
+            }
+          }
+
+          // support for other well known properties in browsers
+          for (i = 0; i < browserLanguagePropertyKeys.length; i++) {
+            language = nav[browserLanguagePropertyKeys[i]]
+            if (language && language.length) {
+              return language
+            }
+          }
+          return 'en'
+        }
+
+        var preferLang = getFirstBrowserLanguage();
+        {{ with site.Languages }}
+          {{ range site.Languages }}
+            if (preferLang.indexOf('{{ . }}') > -1) {
+              window.location.replace('/{{ . }}/')
+            }
+          {{ end }}
+        {{ end }}
+      })()
+    </script>
+</head>
+<body>
+<h1>Rerouting</h1>
+<p>You should be rerouted in a jiff, if not, <a href="{{ .Permalink }}">click here</a>.</p>
+</body>
+</html>

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,3 +1,4 @@
+{{ $should_i18n_redirect := and hugo.IsMultilingual .IsHome }}
 <!DOCTYPE html>
 <html>
 <head>
@@ -5,7 +6,7 @@
   <link rel="canonical" href="{{ .Permalink }}"/>
   <meta name="robots" content="noindex">
   <meta charset="utf-8"/>
-  {{ if not hugo.IsMultilingual }}
+  {{ if not $should_i18n_redirect }}
     <meta http-equiv="refresh" content="0; url={{ .Permalink }}"/>
   {{ else }}
     <noscript>
@@ -65,7 +66,9 @@
   {{ end }}
 </head>
 <body>
-  <h1>Redirection</h1>
-  <p>You should be redirected in a moment, if not click here: <a href="{{ .Permalink }}">{{ .Permalink }}</a>.</p>
+  {{ if $should_i18n_redirect }}
+    <h1>Redirection</h1>
+    <p>You should be redirected in a moment, if not click here: <a href="{{ .Permalink }}">{{ .Permalink }}</a>.</p>
+  {{ end }}
 </body>
 </html>

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,28 +1,26 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>{{ .Permalink }}</title>
-    <link rel="canonical" href="{{ .Permalink }}"/>
-    <meta name="robots" content="noindex">
-    <meta charset="utf-8"/>
+  <title>{{ .Permalink }}</title>
+  <link rel="canonical" href="{{ .Permalink }}"/>
+  <meta name="robots" content="noindex">
+  <meta charset="utf-8"/>
+  {{ if not hugo.IsMultilingual }}
+    <meta http-equiv="refresh" content="0; url={{ .Permalink }}"/>
+  {{ else }}
     <noscript>
-        <meta http-equiv="refresh" content="0; url={{ .Permalink }}"/>
+      <meta http-equiv="refresh" content="0; url={{ .Permalink }}"/>
     </noscript>
     <script>
-
       // Thanks to nanmu42 : https://nanmu.me/en/posts/2020/hugo-i18n-automatic-language-redirection/
       ;(function () {
         // Only do i18n at root, 
         // otherwise, redirect immediately
         if (window.location.pathname !== '/') {
-          window.location.replace('{{ .Permalink }}')
-          return
+          // As we stopped hugo redirect (meta refresh) we must do it in js
+          window.location.replace('{{ .Permalink }}');
+          return;
         }
-
-        // If site has only one language, redirect immediately
-        {{ if eq (len site.Languages) 1 }}
-          window.location.replace('{{ .Permalink }}')
-        {{ end }}
 
         var getFirstBrowserLanguage = function () {
           var nav = window.navigator,
@@ -46,7 +44,8 @@
               return language
             }
           }
-          return 'en'
+
+          return 'en';
         }
 
         var preferLang = getFirstBrowserLanguage(),
@@ -63,9 +62,10 @@
         window.location.replace(url);
       })();
     </script>
+  {{ end }}
 </head>
 <body>
-<h1>Rerouting</h1>
-<p>You should be rerouted in a jiff, if not, <a href="{{ .Permalink }}">click here</a>.</p>
+  <h1>Redirection</h1>
+  <p>You should be redirected in a moment, if not click here: <a href="{{ .Permalink }}">{{ .Permalink }}</a>.</p>
 </body>
 </html>

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,8 +1,3 @@
-{{ $isHome := false }}
-{{ if .Page }}
-  {{ $isHome = .Page.IsHome }}
-{{ end }}
-{{ $should_i18n_redirect := and hugo.IsMultilingual $isHome }}
 <!DOCTYPE html>
 <html>
 <head>
@@ -10,7 +5,7 @@
   <link rel="canonical" href="{{ .Permalink }}"/>
   <meta name="robots" content="noindex">
   <meta charset="utf-8"/>
-  {{ if not $should_i18n_redirect }}
+  {{ if not hugo.IsMultilingual }}
     <meta http-equiv="refresh" content="0; url={{ .Permalink }}"/>
   {{ else }}
     <noscript>
@@ -70,7 +65,7 @@
   {{ end }}
 </head>
 <body>
-  {{ if $should_i18n_redirect }}
+  {{ if hugo.IsMultilingual }}
     <h1>Redirection</h1>
     <p>You should be redirected in a moment, if not click here: <a href="{{ .Permalink }}">{{ .Permalink }}</a>.</p>
   {{ end }}

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,3 +1,8 @@
+{{ $isHome := false }}
+{{ if .Page }}
+  {{ $isHome = .Page.IsHome }}
+{{ end }}
+{{ $should_i18n_redirect := and hugo.IsMultilingual $isHome }}
 <!DOCTYPE html>
 <html>
 <head>
@@ -5,7 +10,7 @@
   <link rel="canonical" href="{{ .Permalink }}"/>
   <meta name="robots" content="noindex">
   <meta charset="utf-8"/>
-  {{ if not hugo.IsMultilingual }}
+  {{ if not $should_i18n_redirect }}
     <meta http-equiv="refresh" content="0; url={{ .Permalink }}"/>
   {{ else }}
     <noscript>
@@ -65,7 +70,7 @@
   {{ end }}
 </head>
 <body>
-  {{ if hugo.IsMultilingual }}
+  {{ if $should_i18n_redirect }}
     <h1>Redirection</h1>
     <p>You should be redirected in a moment, if not click here: <a href="{{ .Permalink }}">{{ .Permalink }}</a>.</p>
   {{ end }}

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,4 +1,3 @@
-{{ $should_i18n_redirect := and hugo.IsMultilingual .IsHome }}
 <!DOCTYPE html>
 <html>
 <head>
@@ -6,7 +5,7 @@
   <link rel="canonical" href="{{ .Permalink }}"/>
   <meta name="robots" content="noindex">
   <meta charset="utf-8"/>
-  {{ if not $should_i18n_redirect }}
+  {{ if not hugo.IsMultilingual }}
     <meta http-equiv="refresh" content="0; url={{ .Permalink }}"/>
   {{ else }}
     <noscript>
@@ -66,7 +65,7 @@
   {{ end }}
 </head>
 <body>
-  {{ if $should_i18n_redirect }}
+  {{ if hugo.IsMultilingual }}
     <h1>Redirection</h1>
     <p>You should be redirected in a moment, if not click here: <a href="{{ .Permalink }}">{{ .Permalink }}</a>.</p>
   {{ end }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Dans le fichier `alias.html` : 
- on récupère la langue préférée du navigateur
- on vérifie qu'on est sur la page d'accueil
- on cherche une correspondance dans les langues disponibles du site avec la langue du navigateur
- si il y a une correspondance, on redirige sur la page d'accueil dans la bonne langue
- sinon, on redirige sur la langue par défaut (la master du site)

Merci à nanmu42 : https://nanmu.me/en/posts/2020/hugo-i18n-automatic-language-redirection/

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


