### PR TITLE
Bloc image : ajustement des largeurs du contenu

### DIFF
--- a/assets/sass/_theme/blocks/image.sass
+++ b/assets/sass/_theme/blocks/image.sass
@@ -49,7 +49,7 @@
                 picture
                     margin-left: 0
                 figcaption
-                    width: columns(5)
+                    width: columns(4)
                     order: 1
                     text-align: right
         &.image-landscape

--- a/assets/sass/_theme/blocks/image.sass
+++ b/assets/sass/_theme/blocks/image.sass
@@ -36,13 +36,13 @@
                 position: relative
                 .top
                     position: absolute
-                    width: columns(5)
+                    width: columns(4)
             figure
                 display: flex
                 align-items: flex-end
                 justify-content: flex-end
                 > button
-                    width: columns(7)
+                    width: columns(8)
                     margin-left: var(--grid-gutter)
                     display: block
                     order: 2


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Le bloc image diffère des autres (contrairement à la maquette) : 5 colonnes pour le top et 7 pour l'image, ce qui provoque un décalage évident quand on l'ajoute à la suite d'un chapitre.

![Capture d’écran 2025-04-22 à 15 07 10](https://github.com/user-attachments/assets/07c70203-13ff-436c-aa65-1998232ceab7)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`/fr/blocks/blocks-de-base/image/`

## URL de test du site Diapason

`/projets/2024-a-vivre-bilan-de-mandat-annuel/`

## Screenshots

![Capture d’écran 2025-04-22 à 15 06 56](https://github.com/user-attachments/assets/b770a942-f3d6-4d56-a9c5-08292ef43a12)

![Capture d’écran 2025-04-22 à 15 13 56](https://github.com/user-attachments/assets/bb2d4f6c-da09-40ea-b58d-176ac087b390)
