### PR TITLE
Mixin sass : `top-flex`

### DIFF
--- a/assets/sass/_theme/blocks/contact.sass
+++ b/assets/sass/_theme/blocks/contact.sass
@@ -1,6 +1,5 @@
 .block-contact
     .top
-        @include top-flex
         margin-bottom: 0
         + .contact-content
             margin-top: $spacing-4
@@ -98,6 +97,7 @@
             row-gap: space()
     @include in-page-without-sidebar
         .top
+            @include top-flex
             margin-bottom: $spacing-4
         .contact-content
             .contacts

--- a/assets/sass/_theme/blocks/files.sass
+++ b/assets/sass/_theme/blocks/files.sass
@@ -1,6 +1,4 @@
 .block-files
-    .top
-        @include top-flex
     .files
         @include list-reset
         li
@@ -29,5 +27,7 @@
             @include grid(2, desktop, $spacing-3)
 
     @include in-page-without-sidebar
+        .top
+            @include top-flex
         .files
             @include grid(3, desktop, $spacing-3)

--- a/assets/sass/_theme/blocks/pages.sass
+++ b/assets/sass/_theme/blocks/pages.sass
@@ -16,6 +16,7 @@
 
     @include in-page-without-sidebar
         .top
+            @include top-flex
             a
                 @include icon(arrow-right-line, after, true)
                 @include hover-translate-icon
@@ -23,8 +24,6 @@
                 @include h2
 
     &--grid
-        .top
-            @include top-flex
         .grid
             .page-title a
                 @include icon(arrow-right-line, after, true)
@@ -38,8 +37,6 @@
             margin-top: 0
         .blocks &:last-of-type
             margin-bottom: 0
-        .top
-            @include top-flex
         .cards
             @include grid(2, desktop)
             @include in-page-without-sidebar
@@ -140,7 +137,6 @@
                     width: columns(6)
 
         @include in-page-without-sidebar
-            .block-title
             .top
                 .description
                     p
@@ -191,8 +187,6 @@
                         grid-column: 7 / 13
 
     &--alternate
-        .top
-            @include top-flex
         .alternate
             @include alternate
             article 
@@ -217,8 +211,6 @@
                     @include body-text
 
     &--large
-        .top
-            @include top-flex
         .page
             position: relative
             + .page

--- a/assets/sass/_theme/utils/shame.sass
+++ b/assets/sass/_theme/utils/shame.sass
@@ -56,16 +56,15 @@
 
 
 @mixin top-flex
-    @include in-page-without-sidebar
-        align-items: baseline
-        display: flex
-        .block-title
-            width: columns(4)
-            + .description
-                margin-left: var(--grid-gutter)
-        .description
-            margin-top: 0
-            width: columns(8)
+    align-items: baseline
+    display: flex
+    .block-title
+        width: columns(4)
+        + .description
+            margin-left: var(--grid-gutter)
+    .description
+        margin-top: 0
+        width: columns(8)
 
 @mixin collapsed-figcaption
     // TODO: remove hero specifics variables


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Retirer la condition de breakpoint du mixin `top-flex` afin de pouvoir l'utiliser sur une page spécifique.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


