### PR TITLE
Agenda : affichage de la date d'un événement simple

### DIFF
--- a/assets/sass/_theme/design-system/taxonomies.sass
+++ b/assets/sass/_theme/design-system/taxonomies.sass
@@ -57,10 +57,6 @@
         display: block
     .taxonomy-title
         @include meta
-    .hero &, &
-        &.without-label
-            display: flex
-            gap: $spacing-2
     .hero &
         margin-top: $spacing-4
         display: block
@@ -78,7 +74,18 @@
                     gap: $spacing-1
             @include media-breakpoint-up(lg)
                 width: columns(4)
-
+    @include media-breakpoint-down(desktop)
+        .hero &, &
+            &.without-label
+                li, a
+                    display: inline
+                li
+                    padding-right: $spacing-1
+    @include media-breakpoint-up(desktop)
+        .hero &, &
+            &.without-label
+                display: flex
+                gap: $spacing-2
 // For index pages
 .taxonomy-categories--grid
     @include list-reset

--- a/assets/sass/_theme/sections/events/single.sass
+++ b/assets/sass/_theme/sections/events/single.sass
@@ -133,7 +133,7 @@
                     --btn-hover-background: var(--color-border)
                     margin-top: $spacing-3
             @include media-breakpoint-up(desktop)
-                &.parent-event
+                &.parent-event, &.simple-event
                     display: flex
                     align-items: baseline
                     gap: var(--grid-gutter)

--- a/assets/sass/_theme/sections/events/single.sass
+++ b/assets/sass/_theme/sections/events/single.sass
@@ -139,6 +139,11 @@
                     gap: var(--grid-gutter)
                     .event-summary
                         flex: 1
+            @include media-breakpoint-down(desktop)
+                .event-summary
+                    flex-direction: column
+                    .date
+                        width: 100%
         .event-summary,
         .event-time-slot
             align-items: baseline

--- a/layouts/partials/commons/agenda/access.html
+++ b/layouts/partials/commons/agenda/access.html
@@ -1,4 +1,4 @@
-{{ if or .Params.text .Params.notes .Params.header_cta.display .Params.time_slots .Params.children }}
+{{ if or .Params.text .Params.notes .Params.header_cta.display .Params.time_slots .Params.children .Params.dates }}
   <div class="container event-access">
     {{ if or .Params.text .Params.notes .Params.header_cta.display }}
       {{ partial "commons/agenda/practicals.html" . }}

--- a/layouts/partials/commons/agenda/access.html
+++ b/layouts/partials/commons/agenda/access.html
@@ -3,7 +3,7 @@
     {{ if or .Params.text .Params.notes .Params.header_cta.display }}
       {{ partial "commons/agenda/practicals.html" . }}
     {{ end }}
-    {{ if or .Params.time_slots .Params.children }}
+    {{ if or .Params.time_slots .Params.children .Params.dates }}
       {{ partial "commons/agenda/dates.html" . }}
     {{ end }}
   </div>

--- a/layouts/partials/commons/agenda/dates.html
+++ b/layouts/partials/commons/agenda/dates.html
@@ -1,7 +1,7 @@
 {{ $is_repeating := gt .Params.time_slots 1 }}
 {{ $multiple_dates_event := ne .Params.dates.from.day .Params.dates.to.day }}
-{{ $is_parent := .Params.children}}
-{{ $has_primary_date := or $is_repeating $multiple_dates_event $is_parent }}
+{{ $is_parent := .Params.children }}
+{{ $has_primary_date := or $is_repeating $multiple_dates_event $is_parent .Params.dates }}
 
 <div class="event-slots {{- if $is_parent }} parent-event{{ end }}">
   <h2 class="events-slots-title">{{ i18n "commons.date" (cond $has_primary_date 2 1) }}</h2>

--- a/layouts/partials/commons/agenda/dates.html
+++ b/layouts/partials/commons/agenda/dates.html
@@ -1,7 +1,8 @@
 {{ $is_repeating := gt .Params.time_slots 1 }}
 {{ $multiple_dates_event := ne .Params.dates.from.day .Params.dates.to.day }}
 {{ $is_parent := .Params.children }}
-{{ $has_primary_date := or $is_repeating $multiple_dates_event $is_parent .Params.dates }}
+{{ $is_simple_event := and .Params.dates (not .Params.time_slots) }}
+{{ $has_primary_date := or $is_repeating $multiple_dates_event $is_parent $is_simple_event }}
 
 <div class="event-slots {{- if $is_parent }} parent-event{{ end }}">
   <h2 class="events-slots-title">{{ i18n "commons.date" (cond $has_primary_date 2 1) }}</h2>

--- a/layouts/partials/commons/agenda/dates.html
+++ b/layouts/partials/commons/agenda/dates.html
@@ -4,7 +4,7 @@
 {{ $is_simple_event := and .Params.dates (not .Params.time_slots) }}
 {{ $has_primary_date := or $is_repeating $multiple_dates_event $is_parent $is_simple_event }}
 
-<div class="event-slots {{- if $is_parent }} parent-event{{ end }}">
+<div class="event-slots {{- if $is_parent }} parent-event {{ end }} {{ if $is_simple_event }} simple-event {{ end }}">
   <h2 class="events-slots-title">{{ i18n "commons.date" (cond $has_primary_date 2 1) }}</h2>
   {{ if $has_primary_date }}
     <div class="event-summary">


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

- Afficher la date d'un événement simple qui n'a pas de time_slot
- Ajustement de l'affichage de la date principale en mobile
- Ajustement des catégories dans le hero en mobile


## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱


