### PR TITLE
Favicon : support des svg

### DIFF
--- a/layouts/partials/head/favicons.html
+++ b/layouts/partials/head/favicons.html
@@ -9,13 +9,13 @@
   <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicons/favicon-16x16.png">
 {{ end -}}
 {{- if os.FileExists "static/assets/images/favicons/favicon.png" -}}
-  <link rel="icon shorcut" type="image/png" href="/assets/images/favicons/favicon.png">
+  <link rel="icon" type="image/png" href="/assets/images/favicons/favicon.png">
 {{ end -}}
 {{- if os.FileExists "static/assets/images/favicons/favicon.ico" -}}
   <link rel="icon" type="image/x-icon" href="/assets/images/favicons/favicon.ico">
 {{ end -}}
 {{- if os.FileExists "static/assets/images/favicons/favicon.svg" -}}
-  <link rel="icon shorcut" type="image/svg" href="/assets/images/favicons/favicon.svg">
+  <link rel="icon" type="image/svg" href="/assets/images/favicons/favicon.svg">
 {{ end -}}
 {{- if os.FileExists "static/site.webmanifest" -}}
   <link rel="manifest" href="/site.webmanifest">

--- a/layouts/partials/head/favicons.html
+++ b/layouts/partials/head/favicons.html
@@ -8,11 +8,14 @@
 {{- if os.FileExists "static/assets/images/favicons/favicon-16x16.png" -}}
   <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicons/favicon-16x16.png">
 {{ end -}}
-{{- if os.FileExists "static/assets/images/favicons/favicon.ico" -}}
-  <link rel="icon" type="image/ico" href="/assets/images/favicons/favicon.ico">
-{{ end -}}
 {{- if os.FileExists "static/assets/images/favicons/favicon.png" -}}
-  <link rel="icon" type="image/png" href="/assets/images/favicons/favicon.png">
+  <link rel="icon shorcut" type="image/png" href="/assets/images/favicons/favicon.png">
+{{ end -}}
+{{- if os.FileExists "static/assets/images/favicons/favicon.ico" -}}
+  <link rel="icon" type="image/x-icon" href="/assets/images/favicons/favicon.ico">
+{{ end -}}
+{{- if os.FileExists "static/assets/images/favicons/favicon.svg" -}}
+  <link rel="icon shorcut" type="image/svg" href="/assets/images/favicons/favicon.svg">
 {{ end -}}
 {{- if os.FileExists "static/site.webmanifest" -}}
   <link rel="manifest" href="/site.webmanifest">


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout du support du format svg pour les favicons.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


