### PR TITLE
Agenda : ajout du markup `startDate`

### DIFF
--- a/assets/sass/_theme/sections/events/single.sass
+++ b/assets/sass/_theme/sections/events/single.sass
@@ -1,6 +1,5 @@
 .events__page
     .hero
-        margin-bottom: 0
         .content
             align-items: stretch
             display: flex
@@ -14,6 +13,7 @@
                 li
                     line-height: 100%
         @include media-breakpoint-up(desktop)
+            margin-bottom: 0
             figure
                 order: -1
             &.hero--image-square,

--- a/layouts/partials/events/partials/event.html
+++ b/layouts/partials/events/partials/event.html
@@ -54,6 +54,10 @@
             "dates" .Params.dates
             "on_two_lines" (ne $layout "list")
           )}}
+      {{ else }}
+        {{ with .Params.dates }}
+          <time class="sr-only" itemprop="startDate" datetime="{{- if .from.day -}}{{ .from.day }}{{- end -}}{{- if .from.hour -}}T{{ .from.hour }}{{- end -}}">{{ .computed.short }}</time>
+        {{ end }}
       {{ end }}
 
       {{ if and $dates.status $options.status }}

--- a/layouts/partials/events/partials/event.html
+++ b/layouts/partials/events/partials/event.html
@@ -56,7 +56,8 @@
           )}}
       {{ else }}
         {{ with .Params.dates }}
-          <time class="sr-only" itemprop="startDate" datetime="{{- if .from.day -}}{{ .from.day }}{{- end -}}{{- if .from.hour -}}T{{ .from.hour }}{{- end -}}">{{ .computed.short }}</time>
+          <meta itemprop="startDate" content="{{- if .from.day -}}{{ .from.day }}{{- end -}}{{- if .from.hour -}}T{{ .from.hour }}{{- end -}}">
+          <meta itemprop="endDate" content="{{- if .to.day -}}{{ .to.day }}{{- end -}}{{- if .to.hour -}}T{{ .to.hour }}{{- end -}}">
         {{ end }}
       {{ end }}
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Ajout du markup startDate dans le format agenda des événements.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

<img width="535" alt="image" src="https://github.com/user-attachments/assets/7dc61696-bc65-40c7-a3bf-cc4aec96cdd2" />



