### PR TITLE
Ajout des images svg au style "icônes" du bloc de liens

### DIFF
--- a/assets/sass/_theme/blocks/links.sass
+++ b/assets/sass/_theme/blocks/links.sass
@@ -28,21 +28,27 @@
             @include small
             margin-top: space(3)
         .media
-            picture:not(.is-png) 
-                img
-                    display: block
-                    object-fit: cover
-                    width: 100%
-                    height: 100%
-                    aspect-ratio: 16/9
-            picture.is-png 
-                img
-                    margin: space(4) space(4) 0
-                    max-width: $block-links-icon-max-width
+            picture
+                &:not(.is-svg, .is-png) 
+                    img
+                        display: block
+                        object-fit: cover
+                        width: 100%
+                        height: 100%
+                        aspect-ratio: 16/9
+                // display images as icons
+                &.is-png,
+                &.is-svg
+                    img
+                        margin: space(4) space(4) 0
+                        max-width: $block-links-icon-max-width
         &:hover
             background-color: $block-links-card-hover-background
             &, a
                 color: $block-links-card-hover-color
+            .is-png,
+            .is-svg
+                filter: $block-links-hover-filter
     @include in-page-without-sidebar
         .top
             display: flex

--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -127,6 +127,7 @@ $block-links-card-color: var(--color-text) !default
 $block-links-card-hover-background: var(--color-accent) !default
 $block-links-card-hover-color: var(--color-background) !default
 $block-links-icon-max-width: pxToRem(40) !default
+$block-links-hover-filter: invert(1) !default
 
 // Bloc fonctionnalités
 $block-features-icon-max-width: pxToRem(80) !default


### PR DESCRIPTION
 behaviour to svg images and hover effect

## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Ajout des images `.is-svg` au système d'icônes du bloc de liens, ainsi qu'un effet au survol, par défaut inverser de noir à blanc.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/blocks-techniques/liens/`

## Screenshots

![Capture d’écran 2025-02-04 à 15 05 40](https://github.com/user-attachments/assets/d07ba571-1d3c-42cf-8094-e64eb969e324)

L'effet est valable aussi pour les png : 
![Capture d’écran 2025-02-04 à 15 09 17](https://github.com/user-attachments/assets/609a8a3d-c9a7-4d31-848f-fc0e680c0915)