### PR TITLE
Afficher les taxonomies sur la section des formations

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -331,6 +331,7 @@ params:
         image: false
         logo: false
         summary: false
+      taxonomies: false
       truncate_description: 200 # Set to 0 to disable truncate
     single:
       options:

--- a/layouts/partials/programs/section.html
+++ b/layouts/partials/programs/section.html
@@ -12,6 +12,7 @@
     ) }}
   {{ partial "contents/list.html" . }}
   <div class="container">
+    {{ partial "taxonomies/section-list.html" . }}
     {{ partial "diplomas/section/diplomas-select.html" . }}
     {{/* Toutes les formations... */}}
     {{ $programs := where .Site.Pages "Section" "programs" }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout des taxonomies sur l'index des formations. Option désactivée par défaut.

```
params:
  programs:
    index:
      taxonomies: true
```

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


