### PR TITLE
Réparation des 404

### DIFF
--- a/content/error.html
+++ b/content/error.html
@@ -2,6 +2,6 @@
 title: 404
 url: /error.html
 type: error
-outputFormats:
+outputs:
 - html
 ---

--- a/content/error.html
+++ b/content/error.html
@@ -2,4 +2,6 @@
 title: 404
 url: /error.html
 type: error
+outputFormats:
+- html
 ---

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -6,29 +6,29 @@ outputFormats:
     permalinkable: true
     rel: pagedjs
 outputs:
-  home:
-  - html
-  - rss
-  - pagedjs
-  page:
-  - html
-  - pagedjs
-  rss:
-  - rss
-  section:
-  - html
-  - rss
-  - pagedjs
-  taxonomy:
-  - html
-  - rss
-  - pagedjs
-  term:
-  - html
-  - rss
-  - pagedjs
-  error:
-  - html
+  # home:
+  # - html
+  # - rss
+  # - pagedjs
+  # page:
+  # - html
+  # - pagedjs
+  # rss:
+  # - rss
+  # section:
+  # - html
+  # - rss
+  # - pagedjs
+  # taxonomy:
+  # - html
+  # - rss
+  # - pagedjs
+  # term:
+  # - html
+  # - rss
+  # - pagedjs
+  # error:
+  # - html
 removePathAccents: true
 ignoreLogs: ['warning-goldmark-raw-html']
 pagination:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -6,29 +6,13 @@ outputFormats:
     permalinkable: true
     rel: pagedjs
 outputs:
-  # home:
-  # - html
-  # - rss
-  # - pagedjs
   page:
   - html
   - pagedjs
-  # rss:
-  # - rss
   section:
   - html
   - rss
   - pagedjs
-  # taxonomy:
-  # - html
-  # - rss
-  # - pagedjs
-  # term:
-  # - html
-  # - rss
-  # - pagedjs
-  # error:
-  # - html
 removePathAccents: true
 ignoreLogs: ['warning-goldmark-raw-html']
 pagination:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -27,7 +27,7 @@ outputs:
   - html
   - rss
   - pagedjs
-  404:
+  error:
   - html
 removePathAccents: true
 ignoreLogs: ['warning-goldmark-raw-html']

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -27,6 +27,8 @@ outputs:
   - html
   - rss
   - pagedjs
+  404:
+  - html
 removePathAccents: true
 ignoreLogs: ['warning-goldmark-raw-html']
 pagination:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -10,9 +10,9 @@ outputs:
   # - html
   # - rss
   # - pagedjs
-  # page:
-  # - html
-  # - pagedjs
+  page:
+  - html
+  - pagedjs
   # rss:
   # - rss
   section:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -6,9 +6,27 @@ outputFormats:
     permalinkable: true
     rel: pagedjs
 outputs:
-  home: ['html', 'rss', 'pagedjs']
-  page: ['html', 'pagedjs']
-  section: ['html', 'pagedjs']
+  home:
+  - html
+  - rss
+  - pagedjs
+  page:
+  - html
+  - pagedjs
+  rss:
+  - rss
+  section:
+  - html
+  - rss
+  - pagedjs
+  taxonomy:
+  - html
+  - rss
+  - pagedjs
+  term:
+  - html
+  - rss
+  - pagedjs
 removePathAccents: true
 ignoreLogs: ['warning-goldmark-raw-html']
 pagination:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -15,10 +15,10 @@ outputs:
   # - pagedjs
   # rss:
   # - rss
-  # section:
-  # - html
-  # - rss
-  # - pagedjs
+  section:
+  - html
+  - rss
+  - pagedjs
   # taxonomy:
   # - html
   # - rss


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Certaines pages 404 et RSS sont rendues avec Paged.js sur Garage.

https://git.deuxfleurs.fr/Deuxfleurs/garage/issues/955

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


