### PR TITLE
Gestion de l'absence de contenu du bouton du hero

### DIFF
--- a/layouts/partials/header/hero.html
+++ b/layouts/partials/header/hero.html
@@ -12,7 +12,9 @@
 {{ $subtitle_is_summary := false }}
 
 {{ $button := .button | default .context.Params.header_cta }}
+{{ $has_button := or $button.display $button.label }}
 {{ $title_attribute := "" | safeHTMLAttr }}
+
 {{ if site.Params.search.active }}
   {{ $title_attribute = "data-pagefind-weight='10'" | safeHTMLAttr }}
 {{ end }}
@@ -50,7 +52,7 @@
           {{ partial .hero_text_complement .context }}
         {{ end }}
 
-        {{ if or $button .share }}
+        {{ if or $has_button .share }}
           <div class="hero-actions">
             {{ with $button }}
               {{ partial "header/cta.html" . }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

La div d'actions du héros est présente en permanence dans les projets, car on ne vérifie pas la présence du contenu du bouton ! J'ai fait un ajout rapidement avec un `has_button` mais ce n'est peut-être pas l'idéal.

![image](https://github.com/user-attachments/assets/c716a326-f28a-4b09-a927-5a9563065a98)


## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test du site Diapason

`http://localhost:1313/projets/2024-brou-soyons-fous/`