### PR TITLE
Ajout des catégories aux blocs de pages

### DIFF
--- a/assets/sass/_theme/blocks/pages.sass
+++ b/assets/sass/_theme/blocks/pages.sass
@@ -67,6 +67,9 @@
                 margin-top: -$spacing-3
                 img
                     min-width: 100%
+            .page-categories
+                a
+                    @include link(var(--color-accent))
             .more
                 @include arrow-right-hover
                 @include icon(arrow-right-line, after)
@@ -75,10 +78,6 @@
                 position: relative
                 margin-top: auto
                 padding-top: $spacing-3
-            &:hover
-                .more:after
-                    opacity: 1
-                    transform: translateX(pxToRem(7))
             a,
             .more
                 transition: text-decoration-color .3s ease, color .3s ease
@@ -86,8 +85,14 @@
                 background-color: $block-pages-card-page-background-hover
                 &, a, .more
                     color: $block-pages-card-page-color-hover
+                .page-categories
+                    a
+                        @include link($block-pages-card-page-color-hover)
                 .more
                     text-decoration-color: $block-pages-card-page-color-hover
+                    &:after
+                        opacity: 1
+                        transform: translateX(pxToRem(7))
     &--list
         .list
             @include list-reset

--- a/assets/sass/_theme/sections/pages.sass
+++ b/assets/sass/_theme/sections/pages.sass
@@ -18,8 +18,11 @@
         margin-top: space()
         li
             @include meta
+            z-index: 2
             a
                 @include link(var(--color-accent))
+        + .more
+            margin-top: $spacing-2
 
 .block-pages,
 .pages

--- a/assets/sass/_theme/sections/pages.sass
+++ b/assets/sass/_theme/sections/pages.sass
@@ -15,6 +15,7 @@
         display: flex
         flex-wrap: wrap
         gap: 0 $spacing-2
+        margin-top: space()
         li
             @include meta
             a

--- a/assets/sass/_theme/sections/pages.sass
+++ b/assets/sass/_theme/sections/pages.sass
@@ -10,6 +10,15 @@
     .more
         @include icon(arrow-right-line, after, true)
         @include hover-translate-icon(after)
+    &-categories
+        @include list-reset
+        display: flex
+        flex-wrap: wrap
+        gap: 0 $spacing-2
+        li
+            @include meta
+            a
+                @include link(var(--color-accent))
 
 .block-pages,
 .pages

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -136,7 +136,7 @@ params:
     index:
       layout: grid # grid | list
       options:
-        categories: true
+        categories: false
         image: true
         main_summary: false
         summary: true

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -136,6 +136,7 @@ params:
     index:
       layout: grid # grid | list
       options:
+        categories: true
         image: true
         main_summary: false
         summary: true

--- a/layouts/partials/blocks/templates/pages/alternate.html
+++ b/layouts/partials/blocks/templates/pages/alternate.html
@@ -29,6 +29,14 @@
           )}}
         {{ end }}
 
+        {{/*  TODO: set right options when admin is ready  */}}
+        {{ if site.Params.pages.index.options.categories }}
+          {{ partial "commons/categories" ( dict
+            "context" .
+            "kind" "page"
+          )}}
+        {{ end }}
+
         {{ if site.Params.blocks.pages.alternate.more }}
           <p class="more meta" aria-hidden="true">{{- i18n "commons.more" -}}</p>
         {{ end }}

--- a/layouts/partials/blocks/templates/pages/cards.html
+++ b/layouts/partials/blocks/templates/pages/cards.html
@@ -22,6 +22,14 @@
           )}}
         {{ end }}
 
+        {{/*  TODO: set right options when admin is ready  */}}
+        {{ if site.Params.pages.index.options.categories }}
+          {{ partial "commons/categories" ( dict
+            "context" .
+            "kind" "page"
+          )}}
+        {{ end }}
+
         <p class="more meta" aria-hidden="true">{{- i18n "commons.more" -}}</p>
 
         {{ if $options.image }}

--- a/layouts/partials/blocks/templates/pages/grid.html
+++ b/layouts/partials/blocks/templates/pages/grid.html
@@ -29,6 +29,13 @@
               "kind" "pages"
             )}}
           {{ end }}
+          {{/*  TODO: set right options when admin is ready  */}}
+          {{ if site.Params.pages.index.options.categories }}
+            {{ partial "commons/categories" ( dict
+              "context" .
+              "kind" "page"
+            )}}
+          {{ end }}
           {{ if $options.image }}
             {{- partial "pages/page-media.html" . -}}
           {{ end }}

--- a/layouts/partials/blocks/templates/pages/large.html
+++ b/layouts/partials/blocks/templates/pages/large.html
@@ -21,6 +21,15 @@
               "kind" "pages"
             )}}
           {{ end }}
+
+          {{/*  TODO: set right options when admin is ready  */}}
+          {{ if site.Params.pages.index.options.categories }}
+            {{ partial "commons/categories" ( dict
+              "context" .
+              "kind" "page"
+            )}}
+          {{ end }}
+
           <p class="more meta" aria-hidden="true">{{- i18n "commons.more" -}}</p>
         </div>
 

--- a/layouts/partials/blocks/templates/pages/list.html
+++ b/layouts/partials/blocks/templates/pages/list.html
@@ -31,6 +31,13 @@
                   "kind" "pages"
                 )}}
               {{ end }}
+              {{/*  TODO: set right options when admin is ready  */}}
+              {{ if site.Params.pages.index.options.categories }}
+                {{ partial "commons/categories" ( dict
+                  "context" .
+                  "kind" "page"
+                )}}
+              {{ end }}
             </div>
 
             {{ if $options.image }}

--- a/layouts/partials/commons/categories.html
+++ b/layouts/partials/commons/categories.html
@@ -1,8 +1,5 @@
 {{ $kind := .kind }}
 {{ $categories_kind := printf "%ss_categories" $kind }}
-{{ if eq $kind "page" }}
-  {{ $categories_kind := "pages_categories" }}
-{{ end }}
 {{ $categories := .context.GetTerms $categories_kind }}
 
 {{- if $categories -}}

--- a/layouts/partials/commons/categories.html
+++ b/layouts/partials/commons/categories.html
@@ -1,5 +1,8 @@
 {{ $kind := .kind }}
 {{ $categories_kind := printf "%ss_categories" $kind }}
+{{ if eq $kind "page" }}
+  {{ $categories_kind := "pages_categories" }}
+{{ end }}
 {{ $categories := .context.GetTerms $categories_kind }}
 
 {{- if $categories -}}

--- a/layouts/partials/pages/page.html
+++ b/layouts/partials/pages/page.html
@@ -22,6 +22,14 @@
       {{- with and $options.summary  .Params.summary }}
         {{ . | safeHTML }}
       {{ end -}}
+
+      {{/*  TODO: set right options when admin is ready  */}}
+      {{ if site.Params.pages.index.options.categories }}
+        {{ partial "commons/categories" ( dict
+          "context" .
+          "kind" "page"
+        )}}
+      {{ end }}
     </div>
     {{ if $options.image }}
       <div class="media">


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

En config il faut activer : 
```yml
pages:
    default_image: false
    index:
      layout: grid # grid | list
      options:
        categories: false
```

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

- Tous les blocs de pages :`/fr/blocks/blocs-de-liste/pages/`
- Pour les pages dans une catégorie : `/fr/sujet/osuny/`
## Screenshots
**Liste :**
![Capture d’écran 2025-01-31 à 16 18 07](https://github.com/user-attachments/assets/92ff7007-b168-4a99-872d-35137939a429)
![Capture d’écran 2025-01-31 à 16 18 13](https://github.com/user-attachments/assets/0ec4fa39-763a-4af6-882d-df7064c7bf64)

**Cartes :**
![Capture d’écran 2025-01-31 à 16 18 25](https://github.com/user-attachments/assets/bafafee1-27b3-4e3c-be87-7362f53e974b)
![Capture d’écran 2025-01-31 à 16 18 38](https://github.com/user-attachments/assets/71f26beb-e0bd-45bc-bc90-1a6aaa00f0e4)

**Alternance :**
![Capture d’écran 2025-01-31 à 16 18 51](https://github.com/user-attachments/assets/7eded7a5-ccd2-4748-ac6e-56e4a8244d0e)
![Capture d’écran 2025-01-31 à 16 19 06](https://github.com/user-attachments/assets/e090dce1-eca6-4b42-a80a-5ffa5cb926fe)

**Grille : **
![Capture d’écran 2025-01-31 à 16 19 23](https://github.com/user-attachments/assets/9ff99a34-b399-4c1d-bbd1-18594b7220a0)
![Capture d’écran 2025-01-31 à 16 19 36](https://github.com/user-attachments/assets/5e19f989-904c-4f1f-8396-916196296a27)

**Grand : **
![Capture d’écran 2025-01-31 à 16 35 18](https://github.com/user-attachments/assets/d96d5c5e-466a-4597-a58e-eb8185f2f82c)
![Capture d’écran 2025-01-31 à 16 35 30](https://github.com/user-attachments/assets/36757315-a9fd-4a3f-9694-55b51c6fccc6)



