### PR TITLE
Réduction du nombre de fragments Pagefind

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,7 +16,7 @@
     {{- partial "header/accessibility.html" -}}
     {{- partial "hooks/before-header" . -}}
     {{- partial "header/header.html" . -}}
-    <main{{ if .Params.contents }} class="page-with-blocks"{{ end }} id="main">
+    <main{{ if .Params.contents }} class="page-with-blocks"{{ end }} id="main" {{ if site.Params.search.active }}data-pagefind-body{{ end }}>
       {{ partial "commons/search/button.html" "fixed" }}
       {{- block "main" . }}{{- end }}
       {{- partial "hooks/before-main-end" . -}}

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -64,12 +64,10 @@
     </script>
   {{ end }}
 </head>
-{{ if hugo.IsMultilingual }}
-  <body>
-    {{ if hugo.IsMultilingual }}
+  {{ if hugo.IsMultilingual }}
+    <body>
       <h1>Redirection</h1>
       <p>You should be redirected in a moment, if not click here: <a href="{{ .Permalink }}">{{ .Permalink }}</a>.</p>
-    {{ end }}
-  </body>
-{{ end }}
+    </body>
+  {{ end }}
 </html>

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -64,10 +64,12 @@
     </script>
   {{ end }}
 </head>
-<body>
-  {{ if hugo.IsMultilingual }}
-    <h1>Redirection</h1>
-    <p>You should be redirected in a moment, if not click here: <a href="{{ .Permalink }}">{{ .Permalink }}</a>.</p>
-  {{ end }}
-</body>
+{{ if hugo.IsMultilingual }}
+  <body>
+    {{ if hugo.IsMultilingual }}
+      <h1>Redirection</h1>
+      <p>You should be redirected in a moment, if not click here: <a href="{{ .Permalink }}">{{ .Permalink }}</a>.</p>
+    {{ end }}
+  </body>
+{{ end }}
 </html>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

En ajoutant l'attribut `data-pagefind-body` cela permet d'ignorer les alias et les html de pagedjs.

On ajoute l'attribut sur la balise `main` afin de ne pas rechercher dans les menu (en-tête et pied de page).


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


