### PR TITLE
Événements : utiliser le `time_slot` dans l'item 

### DIFF
--- a/assets/sass/_theme/sections/events/single.sass
+++ b/assets/sass/_theme/sections/events/single.sass
@@ -197,6 +197,7 @@
             .event-time-slot
                 .hours
                     width: columns(2)
+                    white-space: nowrap
             .event-summary + ul
                 .dropdown-calendar
                     button

--- a/layouts/partials/commons/item/schedule.html
+++ b/layouts/partials/commons/item/schedule.html
@@ -1,11 +1,12 @@
 {{ $dates := .dates }}
+{{ $time_slot := .time_slot }}
 {{ $on_two_lines := .on_two_lines }}
 {{ $type := .type }}
 {{ $date_format := index site.Params $type "date_format" }}
 {{ $time_format := index site.Params $type "time_format" }}
 
-{{ if or $dates.computed.short $dates.computed.two_lines.short $dates.from.hour $dates.to.hour }}
-  <div class="{{ $type }}-schedule" itemprop="startDate" content="{{- if $dates.from.day -}}{{ $dates.from.day }}{{- end -}}{{- if $dates.from.hour -}}T{{ $dates.from.hour }}{{- end -}}">
+{{ if or $dates.computed.short $dates.computed.two_lines.short $time_slot }}
+  <div class="{{ $type }}-schedule">
     <p class="{{ $type }}-dates">
       {{ $formated_date := $dates.computed.short }}
       {{ if $on_two_lines }}
@@ -19,17 +20,17 @@
       {{ end }}
       {{ partial "PrepareHTML" $formated_date }}
     </p>
-    {{- if (or $dates.from.hour $dates.to.hour) }}
+    {{- if $time_slot }}
       {{- $hour := "" -}}
       <p class="{{ $type }}-time">
-        {{ with $dates.from.hour }}
+        {{ with $time_slot.start.time }}
           {{- $hour = . -}}
           {{- with $time_format }}
             {{- $hour = time.Format . (printf "2021-09-01T%s:00" $hour) -}}
           {{ end -}}
           <span>{{- $hour -}}</span>
         {{- end -}}
-        {{- with $dates.to.hour -}}
+        {{- with $time_slot.end.time -}}
           {{- $hour = . -}}
           {{- with $time_format -}}
             {{- $hour = time.Format . (printf "2021-09-01T%s:00" $hour) -}}

--- a/layouts/partials/events/partials/event.html
+++ b/layouts/partials/events/partials/event.html
@@ -30,6 +30,14 @@
       {{ if $is_sub_event }} itemprop="subEvent" {{ end }}
       {{ if $is_sup_event }} itemprop="superEvent" {{ end }}
       itemscope itemtype="https://schema.org/Event">
+
+    {{ if or .Params.dates .Params.current_time_slot }}
+      {{ partial "events/partials/event/meta-dates.html" (dict
+          "dates" .Params.dates 
+          "time_slot" .Params.current_time_slot
+        )}}
+    {{ end }}
+
     <div class="event-content">
       {{- $title := partial "PrepareHTML" .Title -}}
       {{ if and $options.subtitle .Params.subtitle }}
@@ -55,11 +63,6 @@
             "time_slot" .Params.current_time_slot
             "on_two_lines" (ne $layout "list")
           )}}
-      {{ else }}
-        {{ with .Params.dates }}
-          <meta itemprop="startDate" content="{{- if .from.day -}}{{ .from.day }}{{- end -}}{{- if .from.hour -}}T{{ .from.hour }}{{- end -}}">
-          <meta itemprop="endDate" content="{{- if .to.day -}}{{ .to.day }}{{- end -}}{{- if .to.hour -}}T{{ .to.hour }}{{- end -}}">
-        {{ end }}
       {{ end }}
 
       {{ if and $dates.status $options.status }}

--- a/layouts/partials/events/partials/event.html
+++ b/layouts/partials/events/partials/event.html
@@ -52,6 +52,7 @@
       {{ if $options.dates }}
         {{ partial "events/partials/event/schedule.html" (dict 
             "dates" .Params.dates
+            "time_slot" .Params.current_time_slot
             "on_two_lines" (ne $layout "list")
           )}}
       {{ else }}

--- a/layouts/partials/events/partials/event/meta-dates.html
+++ b/layouts/partials/events/partials/event/meta-dates.html
@@ -1,0 +1,24 @@
+{{ $start_time := "" }}
+{{ $end_time := "" }}
+
+{{- with .dates.from.day -}}
+  {{ $start_time = . }}
+{{- end -}}
+{{- with .time_slot -}}
+  {{ $start_time = printf "%sT%s" $start_time .start.time }}
+{{- end -}}
+
+{{- with .dates.to.day -}}
+  {{ $end_time = . }}
+{{- end -}}
+{{- with .time_slot -}}
+  {{ $end_time = printf "%sT%s" $end_time .end.time }}
+{{- end -}}
+
+{{- with $start_time }}
+  <meta itemprop="startDate" content="{{ . }}">
+{{ end -}}
+
+{{- with $end_time }}
+  <meta itemprop="endDate" content="{{ . }}">
+{{ end -}}

--- a/layouts/partials/events/partials/event/schedule.html
+++ b/layouts/partials/events/partials/event/schedule.html
@@ -1,5 +1,6 @@
 {{ partial "commons/item/schedule.html" (dict
     "dates" .dates
+    "time_slot" .time_slot
     "layout" .layout
     "type" "event"
   ) }}

--- a/layouts/partials/events/single.html
+++ b/layouts/partials/events/single.html
@@ -5,6 +5,10 @@
   <div class="document-content">
     <meta itemprop="name" content="{{ partial "PrepareHTML" .Title }}">
     <meta itemprop="url" content="{{ .Permalink }}">
+    {{ partial "events/partials/event/meta-dates.html" (dict
+        "dates" .Params.dates 
+        "time_slot" .Params.current_time_slot
+      )}}
     {{ with .Params.summary }}<meta itemprop="description" content="{{ . | safeHTML }}">{{ end }}
 
     {{ partial "events/single/sidebar.html" . }}

--- a/layouts/partials/events/single/event-infos.html
+++ b/layouts/partials/events/single/event-infos.html
@@ -1,10 +1,10 @@
 {{ $unique_day := eq .Params.dates.from.day .Params.dates.to.day }}
 <ul class="event-infos">
-  {{ if .Params.dates }}
-    {{ if .Params.dates.computed }}
+  {{ with .Params.dates }}
+    {{ with .computed }}
       <li class="event-date">
         <span>{{ i18n "commons.date.one" }}</span>
-        {{ partial "PrepareHTML" .computed.two_lines.long }}
+        {{ partial "PrepareHTML" .two_lines.long }}
       </li>
     {{ end }}
   {{ end }}

--- a/layouts/partials/events/single/event-infos.html
+++ b/layouts/partials/events/single/event-infos.html
@@ -1,19 +1,21 @@
 {{ $unique_day := eq .Params.dates.from.day .Params.dates.to.day }}
 <ul class="event-infos">
-  {{ with .Params.dates }}
-    {{ if .computed }}
-      <li class="event-date" itemprop="startDate" content="{{- if .from.day -}}{{ .from.day }}{{- end -}}{{- if .from.hour -}}T{{ .from.hour }}{{- end -}}">
+  {{ if .Params.dates }}
+    {{ if .Params.dates.computed }}
+      <li class="event-date">
         <span>{{ i18n "commons.date.one" }}</span>
         {{ partial "PrepareHTML" .computed.two_lines.long }}
       </li>
     {{ end }}
-    {{ if .from.hour }}
+  {{ end }}
+  {{ with .Params.current_time_slot }}
+    {{ if .start.time }}
       <li>
         <span>{{ i18n "commons.hour" }}</span>
-        {{ with .from.hour }}
+        {{ with .start.time }}
           <time datetime="{{ . }}">{{ . }}</time>
         {{ end }}
-        {{ with .to.hour }}
+        {{ with .end.time }}
           <time datetime="{{ . }}">{{ . }}</time>
         {{ end }}
       </li>

--- a/layouts/partials/exhibitions/single/exhibition-infos.html
+++ b/layouts/partials/exhibitions/single/exhibition-infos.html
@@ -2,20 +2,9 @@
 <ul class="exhibition-infos">
   {{ with .Params.dates }}
     {{ if .computed }}
-      <li class="exhibition-date" itemprop="startDate" content="{{- if .from.day -}}{{ .from.day }}{{- end -}}{{- if .from.hour -}}T{{ .from.hour }}{{- end -}}">
+      <li class="exhibition-date">
         <span>{{ i18n "exhibitions.date" }}</span>
         {{ partial "PrepareHTML" .computed.two_lines.long }}
-      </li>
-    {{ end }}
-    {{ if .from.hour }}
-      <li>
-        <span>{{ i18n "exhibitions.hour" }}</span>
-        {{ with .from.hour }}
-          <time datetime="{{ . }}">{{ . }}</time>
-        {{ end }}
-        {{ with .to.hour }}
-          <time datetime="{{ . }}">{{ . }}</time>
-        {{ end }}
       </li>
     {{ end }}
   {{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Les blocs d'événement utilisent une donnée du static obsolète : 

Données obsolètes :
```
dates:
  from:
    hour: "16:45"
  to:
    hour: "19:00"

```

Il faut s'appuyer sur la clé `current_time_slot` du static de l'événement.


## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱

