### PR TITLE
Ajout de l'heure de fin d'un événement dans les dates

### DIFF
--- a/assets/sass/_theme/sections/events/single.sass
+++ b/assets/sass/_theme/sections/events/single.sass
@@ -146,6 +146,10 @@
             gap: var(--grid-gutter)
             .date
                 width: columns(4)
+            .hours
+                time + time
+                    @include icon(arrow-right-line)
+                        padding-right: space()
             .dropdown-calendar
                 @include dropdown
                 @include meta
@@ -173,10 +177,10 @@
                 flex-wrap: wrap
                 row-gap: $spacing-1
                 .date,
-                time,
+                .hours,
                 .dropdown-calendar
                     width: columns(6)
-                time
+                .hours
                     text-align: right
                 .location
                     @include meta
@@ -191,7 +195,7 @@
                         width: 100vw
         @include media-breakpoint-up(desktop)
             .event-time-slot
-                time
+                .hours
                     width: columns(2)
             .event-summary + ul
                 .dropdown-calendar

--- a/assets/sass/_theme/sections/events/single.sass
+++ b/assets/sass/_theme/sections/events/single.sass
@@ -88,8 +88,9 @@
 
     .event-access
         > div:first-child
-            border-top: 1px solid var(--color-border)
             padding-top: $spacing-4
+            @if $color-background == $hero-background-color
+                border-top: 1px solid var(--color-border)
         > div:last-child
             border-bottom: 1px solid var(--color-border)
             padding-bottom: $spacing-4

--- a/layouts/partials/commons/dates.html
+++ b/layouts/partials/commons/dates.html
@@ -1,8 +1,8 @@
-{{ $event := . }}
 {{ $is_repeating := gt .Params.time_slots 1 }}
 {{ $multiple_dates_event := ne .Params.dates.from.day .Params.dates.to.day }}
-{{ $is_parent := .Params.children }}
+{{ $is_parent := .Params.children}}
 {{ $has_primary_date := or $is_repeating $multiple_dates_event $is_parent }}
+
 <div class="event-slots {{- if $is_parent }} parent-event{{ end }}">
   <h2>{{ i18n "commons.date" (cond $has_primary_date 2 1) }}</h2>
   {{ if $has_primary_date }}
@@ -23,14 +23,13 @@
   {{ with .Params.time_slots }}
     <ul id="all-dates" class="extendable-list">
       {{ range $index, $time_slot := . }}
-        <li class="event-time-slot" itemprop="subEvent" itemscope itemtype="https://schema.org/Event">
-          <meta itemprop="name" content="{{ $event.Title }}">
-          <meta itemprop="url" content="{{ $event.Permalink }}">
+        <li class="event-time-slot" itemprop="subEvent">
           <span class="date" itemprop="startDate" content="{{ .start.datetime }}">{{ $time_slot.start.date | time.Format site.Params.events.single.time_slots.date_format }}</span>
-          <time datetime="{{ .start.time }}">{{ $time_slot.start.datetime | time.Format site.Params.events.single.time_slots.time_format }}</time>
-          {{ with $time_slot.place }}
-            <span class="location" itemprop="location">{{ . }}</span>
-          {{ end }}
+          <p class="hours">
+            <time datetime="{{ .start.time }}">{{ $time_slot.start.datetime | time.Format site.Params.events.single.time_slots.time_format }}</time>
+            <time datetime="{{ .end.time }}">{{ $time_slot.end.datetime | time.Format site.Params.events.single.time_slots.time_format }}</time>
+          </p>
+          <span class="location" itemprop="location" itemscope itemtype="https://schema.org/Place">{{ $time_slot.place }}</span>
           {{ partial "commons/dropdown-calendar.html" (dict
               "index" $index
               "calendar_links" $time_slot.add_to_calendar

--- a/layouts/partials/commons/dates.html
+++ b/layouts/partials/commons/dates.html
@@ -26,8 +26,12 @@
         <li class="event-time-slot" itemprop="subEvent">
           <span class="date" itemprop="startDate" content="{{ .start.datetime }}">{{ $time_slot.start.date | time.Format site.Params.events.single.time_slots.date_format }}</span>
           <p class="hours">
-            <time datetime="{{ .start.time }}">{{ $time_slot.start.datetime | time.Format site.Params.events.single.time_slots.time_format }}</time>
-            <time datetime="{{ .end.time }}">{{ $time_slot.end.datetime | time.Format site.Params.events.single.time_slots.time_format }}</time>
+            {{ if $time_slot.start.datetime }}
+              <time datetime="{{ .start.time }}">{{ $time_slot.start.datetime | time.Format site.Params.events.single.time_slots.time_format }}</time>
+            {{ end }}
+            {{ if $time_slot.end.datetime }}
+              <time datetime="{{ .end.time }}">{{ $time_slot.end.datetime | time.Format site.Params.events.single.time_slots.time_format }}</time>
+            {{ end }}
           </p>
           <span class="location" itemprop="location" itemscope itemtype="https://schema.org/Place">{{ $time_slot.place }}</span>
           {{ partial "commons/dropdown-calendar.html" (dict


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

- Ajout de l'heure de fin de l'événement dans les time slots.
- Ajout d'une condition qui compare la couleur de fond du site et du hero pour déterminer si on ajoute une bordure ou non

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1313/fr/agenda/2024/anne-charlotte-finel-respiro/`

## URL de test du site La Criée

`http://localhost:1313/fr/agenda/2025/projection-ai-african-intelligence/`

## URL de test du site EPV (pour la bordure)
`http://localhost:1314/fr/agenda/2025/save-the-date-les-epv-bougent-dans-le-grand-est/`

## Screenshots
![image](https://github.com/user-attachments/assets/e182adbf-f549-4bb2-b079-ed9bb6d7e58d)
![Capture d’écran 2025-03-18 à 16 39 57](https://github.com/user-attachments/assets/f9ac37c0-8683-46df-97ee-d043ca523f74)

![image](https://github.com/user-attachments/assets/79c2a734-acfa-42ea-8901-4c29598b47c3)

![Capture d’écran 2025-03-18 à 17 36 11](https://github.com/user-attachments/assets/d8753967-8a62-4058-9b0b-3689ad2e3fb8)

![image](https://github.com/user-attachments/assets/5fa437e9-da48-46f4-b2a3-c62cc066881c)

Et all good pour le cas contraire, avec hero = fond : 
![Capture d’écran 2025-03-18 à 18 02 34](https://github.com/user-attachments/assets/97822eeb-b124-499c-9ec3-8f3d8c4f7e1d)
