### PR TITLE
Correction de la taille de l'image des events en mobile

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -492,7 +492,7 @@ params:
           desktop:  1019
       events:
         grid:
-          mobile:   90
+          mobile:   400
           tablet:   360
           desktop:  690
         large:
@@ -513,7 +513,7 @@ params:
           desktop:  645
       exhibitions:
         grid:
-          mobile:   90
+          mobile:   400
           tablet:   360
           desktop:  555
         large:


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

La taille mobile de l'image pour les blocs événement et expo en mode grille était trop petite.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
