### PR TITLE
Exclude PagedJS pages from Pagefind

### DIFF
--- a/bin/osuny.js
+++ b/bin/osuny.js
@@ -56,7 +56,7 @@ if (command === "watch") {
 
 if (command === "dev") {
     execute("hugo");
-    execute("npx pagefind --site 'public' --output-subdir '../static/pagefind' --exclude-selectors '" + pagefindExclude + "'");
+    execute("npx pagefind --site 'public' --output-subdir '../static/pagefind' --glob '**/index.{html}' --exclude-selectors '" + pagefindExclude + "'");
     execute("hugo server");
 }
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

En précisant grâce à l'option [`--glob`](https://pagefind.app/docs/config-options/#glob) de Pagefind, on peut limiter l'indexation aux fichiers `index.html`. En regardant des sites générés, il me semble que les fichiers HTML sont nommés uniquement `index.html`.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


