### PR TITLE
Ajustement des icônes dans les titres des blocs de page

### DIFF
--- a/assets/sass/_theme/blocks/pages.sass
+++ b/assets/sass/_theme/blocks/pages.sass
@@ -141,8 +141,6 @@
 
         @include in-page-without-sidebar
             .block-title
-                a
-                    @include stretched-link(before)
             .top
                 .description
                     p
@@ -202,13 +200,8 @@
                 display: flex
                 flex-direction: column
                 .page-title a
-                    @include stretched-link
+                    @include stretched-link(before)
                     text-decoration: none
-                .more
-                    @include icon(arrow, after, true)
-                    &::after
-                        opacity: 1
-                        transition: padding-left 0.3s
                 &:hover .more::after
                     padding-left: pxToRem(10)
                 .media 
@@ -231,13 +224,8 @@
             position: relative
             + .page
                 margin-top: $spacing-5
-            .more
-                @include icon(arrow-right-line, after, true)
-                @include hover-translate-icon(after)
             &:hover .more:after
                 transform: translateX(#{pxToRem(10)})
-            &-title a
-                @include stretched-link
             .media
                 img
                     aspect-ratio: 1

--- a/assets/sass/_theme/blocks/pages.sass
+++ b/assets/sass/_theme/blocks/pages.sass
@@ -200,7 +200,6 @@
                 display: flex
                 flex-direction: column
                 .page-title a
-                    @include stretched-link(before)
                     text-decoration: none
                 &:hover .more::after
                     padding-left: pxToRem(10)

--- a/assets/sass/_theme/sections/pages.sass
+++ b/assets/sass/_theme/sections/pages.sass
@@ -2,9 +2,14 @@
     @include article
     .page-title
         a
-            @include icon(arrow-right-line, after, true)
-            @include hover-translate-icon(after)
             @include stretched-link(before)
+            // exclusion for blocks with "more" link
+            .block:not(.block-pages--large, .block-pages--alternate) &
+                @include icon(arrow-right-line, after, true)
+                @include hover-translate-icon(after)
+    .more
+        @include icon(arrow-right-line, after, true)
+        @include hover-translate-icon(after)
 
 .block-pages,
 .pages

--- a/layouts/partials/blocks/templates/pages/alternate.html
+++ b/layouts/partials/blocks/templates/pages/alternate.html
@@ -15,7 +15,7 @@
       {{ else }}
         {{ $image_class = "" }}
       {{ end }}
-      <article class="{{ $image_class }} {{- if (not (isset .Params "image")) -}} without-image {{- end -}}">
+      <article class="page {{ $image_class }} {{- if (not (isset .Params "image")) -}} without-image {{- end -}}">
         {{ $heading_tag.open }}
           <a href="{{- .Permalink -}}">
             {{- partial "PrepareHTML" .Title -}}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Avec l'uniformisation des pages, des cas particuliers nous ont échappé : les blocs de projets et d'alternance n'ont une icône que dans le lien "En savoir plus", et non dans le titre, contrairement aux autres. Cela entraînait un conflit avec le stretched link.

On factorise ici pour remonter ces cas particuliers dans la section `page.sass`, pour éviter l'éparpillement dans les blocs. J'en ai profité pour ajouter la class `.page` aux pages du layout alternate pour uniformiser.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`blocks/blocs-de-liste/pages/#pages-en-layout-grand`

## URL de test du site IUT de Bordeaux

Accueil

## Screenshots

Le pb : 
![Capture d’écran 2025-01-29 à 16 06 00](https://github.com/user-attachments/assets/3a6ef8e3-7fd1-49b2-aa99-1d99394e4e65)
![Capture d’écran 2025-01-29 à 16 02 54](https://github.com/user-attachments/assets/d4bd2a20-5be5-42b6-9184-935c24bb475b)

Sur example : 
![Capture d’écran 2025-01-29 à 16 05 09](https://github.com/user-attachments/assets/5b9026d4-747d-49a6-94e5-1aea198e153e)
![Capture d’écran 2025-01-29 à 16 04 58](https://github.com/user-attachments/assets/1f67bcd9-c8e9-456e-acbb-f18b1533c702)
![Capture d’écran 2025-01-29 à 16 04 51](https://github.com/user-attachments/assets/16629a29-3951-48ae-9c00-8b34914d1b1e)
