### PR TITLE
Alignement du texte du toc

### DIFF
--- a/assets/sass/_theme/design-system/table_of_contents.sass
+++ b/assets/sass/_theme/design-system/table_of_contents.sass
@@ -99,6 +99,7 @@
         @include link-icon(menu-3-line)
         border: 0
         cursor: pointer
+        gap: space()
         line-height: inherit
         padding: 0
         text-align: left

--- a/assets/sass/_theme/design-system/table_of_contents.sass
+++ b/assets/sass/_theme/design-system/table_of_contents.sass
@@ -99,10 +99,8 @@
         @include link-icon(menu-3-line)
         border: 0
         cursor: pointer
-        gap: space()
         line-height: inherit
         padding: 0
-        text-align: left
         span
             @include meta
             color: $toc-color
@@ -114,9 +112,11 @@
             color: $toc-color
             margin-right: $icon-toc-margin-right
         @include media-breakpoint-down(desktop)
-            display: flex
-            justify-content: space-between
             align-items: center
+            display: flex
+            gap: space()
+            justify-content: space-between
+            text-align: left
             width: 100%
 
 .toc-container

--- a/assets/sass/_theme/design-system/table_of_contents.sass
+++ b/assets/sass/_theme/design-system/table_of_contents.sass
@@ -98,9 +98,10 @@
     button
         @include link-icon(menu-3-line)
         border: 0
-        line-height: inherit
         cursor: pointer
+        line-height: inherit
         padding: 0
+        text-align: left
         span
             @include meta
             color: $toc-color


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Pour fix le problème de l'icône à droite du bouton du toc, qui sautait en mobile, le `span` prend toute la largeur (hors `gap`) du contenant. Or, le style de base du bouton lui est appliqué (un `text-align: center`), ce qui le centre au milieu.

Il n'y avait également pas de gap entre le titre et l'icône, j'en ai ajouté un pour éviter d'avoir les `...` collés à l'icône lorsque le titre est long.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/blocs-de-liste/actualites-1/`

## Screenshots

<img width="462" alt="Capture d’écran 2025-03-15 à 17 23 20" src="https://github.com/user-attachments/assets/83c82cbe-8356-479e-a6b1-7b039b7573d5" />
<img width="495" alt="Capture d’écran 2025-03-15 à 17 27 20" src="https://github.com/user-attachments/assets/fcc5d0b7-ccdc-4e22-80dc-b7ebd4d3e5f4" />
