### PR TITLE
Enlever la bordure du dernier élément du layout `list`

### DIFF
--- a/assets/sass/_theme/blocks/posts.sass
+++ b/assets/sass/_theme/blocks/posts.sass
@@ -215,10 +215,11 @@
             margin-top: $spacing-3
             border-top: 1px solid var(--color-border)
             article
-                // border-bottom: 1px solid var(--color-border)
                 position: relative
                 padding-bottom: $spacing-3
                 margin-top: $spacing-3
+                &:where(:not(:last-child))
+                    border-bottom: 1px solid var(--color-border)
         article
             > * + * 
                 margin-top: $spacing-2

--- a/assets/sass/_theme/blocks/posts.sass
+++ b/assets/sass/_theme/blocks/posts.sass
@@ -131,7 +131,8 @@
                                 width: columns(8)
     &--list
         article
-            border-bottom: 1px solid var(--color-border)
+            &:where(:not(:last-child))
+                border-bottom: 1px solid var(--color-border)
             .media
                 background: none
                 margin: 0
@@ -176,7 +177,6 @@
 
         @include in-page-without-sidebar
             article
-                border-bottom: 1px solid var(--color-border)
                 gap: var(--grid-gutter)
                 padding-bottom: $spacing-5
                 position: relative
@@ -215,7 +215,7 @@
             margin-top: $spacing-3
             border-top: 1px solid var(--color-border)
             article
-                border-bottom: 1px solid var(--color-border)
+                // border-bottom: 1px solid var(--color-border)
                 position: relative
                 padding-bottom: $spacing-3
                 margin-top: $spacing-3

--- a/assets/sass/_theme/sections/events.sass
+++ b/assets/sass/_theme/sections/events.sass
@@ -118,12 +118,13 @@
 .events
     &--list
         .event
-            border-bottom: 1px solid var(--color-border)
             display: flex
             flex-direction: column
             margin-bottom: $spacing-3
             padding-bottom: $spacing-3
             position: relative
+            &:where(:not(:last-child))
+                border-bottom: 1px solid var(--color-border)
             &-title
                 @include h3
             &-schedule

--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -31,7 +31,7 @@
             .location
                 flex-direction: row-reverse
                 gap: var(--grid-gutter)
-                &:not(:last-child)
+                &:where(:not(:last-child))
                     border-bottom: 1px solid var(--color-border)
                     padding-bottom: $spacing-3
                 + .location


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

On retire la dernière bordure des éléments dans un bloc en mode liste.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

