### PR TITLE
Posts : ajustement du système de marge en mobile

### DIFF
--- a/assets/sass/_theme/sections/posts.sass
+++ b/assets/sass/_theme/sections/posts.sass
@@ -43,7 +43,11 @@
                         display: block
                 @include media-breakpoint-down(desktop)
                     flex: 1
-                    margin-left: $spacing-2
+            @include media-breakpoint-down(desktop)
+                // TODO: replace grid by flex
+                &:not(.without-image)
+                    .post-content
+                        margin-left: $spacing-2
             .media
                 background: none
                 margin: 0

--- a/assets/sass/_theme/sections/posts.sass
+++ b/assets/sass/_theme/sections/posts.sass
@@ -37,21 +37,18 @@
                 margin-bottom: $spacing-5
                 padding-bottom: $spacing-5
             .post-content
+                // TODO: replace grid by flex
                 grid-column: 4/13
                 .post-meta
                     > *
                         display: block
                 @include media-breakpoint-down(desktop)
                     flex: 1
-            @include media-breakpoint-down(desktop)
-                // TODO: replace grid by flex
-                &:not(.without-image)
-                    .post-content
-                        margin-left: $spacing-2
             .media
                 background: none
                 margin: 0
                 @include media-breakpoint-down(desktop)
+                    margin-right: $spacing-2
                     width: 33.33333%
                 @include media-breakpoint-up(desktop)
                     grid-column: 1/4


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Le fait d'utiliser grid en mobile ajoutait une marge à gauche lorsqu'il n'y avait pas d'image. La solution à long terme est de changer avec du flex/gap, j'ai reporté ici la marge sur l'image.

![Capture d’écran 2025-04-22 à 17 32 58](https://github.com/user-attachments/assets/0c7adfc7-01f9-4814-bbab-1ac8329eb7c4) ![Capture d’écran 2025-04-22 à 17 33 02](https://github.com/user-attachments/assets/3da7fc93-87db-4d4a-85b8-5002bc621ffb)


## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1314/fr/actualites/`

## URL de test du site Diapason

`http://localhost:1313/actualites/`

## Screenshots

![Capture d’écran 2025-04-22 à 17 32 46](https://github.com/user-attachments/assets/48f3b6e2-fe5c-4319-840b-a31ecb7462d5) ![Capture d’écran 2025-04-22 à 17 32 35](https://github.com/user-attachments/assets/9b725663-8ebf-462e-8c6c-856a6fa0a82c)

