### PR TITLE
Ajustement des paramètres svg/png en mode icône dans les blocs de liens

### DIFF
--- a/assets/sass/_theme/blocks/links.sass
+++ b/assets/sass/_theme/blocks/links.sass
@@ -46,9 +46,10 @@
             background-color: $block-links-card-hover-background
             &, a
                 color: $block-links-card-hover-color
-            .is-png,
+            .is-png
+                filter: $block-links-png-hover-filter
             .is-svg
-                filter: $block-links-hover-filter
+                filter: $block-links-svg-hover-filter
     @include in-page-without-sidebar
         .top
             display: flex

--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -127,7 +127,8 @@ $block-links-card-color: var(--color-text) !default
 $block-links-card-hover-background: var(--color-accent) !default
 $block-links-card-hover-color: var(--color-background) !default
 $block-links-icon-max-width: pxToRem(40) !default
-$block-links-hover-filter: invert(1) !default
+$block-links-png-hover-filter: invert(1) !default
+$block-links-svg-hover-filter: $block-links-png-hover-filter !default
 
 // Bloc fonctionnalités
 $block-features-icon-max-width: pxToRem(80) !default


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Pour le cas où les svg seraient des logos avec des couleurs dans les liens (dans l'idéal c'est bloc d'orga ceci dit), on distingue les deux animations au hover : `$block-links-svg-hover-filter` et `$block-links-png-hover-filter`.

Je ne distingue pas leur taille, qui reste scopée dans 1 seule variable (`block-links-icon-max-width`) pour uniformiser, ça laisse la possibilité d'overider en css au besoin.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1314/fr/blocks/blocks-techniques/liens/`

## URL de test du site IUT de Bordeaux

`http://localhost:1313/nos-reseaux-nationaux/`

## Screenshots

Exemple sur iut avec la variable max-width à 120px : 
![image](https://github.com/user-attachments/assets/17b2bc3f-8ca1-4e8e-af4a-eb8de566deb1)
![Capture d’écran 2025-02-06 à 15 46 46](https://github.com/user-attachments/assets/852296cb-a90f-4e39-8c3e-9dfdc1dd7ce5)

Elle les avait en pleine largeur, est-ce qu'on laisse ainsi ?
![Capture d’écran 2025-02-06 à 15 59 34](https://github.com/user-attachments/assets/66de95bb-bab6-4921-a3cf-351ad9ba2a43)


Et sur example ça ne change rien :
![Capture d’écran 2025-02-06 à 15 51 00](https://github.com/user-attachments/assets/f1bdf51c-0a41-41ed-804a-37d0467d2930)