### PR TITLE
Agenda : correction du dropdown en dark mode

### DIFF
--- a/assets/sass/_theme/sections/events/single.sass
+++ b/assets/sass/_theme/sections/events/single.sass
@@ -186,7 +186,7 @@
                     @include meta
                     width: columns(12)
                 .dropdown-calendar
-                    background: $color-background-alt
+                    background: var(--color-background-alt)
                     border-radius: var(--btn-border-radius)
                     padding: space(2) space(3)
                     width: auto


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

La couleur appliquée au dropdown s'appuyait sur la variable sass et non pas la variable CSS.


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


## Screenshots

Avant : 

![image](https://github.com/user-attachments/assets/57b1403e-bd2a-415f-8fff-1e6f2189c371)


Après : 

![image](https://github.com/user-attachments/assets/09f34f0c-e6bc-4952-9441-1f55b77267d8)
