### PR TITLE
Ajout de l'horaire de fin des événements dans l'agenda

### DIFF
--- a/assets/sass/_theme/sections/events/item.sass
+++ b/assets/sass/_theme/sections/events/item.sass
@@ -33,9 +33,14 @@
                 @include icon(arrow-right-line, before)
                     margin-left: space()
                     margin-right: space()
+    &-hours
+        time + time
+            @include icon(arrow-right-line, before)
+                margin-left: space()
+                margin-right: space()
     .media
         &:empty
             display: none
     @include media-breakpoint-up(desktop)
-        &-time
+        &-time, &-hours
             display: flex

--- a/layouts/partials/events/partials/event/hours.html
+++ b/layouts/partials/events/partials/event/hours.html
@@ -1,3 +1,12 @@
-{{ with .start }}
-  <p class="event-hours"><span>{{ .time }}</span></p>
+{{ if .start }}
+  <p class="event-hours">
+    <span>
+      {{ if .start.datetime }}
+        <time datetime="{{ .start.time }}">{{ .start.datetime | time.Format site.Params.events.single.time_slots.time_format }}</time>
+      {{ end }}
+      {{ if .end.datetime }}
+        <time datetime="{{ .end.time }}">{{ .end.datetime | time.Format site.Params.events.single.time_slots.time_format }}</time>
+      {{ end }}
+    </span>
+  </p>
 {{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Il manquait l'heure de fin des événements dans la vue agenda

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


