### PR TITLE
Correction de l'espace bas dans une page de section

### DIFF
--- a/assets/sass/_theme/design-system/layout.sass
+++ b/assets/sass/_theme/design-system/layout.sass
@@ -31,8 +31,11 @@ body
     //         transition-duration: 0s !important
 
 main
-    &:not(.page-with-blocks, .page-with-map)
+    &:not(.page-with-blocks, .page-with-map),
+    body[class*="__section"] &
         padding-bottom: $spacing-5
+    .blocks + *
+        margin-top: $spacing-5
 
 iframe
     border: none

--- a/assets/sass/_theme/design-system/pagination.sass
+++ b/assets/sass/_theme/design-system/pagination.sass
@@ -6,8 +6,6 @@
     display: flex
     flex-wrap: wrap
     margin-top: $spacing-5
-    main.page-with-blocks &
-        padding-bottom: $spacing-5
     li
         a
             color: inherit


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout d'un espace vertical en bas de la balise `main` dans le cas où il y a un blocs sur la page, qu'il y ai une pagination ou non.


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
