### PR TITLE
Gestion de la position des taxonomies dans le hero

### DIFF
--- a/assets/sass/_theme/configuration/spacings.sass
+++ b/assets/sass/_theme/configuration/spacings.sass
@@ -1,6 +1,6 @@
 // Breakpoints
 // TODO: réécrire en sass les mixins bootstrap
-$grid-breakpoints: (xs: 0, sm: 576px, md: 768px, desktop: 992px, lg: 992px, xl: 1200px, xxl: 1440px) !default
+$grid-breakpoints: (xs: 0, sm: 576px, md: 768px, desktop: 992px, lg: 992px, xl: 1200px, xxl: 1440px, xxxl: 1920px) !default
 
 // Grid System 
 $grid-gutter: pxToRem(24) !default

--- a/assets/sass/_theme/design-system/taxonomies.sass
+++ b/assets/sass/_theme/design-system/taxonomies.sass
@@ -70,9 +70,9 @@
                     gap: $spacing-1
                     text-align: right
                 @include media-breakpoint-up(xl)
+                    align-items: baseline
                     display: flex
                     justify-content: space-between
-                    align-items: baseline
             @include media-breakpoint-up(lg)
                 width: columns(4)
     @include media-breakpoint-down(desktop)

--- a/assets/sass/_theme/design-system/taxonomies.sass
+++ b/assets/sass/_theme/design-system/taxonomies.sass
@@ -64,14 +64,15 @@
             @include small
         &.with-label
             > li
-                display: flex
-                justify-content: space-between
-                align-items: baseline
                 ul
-                    text-align: right
                     display: flex
                     flex-wrap: wrap
                     gap: $spacing-1
+                    text-align: right
+                @include media-breakpoint-up(xl)
+                    display: flex
+                    justify-content: space-between
+                    align-items: baseline
             @include media-breakpoint-up(lg)
                 width: columns(4)
     @include media-breakpoint-down(desktop)
@@ -88,6 +89,7 @@
                 flex-wrap: wrap
                 column-gap: $spacing-2
                 margin-bottom: $spacing-3
+
 // For index pages
 .taxonomy-categories--grid
     @include list-reset

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -291,7 +291,7 @@ params:
           subtitle: true
           summary: true
       taxonomies:
-        position: hero # content | hero | none
+        position: content # content | hero | none
   posts:
     default_image: false
     date_format: ":date_long"

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -291,7 +291,7 @@ params:
           subtitle: true
           summary: true
       taxonomies:
-        position: content # content | hero | none
+        position: hero # content | hero | none
   posts:
     default_image: false
     date_format: ":date_long"

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -111,6 +111,7 @@ params:
     single:
       taxonomies:
         display: true
+        position: content
   categories:
     index:
       layout: grid # alternate | cards | grid | large | list

--- a/layouts/partials/GetTaxonomiesPosition
+++ b/layouts/partials/GetTaxonomiesPosition
@@ -1,5 +1,5 @@
 {{ $kind := cond (or (eq .Kind "section") (eq .Kind "taxonomy")) "section" "single" }}
-{{ $param := (printf "%s.taxonomies.position" .Type )}}
+{{ $param := (printf "%s.%s.taxonomies.position" .Type $kind )}}
 
 {{ $position := partial "GetSiteParamWithDefault" (dict 
   "param" $param

--- a/layouts/partials/GetTaxonomiesPosition
+++ b/layouts/partials/GetTaxonomiesPosition
@@ -3,7 +3,7 @@
 
 {{ $position := partial "GetSiteParamWithDefault" (dict 
   "param" $param
-  "default" "taxonomies.position"
+  "default" (printf "default.%s.taxonomies.position" $kind)
 ) }}
 
 {{ return $position }}

--- a/layouts/partials/GetTaxonomiesPosition
+++ b/layouts/partials/GetTaxonomiesPosition
@@ -1,5 +1,5 @@
 {{ $kind := cond (or (eq .Kind "section") (eq .Kind "taxonomy")) "section" "single" }}
-{{ $param := (printf "%s.%s.taxonomies.position" .Type $kind )}}
+{{ $param := (printf "%s.taxonomies.position" .Type )}}
 
 {{ $position := partial "GetSiteParamWithDefault" (dict 
   "param" $param

--- a/layouts/partials/GetTaxonomiesPosition
+++ b/layouts/partials/GetTaxonomiesPosition
@@ -1,0 +1,9 @@
+{{ $kind := cond (or (eq .Kind "section") (eq .Kind "taxonomy")) "section" "single" }}
+{{ $param := (printf "%s.%s.taxonomies.position" .Type $kind )}}
+
+{{ $position := partial "GetSiteParamWithDefault" (dict 
+  "param" $param
+  "default" "taxonomies.position"
+) }}
+
+{{ return $position }}

--- a/layouts/partials/events/single/hero.html
+++ b/layouts/partials/events/single/hero.html
@@ -12,11 +12,6 @@
   {{ $sizes = index site.Params.image_sizes.sections.events.hero_single $image_format }}
 {{ end }}
 
-{{- $hero_text_complement := "" -}}
-{{ if .Params.events_categories }}
-  {{ $hero_text_complement = "taxonomies/single-list.html" }}
-{{ end }}
-
 {{- partial "header/hero.html"
   (dict
     "title" $title
@@ -25,5 +20,4 @@
     "context" .
     "share" $share
     "button" false
-    "hero_text_complement" $hero_text_complement
   ) -}}

--- a/layouts/partials/exhibitions/single/hero.html
+++ b/layouts/partials/exhibitions/single/hero.html
@@ -12,11 +12,6 @@
   {{ $sizes = index site.Params.image_sizes.sections.exhibitions.hero_single $image_format }}
 {{ end }}
 
-{{- $hero_text_complement := "" -}}
-{{ if .Params.events_categories }}
-  {{ $hero_text_complement = "taxonomies/single-list.html" }}
-{{ end }}
-
 {{- partial "header/hero.html"
   (dict
     "title" $title
@@ -25,5 +20,4 @@
     "context" .
     "share" $share
     "button" false
-    "hero_text_complement" $hero_text_complement
   ) -}}

--- a/layouts/partials/header/hero.html
+++ b/layouts/partials/header/hero.html
@@ -71,10 +71,6 @@
         {{ partial .hero_content_complement .context }}
       {{ end }}
 
-      {{ if eq site.Params.persons.single.taxonomies.position "hero" }}
-        {{ $hero_text_complement = "taxonomies/single-list.html" }}
-      {{ end }}
-
       {{ if .image }}
         <!-- TODO Peut etre aligner la stucture des données avec les autres cas d'images -->
         {{ partial "commons/image-figure.html" (dict

--- a/layouts/partials/header/hero.html
+++ b/layouts/partials/header/hero.html
@@ -50,6 +50,11 @@
           {{ partial .hero_text_complement .context }}
         {{ end }}
 
+        {{ $taxonomies_position := partial "GetTaxonomiesPosition" .context }}
+        {{ if and .context.Params.taxonomies (eq $taxonomies_position "hero") }}
+          {{ partial "taxonomies/single-list.html" .context }}
+        {{ end }}
+
         {{ if or $button .share }}
           <div class="hero-actions">
             {{ with $button }}
@@ -64,6 +69,10 @@
 
       {{ if .hero_content_complement }}
         {{ partial .hero_content_complement .context }}
+      {{ end }}
+
+      {{ if eq site.Params.persons.single.taxonomies.position "hero" }}
+        {{ $hero_text_complement = "taxonomies/single-list.html" }}
       {{ end }}
 
       {{ if .image }}

--- a/layouts/partials/organizations/single.html
+++ b/layouts/partials/organizations/single.html
@@ -20,11 +20,7 @@
         </div>
       {{ end }}
 
-      {{ if .Params.taxonomies }}
-        <div class="taxonomies-container">
-          {{ partial "taxonomies/single-list.html" . }}
-        </div>
-      {{ end }}
+      {{ partial "taxonomies/single-list-container.html" . }}
 
       {{ partial "commons/contact-details.html" . }}
     </div>

--- a/layouts/partials/persons/single.html
+++ b/layouts/partials/persons/single.html
@@ -71,11 +71,7 @@
       </div>
     {{ end }}
 
-    {{ if and .Params.taxonomies (eq site.Params.persons.single.taxonomies.position "content") }}
-      <div class="taxonomies-container">
-        {{ partial "taxonomies/single-list.html" . }}
-      </div>
-    {{ end }}
+    {{ partial "taxonomies/single-list-container.html" . }}
 
     {{ partial "commons/contact-details.html" . }}
   </div>

--- a/layouts/partials/persons/single/hero.html
+++ b/layouts/partials/persons/single/hero.html
@@ -1,16 +1,10 @@
 {{- $title := or .Params.header_text .Title -}}
 
-{{- $hero_text_complement := "" -}}
-{{ if eq site.Params.persons.single.taxonomies.position "hero" }}
-  {{ $hero_text_complement = "taxonomies/single-list.html" }}
-{{ end }}
-
 {{- partial "header/hero.html"
       (dict
         "title" $title
         "image" .Params.image
         "context" .
         "sizes" site.Params.image_sizes.sections.persons.hero_single
-        "hero_text_complement" $hero_text_complement
       ) -}}
 

--- a/layouts/partials/posts/single/post-infos.html
+++ b/layouts/partials/posts/single/post-infos.html
@@ -1,5 +1,5 @@
 <ul class="post-infos">
-  {{ if .Params.posts_categories }}
+  {{ if ne site.Params.posts.single.taxonomies.position "hero" }}
     <li>
       {{ partial "taxonomies/single-list.html" . }}
     </li>

--- a/layouts/partials/posts/single/post-infos.html
+++ b/layouts/partials/posts/single/post-infos.html
@@ -1,5 +1,6 @@
 <ul class="post-infos">
-  {{ if ne site.Params.posts.single.taxonomies.position "hero" }}
+  {{ $taxonomies_position := partial "GetTaxonomiesPosition" . }}
+  {{ if ne $taxonomies_position "hero" }}
     <li>
       {{ partial "taxonomies/single-list.html" . }}
     </li>

--- a/layouts/partials/projects/single.html
+++ b/layouts/partials/projects/single.html
@@ -7,10 +7,8 @@
 
   {{ partial "projects/single/sidebar.html" . }}
 
-  {{ if and .Params.design.full_width .Params.taxonomies }}
-    <div class="container taxonomies-container">
-      {{ partial "taxonomies/single-list.html" . }}
-    </div>
+  {{ if .Params.design.full_width }}
+    {{ partial "taxonomies/single-list-container.html" . }}
   {{ end }}
 
   {{ partial "projects/single/summary.html" (dict

--- a/layouts/partials/projects/single/project-infos.html
+++ b/layouts/partials/projects/single/project-infos.html
@@ -1,6 +1,6 @@
 
 <ul class="project-infos">
-  {{ if .Params.projects_categories }}
+  {{ if ne site.Params.projects.taxonomies.position "hero" }}
     <li>
       {{ partial "taxonomies/single-list.html" . }}
     </li>

--- a/layouts/partials/projects/single/project-infos.html
+++ b/layouts/partials/projects/single/project-infos.html
@@ -1,6 +1,6 @@
 
 <ul class="project-infos">
-  {{ if ne site.Params.projects.taxonomies.position "hero" }}
+  {{ if ne site.Params.projects.single.taxonomies.position "hero" }}
     <li>
       {{ partial "taxonomies/single-list.html" . }}
     </li>

--- a/layouts/partials/projects/single/project-infos.html
+++ b/layouts/partials/projects/single/project-infos.html
@@ -1,6 +1,7 @@
 
 <ul class="project-infos">
-  {{ if ne site.Params.projects.single.taxonomies.position "hero" }}
+  {{ $taxonomies_position := partial "GetTaxonomiesPosition" . }}
+  {{ if ne $taxonomies_position "hero" }}
     <li>
       {{ partial "taxonomies/single-list.html" . }}
     </li>

--- a/layouts/partials/taxonomies/single-list-container.html
+++ b/layouts/partials/taxonomies/single-list-container.html
@@ -1,0 +1,6 @@
+{{ $taxonomies_position := partial "GetTaxonomiesPosition" . }}
+{{ if and .Params.taxonomies (eq $taxonomies_position "content") }}
+  <div class="taxonomies-container">
+    {{ partial "taxonomies/single-list.html" . }}
+  </div>
+{{ end }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout d'une option pour standardiser le placement de la taxo dans le `hero` ou `content`.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


