### PR TITLE
Bloc chiffres clefs : modification de la disposition en mobile

### DIFF
--- a/assets/sass/_theme/blocks/key_figures.sass
+++ b/assets/sass/_theme/blocks/key_figures.sass
@@ -25,14 +25,14 @@
             font-size: $block-key_figures-number-font-size
             font-weight: $block-key_figures-number-font-weight
             margin-inline-end: 0.1em
-        img
-            margin-bottom: $spacing-2
-            max-width: $block-key_figures-image-max-width
-        picture.is-png 
+        picture.is-png
             img
                 max-width: $block-key_figures-icon-max-width
         @include media-breakpoint-up(desktop)
             font-size: $block-key_figures-font-size-desktop
+            img
+                margin-bottom: $spacing-2
+                max-width: $block-key_figures-image-max-width
             strong
                 font-size: $block-key_figures-number-font-size-desktop
             img
@@ -52,6 +52,20 @@
         span + p
             margin-top: $spacing-2
     @include media-breakpoint-down(desktop)
-        li + li
-            margin-top: $spacing-3
+        li
+            &.with-image
+                // ensure that the text accompanying the number is sent to the right of the image
+                padding-left: offset(4)
+                span
+                    align-items: baseline
+                    display: flex
+                    flex-wrap: wrap
+                picture
+                    // without the negative margin, text goest under the image, not at its right
+                    margin-left: calc(-1 * #{offset(4)})
+                    width: columns(4)
+                    + strong
+                        margin-left: var(--grid-gutter)
+            + li
+                margin-top: $spacing-3
 

--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -94,9 +94,6 @@ $block-key_figures-image-max-width-desktop: pxToRem(128) !default
 $block-key_figures-image-max-width: pxToRem(48) !default
 $block-key_figures-icon-max-width: pxToRem(60) !default
 
-$block-key_figures-font-size: pxToRem(16) !default
-$block-key_figures-number-font-size: pxToRem(32) !default
-
 $block-key_figures-font-size-desktop: pxToRem(18) !default
 $block-key_figures-number-font-size-desktop: pxToRem(40) !default
 
@@ -108,6 +105,9 @@ $block-key_figures-number-font-size-xl: pxToRem(60) !default
 
 $block-key_figures-font-size-xxl: $block-key_figures-font-size-xl !default
 $block-key_figures-number-font-size-xxl: pxToRem(80) !default
+
+$block-key_figures-font-size: $block-key_figures-font-size-lg !default
+$block-key_figures-number-font-size: $block-key_figures-number-font-size-lg !default
 
 // Block gallery
 $block-gallery-carousel-background: var(--color-background-alt) !default

--- a/layouts/partials/blocks/templates/key_figures.html
+++ b/layouts/partials/blocks/templates/key_figures.html
@@ -15,7 +15,7 @@
           {{ end }}
           <ul class="{{ $list_class }}">
             {{- range .figures }}
-              <li>
+              <li {{- if .image }} class="with-image" {{- end -}}>
                 <span>
                   {{ with .image }}
                     {{ partial "commons/image.html"


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Plusieurs changements (mobile uniquement) : 
- HTML : ajout d'une class `with-image` sur le `li`(j'ai essayé de faire sans mais c'est complexe et on risque des effets indésirables quand on n'a pas d'image.
- style du block : on ajoute un padding à gauche d'un `offset(4)` pour aligner tous les textes à droite de l'image, l'image a quant à elle une marge négative à gauche, afin de se caler correctement (c'est le seul moyen que j'ai trouvé pour ne rien changer dans le html, hormis la class)
- configuration : les variables des font-sizes prennent désormais la valeur du `lg` (sur la maquette c'est `xl` qui est choisi (60px) mais ça rend les choses vraiment énormes, avec un risque de retour à la ligne des chiffres, à voir si on s'aligne là-dessus !)

NB : J'ai mis des commentaires aux endroits concernés, on peut les enlever ou les laisser.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/epv-site/issues/10#issuecomment-2662201238

## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/blocks-narratifs/chiffre-cles/`

## Screenshots

![Image](https://github.com/user-attachments/assets/cb2ff795-a05b-4911-bef7-bbba878a1d76)
![Image](https://github.com/user-attachments/assets/9a140143-e909-458b-87fd-cc32c21a3c98)
![Image](https://github.com/user-attachments/assets/c9a086c1-b86f-4375-8eca-54ada17f0006)