### PR TITLE
Bloc organisations : diminution de la largeur du logo en mobile

### DIFF
--- a/assets/sass/_theme/sections/organizations.sass
+++ b/assets/sass/_theme/sections/organizations.sass
@@ -47,10 +47,13 @@
             .organization-summary
                 @include small
         .media
-            width: columns(6)
-        @include media-breakpoint-up(md)
-            .media
+            width: columns(4)
+            @include media-breakpoint-down(md)
+                padding: $spacing-1
+            @include media-breakpoint-up(md)
                 width: columns(3)
+            @include media-breakpoint-up(desktop)
+                width: columns(6)
         @include media-breakpoint-up(xl)
             gap: calc(var(--grid-gutter) / 2)
             width: columns(4)

--- a/assets/sass/_theme/sections/organizations.sass
+++ b/assets/sass/_theme/sections/organizations.sass
@@ -52,7 +52,7 @@
                 padding: $spacing-1
             @include media-breakpoint-up(md)
                 width: columns(3)
-            @include media-breakpoint-up(desktop)
+            @include media-breakpoint-up(xl)
                 width: columns(6)
         @include media-breakpoint-up(xl)
             gap: calc(var(--grid-gutter) / 2)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

[Ne concerne que les blocs d'orga avec l'option `summary` active]

En mobile, les logos sont en `columns(6)`, ce qui rend le texte trop étroit : 

![Capture d’écran 2025-02-17 à 16 39 24](https://github.com/user-attachments/assets/7ec015a3-2d50-4f39-9f49-fa8396a54612)

Pour palier ça, on réduit à 4 colonnes en mobile, en réduisant aussi, pour compenser, le padding autour du logo.

Aussi je me suis rendue compte de ce bug-ci, à cause du breakpoint `desktop`, j'ai donc augmenté à `xl`
![Capture d’écran 2025-02-17 à 16 41 25](https://github.com/user-attachments/assets/d106249a-c1af-4269-88c3-69b3235bc5a3)

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/700

## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/blocs-de-liste/partenaires/`

## Screenshots

![Capture d’écran 2025-02-17 à 16 36 21](https://github.com/user-attachments/assets/1b2d1735-e8a5-4ec5-bd73-070e93964e65)

Aucune incidence en dfesktop : 
![Capture d’écran 2025-02-17 à 16 36 36](https://github.com/user-attachments/assets/de273a47-75fb-4b88-98d3-8a246fd81d04)
