### PR TITLE
Retirer la pagination d'une taxonomie (osuny)

### DIFF
--- a/layouts/partials/categories/section.html
+++ b/layouts/partials/categories/section.html
@@ -15,6 +15,5 @@
 
   <div class="container">
     {{ partial "categories/section/categories.html" . }}
-    {{ partial "commons/pagination.html" . }}
   </div>
 </div>

--- a/layouts/partials/categories/section/categories.html
+++ b/layouts/partials/categories/section/categories.html
@@ -1,7 +1,11 @@
 {{ $options := site.Params.categories.index.options }}
 {{ $layout := site.Params.categories.index.layout }}
 {{ $layout_partial := printf "categories/partials/layouts/%s/%s.html" $layout $layout }}
-{{ $categories := .Params.children }}
+{{ $categories := partial "GetPathSliceFromObjects" .Pages }}
+
+{{ if eq .Kind "term" }}
+  {{ $categories = .Params.children }}
+{{ end }}
 
 {{ partial $layout_partial (dict
     "categories" $categories

--- a/layouts/partials/categories/section/categories.html
+++ b/layouts/partials/categories/section/categories.html
@@ -1,11 +1,7 @@
 {{ $options := site.Params.categories.index.options }}
 {{ $layout := site.Params.categories.index.layout }}
 {{ $layout_partial := printf "categories/partials/layouts/%s/%s.html" $layout $layout }}
-{{ $categories := partial "GetPathSliceFromObjects" .Paginator.Pages }}
-
-{{ if eq .Kind "term" }}
-  {{ $categories = .Params.children }}
-{{ end }}
+{{ $categories := .Params.children }}
 
 {{ partial $layout_partial (dict
     "categories" $categories


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Il ne faut pas afficher la pagination des articles dans une page de taxonomie.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


