### PR TITLE
Configuration des colonnes

### DIFF
--- a/assets/sass/_theme/_variables.sass
+++ b/assets/sass/_theme/_variables.sass
@@ -150,7 +150,8 @@
 
   // Largeur d'une colonne
   // On soustrait à la largeur de la grille les 13 gouttières (les 2 extérieures et les 11 intérieures), puis on divise par 12
-  --column-width: calc( (var(--grid-width) - var(--grid-gutter) * 13) / 12)
+  --columns-count: 12
+  --column-width: calc( (var(--grid-width) - var(--grid-gutter) * calc(var(--columns-count) + 1)) / var(--columns-count))
 
   // Taille de la gouttière
   // Les largeurs des gouttières en fonction des breakpoints sont définies dans _configuration.sass

--- a/assets/sass/_theme/blocks/pages.sass
+++ b/assets/sass/_theme/blocks/pages.sass
@@ -162,7 +162,7 @@
                         margin-top: 0
             &.with-description
                 .block-content
-                    @include grid(12, desktop, $spacing-4)
+                    @include grid(var(--columns-count), desktop, $spacing-4)
                     .top
                         align-items: initial
                         grid-column: 1 / 8

--- a/assets/sass/_theme/blocks/posts.sass
+++ b/assets/sass/_theme/blocks/posts.sass
@@ -291,7 +291,7 @@
                     aspect-ratio: 1.55
         @include media-breakpoint-down(desktop)
             .slider-arrows
-                width: columns(12)
+                width: columns(var(--columns-count))
             .post
                 width: columns(10)
         @include in-page-with-sidebar

--- a/assets/sass/_theme/blocks/testimonials.sass
+++ b/assets/sass/_theme/blocks/testimonials.sass
@@ -21,7 +21,7 @@
                     line-height: $block-testimonials-xl-line-height-long-text
     figure
         margin-bottom: 0
-        width: columns(12)
+        width: columns(var(--columns-count))
     figcaption
         align-items: center
         display: flex
@@ -40,12 +40,12 @@
             width: columns(8)
     @include in-page-without-sidebar
         .testimonials
-            width: columns(12)
+            width: columns(var(--columns-count))
         figure
             min-height: columns(2)
             width: columns(8)
             padding-left: offset(4)
-            width: columns(12)
+            width: columns(var(--columns-count))
             &.with-picture
                 position: relative
                 figcaption

--- a/assets/sass/_theme/blocks/video.sass
+++ b/assets/sass/_theme/blocks/video.sass
@@ -7,7 +7,7 @@
         @include in-page-without-sidebar
             background: $block-video-background
             .block-content
-                @include grid(12, false, 0)
+                @include grid(var(--columns-count), false, 0)
                 padding-top: $block-space-y
                 padding-bottom: $spacing-4
                 .top

--- a/assets/sass/_theme/design-system/layout.sass
+++ b/assets/sass/_theme/design-system/layout.sass
@@ -66,6 +66,12 @@ ol
     @include in-page-with-sidebar
         .heading h2, .block .block-content
             padding-left: offset(4)
+            @include media-breakpoint-up(xxl) // TODO: this is for testing, need to be removed
+                padding-left: offset(8)
+
+\:root // TODO: this is for testing, need to be removed
+    @include media-breakpoint-up(xxl)
+        --columns-count: 16
 
 details
     &:not([open]):hover

--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -126,7 +126,7 @@
                 color: var(--color-background)
                 height: 100%
                 margin: 0
-                width: columns(12) !important // overwrite leaflet js width
+                width: columns(var(--columns-count)) !important // overwrite leaflet js width
                 @include media-breakpoint-up(md)
                     width: columns(5) !important
                 @include media-breakpoint-up(xl)

--- a/assets/sass/_theme/sections/programs.sass
+++ b/assets/sass/_theme/sections/programs.sass
@@ -224,7 +224,7 @@ ol.programs
             .summary
                 margin-bottom: $spacing-6
             .content
-                @include grid(12, desktop)
+                @include grid(var(--columns-count), desktop)
                 position: relative
                 padding-bottom: $spacing-6
                 > *

--- a/layouts/partials/footer/debug.html
+++ b/layouts/partials/footer/debug.html
@@ -49,6 +49,10 @@
   <div>10</div>
   <div>11</div>
   <div>12</div>
+  <div>13</div>
+  <div>14</div>
+  <div>15</div>
+  <div>16</div>
 </div>
 
 <div class="d-spacing">
@@ -94,7 +98,7 @@
     bottom: 0;
     display: none;
     grid-gap: var(--grid-gutter);
-    grid-template-columns: repeat(12, 1fr);
+    grid-template-columns: repeat(var(--columns-count), 1fr);
     opacity: 0.2;
     mix-blend-mode: multiply;
     padding: 0 var(--grid-gutter);
@@ -243,11 +247,15 @@
 </style>
 
 <script>
+  var grid = document.querySelector('.d-grid'),
+      spacings = document.querySelector('.d-spacing'),
+      cross = document.querySelector('.d-cross');
+
   window.addEventListener('keydown', e => {
     if (e.ctrlKey && e.key === 'g') {
-      document.querySelector('.d-grid').classList.toggle('is-visible');
-      document.querySelector('.d-spacing').classList.toggle('is-visible');
-      document.querySelector('.d-cross').classList.toggle('is-visible');
+      grid.classList.toggle('is-visible');
+      spacings.classList.toggle('is-visible');
+      cross.classList.toggle('is-visible');
     }
     if (e.ctrlKey && e.key === 'w') {
       document.body.classList.toggle('full-width');
@@ -281,6 +289,24 @@
   document.querySelector('.d-help__toggle').addEventListener('click', e => {
     e.preventDefault()
     toggleDebug()
+  });
+
+  function setColumns () {
+    var i = 0,
+        column,
+        columnsCount = window.getComputedStyle(document.body).getPropertyValue('--columns-count');
+    columnsCount = parseInt(columnsCount);
+    grid.innerHTML = "";
+
+    for (i = 0; i < columnsCount; i += 1) {
+      column = document.createElement('div');
+      column.innerText = (i + 1);
+      grid.appendChild(column);
+    }
+  }
+
+  window.addEventListener('resize', function () {
+    setColumns();
   });
 
   function toggleDebug() {


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout d'une variable css `columns-count` qui permet de définir le nombre de colonnes de la grille. Cette variable peut être modifier en fonction de la largeur d'écran. L'objectif est également de permettre des compositions différentes en conservant l'intégrité des intégration des blocs.

![image](https://github.com/user-attachments/assets/1dac4b7d-e107-48e6-befb-4c0cff66858b)

![image](https://github.com/user-attachments/assets/de670694-84c2-4a63-9680-55f1b3065d8a)


## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


