### PR TITLE
Retirer le filtre backdrop sur les dates en mobile

### DIFF
--- a/assets/sass/_theme/configuration/zindex.sass
+++ b/assets/sass/_theme/configuration/zindex.sass
@@ -1,5 +1,6 @@
 // Z-index
 $zindex-aside: 48 !default
+$zindex-agenda-sticky-date: 48 !default
 $zindex-body-overlay: 51 !default
 $zindex-dropdown: 3 !default
 $zindex-footer: 50 !default

--- a/assets/sass/_theme/sections/events/layouts.sass
+++ b/assets/sass/_theme/sections/events/layouts.sass
@@ -205,12 +205,10 @@
                 @include sticky
                 top: 0
                 width: 100%
-                backdrop-filter: $backdrop
-                background: white
-                background-color: $backdrop-color
+                background: var(--color-background)
                 padding-bottom: $spacing-2
                 padding-top: $spacing-2
-                z-index: 2
+                z-index: $zindex-agenda-sticky-date
             .event
                 &-content
                     display: flex


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


## Screenshots

Avant

<img width="378" alt="image" src="https://github.com/user-attachments/assets/0aecb74c-f401-44aa-a22a-e5c40d0f5a74" />


Après

<img width="379" alt="image" src="https://github.com/user-attachments/assets/b4ef6462-a7ef-464a-b0f8-8d4fad360f7f" />


