### PR TITLE
Item `page` : ajout d'un hook

### DIFF
--- a/layouts/partials/blocks/templates/pages/alternate.html
+++ b/layouts/partials/blocks/templates/pages/alternate.html
@@ -22,6 +22,8 @@
           </a>
         {{ $heading_tag.close }}
 
+        {{- partial "pages/list/components/hook-after-title.html" . -}}
+
         {{ if and $options.summary .Params.summary }}
           {{ partial "GetRichSummary" ( dict 
               "summary" .Params.summary

--- a/layouts/partials/blocks/templates/pages/cards.html
+++ b/layouts/partials/blocks/templates/pages/cards.html
@@ -15,6 +15,8 @@
           </a>
         {{ $heading_tag.close }}
 
+        {{- partial "pages/list/components/hook-after-title.html" . -}}
+
         {{ if and $options.summary .Params.summary }}
           {{ partial "GetRichSummary" ( dict 
             "summary" .Params.summary

--- a/layouts/partials/blocks/templates/pages/grid.html
+++ b/layouts/partials/blocks/templates/pages/grid.html
@@ -23,6 +23,9 @@
               {{- partial "PrepareHTML" .Title -}}
             </a>
           {{ $heading_tag.close }}
+
+          {{- partial "pages/list/components/hook-after-title.html" . -}}
+
           {{ if and $options.summary .Params.summary }}
             {{ partial "GetRichSummary" ( dict 
               "summary" .Params.summary

--- a/layouts/partials/blocks/templates/pages/large.html
+++ b/layouts/partials/blocks/templates/pages/large.html
@@ -15,6 +15,9 @@
               {{- partial "PrepareHTML" .Title -}}
             </a>
           {{ $heading_tag.close }}
+
+          {{- partial "pages/list/components/hook-after-title.html" . -}}
+
           {{ if and $options.summary .Params.summary }}
             {{ partial "GetRichSummary" ( dict 
               "summary" .Params.summary

--- a/layouts/partials/blocks/templates/pages/list.html
+++ b/layouts/partials/blocks/templates/pages/list.html
@@ -25,6 +25,9 @@
                   {{- partial "PrepareHTML" .Title -}}
                 </a>
               {{ $heading_tag.close }}
+
+              {{- partial "pages/list/components/hook-after-title.html" . -}}
+
               {{ if and $options.summary .Params.summary }}
                 {{ partial "GetRichSummary" ( dict 
                   "summary" .Params.summary

--- a/layouts/partials/pages/page.html
+++ b/layouts/partials/pages/page.html
@@ -19,6 +19,9 @@
           {{- partial "PrepareHTML" .Title -}}
         </a>
       {{- partial "PrepareHTML" (printf "</%s>" $heading) -}}
+
+      {{- partial "pages/list/components/hook-after-title.html" . -}}
+
       {{- with and $options.summary  .Params.summary }}
         {{ . | safeHTML }}
       {{ end -}}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout d'un hook pour créer des overrides sous le titre d'une page dans un item (blocs et listes).

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

