### PR TITLE
Agenda : ajustement de l'espace vertical sous le titre en mobile

### DIFF
--- a/assets/sass/_theme/sections/events/layouts.sass
+++ b/assets/sass/_theme/sections/events/layouts.sass
@@ -201,6 +201,9 @@
             &-hours
                 @include h3
         @include media-breakpoint-down(desktop)
+            .events-date
+                // Set spacing top less title padding-top to get exact same space before and after event-date
+                padding-top: calc(#{$spacing-4} - #{$spacing-2})
             .events-date-title
                 @include sticky
                 top: 0


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Avoir un espace symétrique entre chaque jour de l'agenda en mobile.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots

<img width="376" alt="image" src="https://github.com/user-attachments/assets/10bbabde-7fbd-4a41-93e2-8059f9a2d62b" />

