### PR TITLE
Uniformisation du style des listes

### DIFF
--- a/assets/sass/_theme/design-system/layout.sass
+++ b/assets/sass/_theme/design-system/layout.sass
@@ -51,7 +51,7 @@ iframe
 ul,
 ol
     // https://since1979.dev/aligning-your-lists-with-your-text/
-    padding-left: 0
+    padding-left: var(--body-size)
     list-style-position: outside
     > li
         > p

--- a/assets/sass/_theme/design-system/typography.sass
+++ b/assets/sass/_theme/design-system/typography.sass
@@ -168,8 +168,6 @@ small, .small
         margin-top: $spacing-3
         &:first-child, meta + &
             margin-top: 0
-    ul, ol
-        padding-left: var(--body-size)
 
 .content
     section 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Uniformisation des listes, sur le modèle des listes à l'intérieur des `.rich-text` : on garde le `list-style-position: outside` mais on ajoute un padding à gauche ayant pour valeur `var(--body-size)`.

Est-ce que c'est ok ?

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence

https://github.com/osunyorg/bordeauxmontaigne-iut/issues/124

## URL de test du site IUT Bordeaux

`http://localhost:1314/formations/genie-chimique-genie-des-procedes/` (bloc "en chiffres")

## URL de test du site IUT Bordeaux Montaigne

`http://localhost:1313/tests/`

## Screenshots
![Capture d’écran 2025-02-13 à 17 08 57](https://github.com/user-attachments/assets/d7bda4ba-5a70-4953-b839-40a087d48877)
![Capture d’écran 2025-02-13 à 17 10 06](https://github.com/user-attachments/assets/e78be3d4-5db9-4656-90e1-e1bf1d35fa96)
