### PR TITLE
Ajustements des layouts globaux

### DIFF
--- a/assets/sass/_theme/design-system/layouts/alternate.sass
+++ b/assets/sass/_theme/design-system/layouts/alternate.sass
@@ -10,3 +10,8 @@
     @include media-breakpoint-up(desktop)
         .more
             @include icon(arrow-right-line, after, true)
+                display: inline-block
+                transition: transform 0.25s
+        article:hover
+            .more::after
+                transform: translateX(pxToRem(5))

--- a/assets/sass/_theme/design-system/layouts/cards.sass
+++ b/assets/sass/_theme/design-system/layouts/cards.sass
@@ -9,8 +9,11 @@
         position: relative
         transition: background 0.3s, color 0.3s
         @include arrow-right-hover(".more")
+        height: 100%
         [class$="-title"]
             @include h3
+        @include media-breakpoint-up(desktop)
+            height: 100%
         .media
             margin-left: -$spacing-3
             margin-right: -$spacing-3
@@ -32,6 +35,7 @@
         > li + li
             margin-top: $spacing-3
     @include media-breakpoint-up(desktop)
+        align-items: stretch
         min-height: 320px
     @include in-page-with-sidebar
         @include grid(2)

--- a/assets/sass/_theme/design-system/layouts/grid.sass
+++ b/assets/sass/_theme/design-system/layouts/grid.sass
@@ -7,6 +7,7 @@
             @include h2
             a
                 @include icon(arrow-right-line, after, true)
+                    font-size: 0.8em
                 @include hover-translate-icon(after)
     @include media-breakpoint-down(desktop)
         > li + li

--- a/assets/sass/_theme/design-system/layouts/grid.sass
+++ b/assets/sass/_theme/design-system/layouts/grid.sass
@@ -6,8 +6,8 @@
         [class$="-title"]
             @include h2
             a
-                @include hover-translate-icon(after)
                 @include icon(arrow-right-line, after, true)
+                @include hover-translate-icon(after)
     @include media-breakpoint-down(desktop)
         > li + li
             margin-top: $spacing-5

--- a/assets/sass/_theme/design-system/layouts/large.sass
+++ b/assets/sass/_theme/design-system/layouts/large.sass
@@ -7,11 +7,18 @@
         @include layout-item
         [class$="-title"]
             @include h2
-            a
-                @include icon(arrow-right-line, after, true)
-                @include hover-translate-icon(after)
-    @include media-breakpoint-up(desktop)
-        article
+        .more
+            @include icon(arrow-right-line, after, true)
+                display: inline-block
+                transition: transform 0.25s
+        &:hover
+            .more::after
+                transform: translateX(pxToRem(5))
+        @include media-breakpoint-down(desktop)
+            .media
+                margin-left: var(--grid-gutter-negative)
+                margin-right: var(--grid-gutter-negative)
+        @include media-breakpoint-up(desktop)
             flex-direction: row
             gap: var(--grid-gutter)
     @include in-page-with-sidebar

--- a/assets/sass/_theme/design-system/layouts/list.sass
+++ b/assets/sass/_theme/design-system/layouts/list.sass
@@ -3,7 +3,7 @@
     > li
         padding-bottom: $spacing-3
         padding-top: $spacing-3
-        &:not(:last-child)
+        &:where(:not(:last-child))
             border-bottom: 1px solid var(--color-border)
     article
         display: flex
@@ -22,12 +22,11 @@
             gap: var(--grid-gutter)
             [class$="-content"]
                 flex-shrink: 0
-                width: columns(6)
+                flex: 1
             [class$="-title"],
             [class$="-subtitle"]
                 @include h4
             .media
-                flex-shrink: 0
                 width: columns(2)
     @include in-page-without-sidebar
         > li
@@ -36,11 +35,10 @@
         article
             display: flex
             gap: var(--grid-gutter)
-            justify-content: end
+            &:where(:not:only-child)
+                justify-content: end
             [class$="-content"]
-                flex-shrink: 0
-                width: columns(9)
-                padding-right: columns(3)
+                flex: 1
                 position: relative
                 [class$="-title"]
                     @include h3

--- a/assets/sass/_theme/design-system/layouts/list.sass
+++ b/assets/sass/_theme/design-system/layouts/list.sass
@@ -29,17 +29,15 @@
             .media
                 width: columns(2)
     @include in-page-without-sidebar
-        > li
-            padding-bottom: $spacing-4
-            padding-top: $spacing-4
         article
             display: flex
             gap: var(--grid-gutter)
-            &:where(:not:only-child)
-                justify-content: end
+            // align title to the next article title if image options is active
+            &:has(.media:empty)
+                [class$="-content"]
+                    margin-left: offset(3)
             [class$="-content"]
                 flex: 1
-                position: relative
                 [class$="-title"]
                     @include h3
                 .articles-count

--- a/assets/sass/_theme/sections/projects.sass
+++ b/assets/sass/_theme/sections/projects.sass
@@ -35,13 +35,14 @@
         .project
             justify-content: space-between
             &-meta
+                align-items: baseline
                 display: flex
                 gap: $spacing-2
-                align-items: baseline
                 time
                     display: inline
             .media
                 flex-shrink: 0
+                margin-bottom: 0
             &-title a
                 @include icon(arrow-right-line, after, true)
                 @include hover-translate-icon(after, $fade: true)
@@ -50,8 +51,8 @@
         @include media-breakpoint-down(md)
             .project
                 .media
-                    order: -1
                     margin-bottom: 0
+                    order: -1
                 &-meta
                     margin-top: $spacing-1
         @include media-breakpoint-up(md)
@@ -60,24 +61,25 @@
                 .media
                     order: 1
                 &-categories
-                    width: fit-content
                     display: block
+                    width: fit-content
                     li
                         display: inline
         @include media-breakpoint-between(sm, desktop)
             .project
                 .media
                     width: columns(4)
-        @include in-page-with-sidebar
-            .project
-                &-title,
-                &-subtitle
-                    @include h3
-        @include in-page-without-sidebar
-            .project
-                &-title,
-                &-subtitle
-                    @include h2
+        article
+            @include in-page-with-sidebar
+                .project
+                    &-title,
+                    &-subtitle
+                        @include h3
+            @include in-page-without-sidebar
+                &.project
+                    .project-title,
+                    .project-subtitle
+                        @include h2
     &--alternate
         .project-subtitle
             @include h3
@@ -123,6 +125,7 @@
                 margin-top: $spacing-4
             .more
                 @include icon(arrow-right-line, after)
+                    display: inline-block
                     margin-left: $spacing-1
                     transition: transform 0.55s $arrow-ease-transition
             &:hover 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -441,6 +441,14 @@ params:
           mobile:   350
           tablet:   990
           desktop:  600
+        large:
+          mobile:   360
+          tablet:   555
+          desktop:  864
+        list:
+          mobile:   90
+          tablet:   360
+          desktop:  400
       diplomas:
         hero:
           mobile:   400


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description
[Cela concerne pour l'instant les layouts du blocs catégorie, ainsi que certains layouts du bloc projets]

- Projets uniquement : J'ai ajusté les typos du layout liste pour les projets (on devait avoir du h2 en full-width, contrairement aux catégories), ça rajoute des lignes car le niveau de précision du `.project-title` seul était perdu du fait du `[class$="-title"]`
- Catégories uniquement : ajout des tailles d'images pour 2 layouts

Quelques petits points sur les layouts globaux : 
- **Layout liste** : 
Pour bloc catégories, où, quand il y a l'option "image" d'activée, on doit aligner le titre avec celui de l'élément suivant, peu importe qu'il y ait ou non une image (uniquement en without sidebar), cela engendrait ce problème dans un bloc où les images étaient désactivées : 
![Capture d’écran 2025-02-13 à 11 44 55](https://github.com/user-attachments/assets/4999d2be-66f4-4959-a073-db278fce5479)

Pour régler ça, on utilise `&:has(.media:empty)`, car dans un bloc avec l'option image d'activée, on reçoit bien `media` (ça pose quand même la question de l'utilité de ce contenant vide), donc, si on est dans un bloc qui a un `.media` viide, on est forcément dans le cas d'un bloc avec des images, mais avec un item qui n'en a pas.

Ce qui donne : 
![Capture d’écran 2025-02-13 à 11 24 01](https://github.com/user-attachments/assets/bc837e7e-b7af-4e89-9a44-60c4a409ab95)
![Capture d’écran 2025-02-13 à 11 24 09](https://github.com/user-attachments/assets/9305fdbd-df8d-47f7-8884-583c2d7a1413)

Et aucun souci sur un projet où on aurait une image manquante :
![Capture d’écran 2025-02-13 à 11 51 09](https://github.com/user-attachments/assets/bd980c66-25f3-4536-a1d6-af6f448729b4)

Ça corrige aussi le fait qu'on avait perdu la zone cliquable sur l'image.

- **Layout cartes**
Pour nous aligner avec le layout carte du bloc pages, j'ai ajouté une height à 100% sur l'article, afin que le rectangle gris puisse prendre la hauteur du plus grand élément : 
![Capture d’écran 2025-02-13 à 11 29 12](https://github.com/user-attachments/assets/e61053c4-199a-4691-aef2-bf4774f44080)
![Capture d’écran 2025-02-13 à 11 29 22](https://github.com/user-attachments/assets/d5cbeba3-8861-4b05-8d30-b802cecef5c9)

- **Layout grand**

On a la flèche sur le titre : 
![Capture d’écran 2025-02-13 à 11 55 30](https://github.com/user-attachments/assets/55558223-5de1-4984-b87e-fd44d65415c0)
Or flèche doit être sur l'élément "more", je l'ai donc déplacée :
![Capture d’écran 2025-02-13 à 11 56 11](https://github.com/user-attachments/assets/983d8ba1-36be-4b6c-b699-80998d20891e)

Aussi, l'image doit déborder sur les marges en mobile, comme ceci : 
![Capture d’écran 2025-02-13 à 11 42 56](https://github.com/user-attachments/assets/7d90806a-c455-4ad9-ac91-cc77318f3a40)

- **Layout Grille**
Au sujet de la flèche, elle est vraiment énorme dans un élément de h2, par exemple sur les grilles : 
![Capture d’écran 2025-02-13 à 11 40 27](https://github.com/user-attachments/assets/166a4456-833d-49a9-ab34-539b3cb994f7)

Pourrait-on envisager un `font-size: 80%` ou ce n'est pas assez robuste ?
![Capture d’écran 2025-02-13 à 11 40 38](https://github.com/user-attachments/assets/0f7bf892-ff57-4e0a-a493-081b0badc4f6)

Pour les flèches et leur animation, on pourrait peut-être envisager un mixin (ou une évolution) qui s'occupe du cas où le hover se fait sur l'article entier, et non juste sur les titre (ce qui arrive souvent dans ces blocs, comme ce sont des `stretched-link` pour la plupart.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

- Les projets : `http://localhost:1314/fr/blocks/blocs-de-liste/les-projets/#selection-de-projets-liste`
- Les catégories : `http://localhost:1314/fr/blocks/blocs-de-liste/les-categories/`