### PR TITLE
Bloc agenda : taille des images (large et grid)

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -401,11 +401,11 @@ params:
         grid:
           mobile:   90
           tablet:   360
-          desktop:  555
+          desktop:  690
         large:
           mobile:   400
           tablet:   360
-          desktop:  645
+          desktop:  1019
         list:
           mobile:   90
           tablet:   200


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Correction des tailles d'images du bloc agenda.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/957

## URL de test sur example.osuny.org

`https://example.osuny.org/fr/blocks/blocs-de-liste/agenda-1/`

## Captures d'écran
![Capture d’écran 2025-03-13 à 17 23 26](https://github.com/user-attachments/assets/26e171fd-efc8-4f9e-9f9a-998a89c3da65)

![Capture d’écran 2025-03-13 à 17 22 53](https://github.com/user-attachments/assets/0f199ed3-1b2a-448a-af49-b3d91b2f5762)
