### PR TITLE
Erreur de js dans une figure clé sans chiffre

### DIFF
--- a/layouts/partials/blocks/templates/key_figures.html
+++ b/layouts/partials/blocks/templates/key_figures.html
@@ -24,7 +24,9 @@
                         "sizes"    site.Params.image_sizes.blocks.key_figures
                       )}}
                   {{ end }}
-                  <strong>{{ .number }}</strong>{{ partial "PrepareHTML" .unit }}
+                  {{ if .number }}
+                    <strong>{{ .number }}</strong>{{ partial "PrepareHTML" .unit }}
+                  {{ end }}
                 </span>
                 {{ partial "PrepareHTML" .description }}
               </li>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Dans les figures clé, lorsqu'il n'y a pas de nombre renseigné, on a une erreur JS.

![Capture d’écran 2025-02-13 à 16 22 10](https://github.com/user-attachments/assets/aaf29655-17be-4fa2-9a16-fe871db7e618)
![Capture d’écran 2025-02-13 à 16 22 25](https://github.com/user-attachments/assets/b2b62cc8-02c7-4c0b-910d-04743be610fe)

On a deux options : 
- laisser "NaN" ou une autre valeur par défaut et faire le fix au niveau du js
- ne rien afficher si on ne reçoit pas de donnée du statique

Dans cette PR j'ai choisi la 2e option : ni NaN ni %.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test du site IUT de Bordeaux

`http://localhost:1314/formations/carrieres-sociales/animation-sociale-et-socioculturelle/#informations-administratives`