### PR TITLE
Ajustement du block image en sidebar

### DIFF
--- a/assets/sass/_theme/blocks/image.sass
+++ b/assets/sass/_theme/blocks/image.sass
@@ -24,10 +24,11 @@
         &.image-portrait
             picture
                 margin-right: 0
+                img
+                    max-width: columns(6)
         img
             max-height: $block-image-max-height-with-sidebar
             width: auto
-            max-width: columns(6)
 
     @include in-page-without-sidebar
         figure


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Correction du bloc image avec une sidebar.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


## Screenshots

Avant : 

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/f5b3a97d-e899-472d-ab0d-00c632a22de2" />


Après :  

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/b31f6fda-93c6-4459-bd9c-7d406d957816" />

