### PR TITLE
TOC : réparation du saut de l'icône du cta en mobile

### DIFF
--- a/assets/sass/_theme/design-system/table_of_contents.sass
+++ b/assets/sass/_theme/design-system/table_of_contents.sass
@@ -106,6 +106,8 @@
             color: $toc-color
             text-overflow: ellipsis
             overflow: hidden
+            @include media-breakpoint-down(desktop)
+                flex: 1
         &::after
             color: $toc-color
             margin-right: $icon-toc-margin-right


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

L'icône dans le bouton de CTA bougeait quand le texte devenait trop long, c'était dû au fait que dans un parent en `display: flex`, si on ne précise pas de `flex: 1` ou de `width` à un élément, mais qu'un autre a une `width`, le premier va pousser le 2e.

Ici, on ajoute donc un `flex: 1` sur le span

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1313/fr/actualites/2023-03-04-referentiel-general-decoconception-de-services-numeriques-rgesn/`
