### PR TITLE
Affichage du bouton de candidature même sans texte

### DIFF
--- a/layouts/partials/programs/single/admission.html
+++ b/layouts/partials/programs/single/admission.html
@@ -39,7 +39,7 @@
           </section>
         {{- end -}}
 
-        {{- if partial "GetTextFromHTML" .Params.registration -}}
+        {{- if or .Params.registration .Params.registration_url -}}
           <section class="rich-text program-admission-registration" id="{{ anchorize (i18n "programs.registration") }}">
             <h3>{{ i18n "programs.registration" }}</h3>
             {{- partial "PrepareHTML" .Params.registration -}}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Actuellement le bouton de candidature ne s'affiche que quand le texte de modalité est remplie.


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
