### PR TITLE
Ajustement des listes des années pour les événements

### DIFF
--- a/layouts/partials/events/section/archives/years.html
+++ b/layouts/partials/events/section/archives/years.html
@@ -4,11 +4,13 @@
     <h2 class="sr-only">{{ i18n "events.archives.by_year" }}</h2>
     <ol>
       {{ range . }}
-        <li>
-          <a href="{{ .Permalink }}" title="{{ i18n "events.archives.list.title" (dict "year" .Title)}}">{{ .Title }}</a>
-          {{ $count := len (where .RegularPagesRecursive ".Params.is_month" nil) }}
-          <p>{{ i18n "events.count" $count  }}</p>
-        </li>
+        {{ if .Params.is_year }}
+          <li>
+            <a href="{{ .Permalink }}" title="{{ i18n "events.archives.list.title" (dict "year" .Title)}}">{{ .Title }}</a>
+            {{ $count := len (where .RegularPagesRecursive ".Params.is_month" nil) }}
+            <p>{{ i18n "events.count" $count  }}</p>
+          </li>
+        {{ end }}
       {{ end }}
     </ol>
   </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

On ajoute une vérification sur l'objet pour savoir s'il est bien une année avec le `.Params.is_year` afin d'éviter une longue liste d'événements pendant la migration des `events`.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


