### PR TITLE
Correction des icônes sur iOS iphone 13

### DIFF
--- a/assets/sass/_theme/utils/icons.sass
+++ b/assets/sass/_theme/utils/icons.sass
@@ -14,6 +14,7 @@
 
 @mixin icon($icon-name: '', $pseudo-element: before, $non-breaking: false)
     &::#{$pseudo-element}
+        content: map-get($icons, $icon-name)
         content: map-get($icons, $icon-name) #{/ ""} // Add ‘ / ""‘ to hide from screen reader
         font-family: 'Icon'
         font-style: normal


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Permet d'afficher les icônes tout en les masquants pour les lecteurs d'écran.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


