### PR TITLE
Block image : gestion du `rich-text` des figcaption

### DIFF
--- a/layouts/partials/commons/image-figure.html
+++ b/layouts/partials/commons/image-figure.html
@@ -38,7 +38,7 @@
       {{ if or .text .credit }}
         <figcaption>
           {{ with .text }}
-            {{ . | safeHTML }}
+            <div>{{ . | safeHTML }}</div>
           {{ end }}
           {{ with .credit }}
             <div class="credit">


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Avec le passage de la plupart des textes descriptifs dans les blocs en `rich-text`, le bloc image (en full-width) ne gérait pas correctement la présence de plusieurs paragraphes :
![Capture d’écran 2025-04-25 à 10 38 32](https://github.com/user-attachments/assets/5b91ab61-77a6-482e-b746-78ab9b9c50b4)
![Capture d’écran 2025-04-25 à 10 42 13](https://github.com/user-attachments/assets/f16a64dc-28ea-4dce-a849-7ca8048ff7c2)
![Capture d’écran 2025-04-25 à 10 42 19](https://github.com/user-attachments/assets/e0d50447-4467-45fc-9f5f-85250f9c974f)

Le `figcaption` a un display: flex pour aligner le crédit à gauche, mais avec la multitude de `p`, il faut ajouter un contenant pour le texte. J'ai donc simplement ajouté une `div` sans class.

Pas d'impact sur les autres appels du `commons/image-figure` (dans le bloc galerie notamment le fonctionnement en mode large se calque bien), ni en mode sidebar.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`blocks/blocks-de-base/image/#image` (en bas de page)
`blocks/blocks-narratifs/galeries/#galerie-large`

## URL de test du site Gaîté Lyrique

`infos-pratiques/le-lieu/`

## Screenshots

**Gaîté :** 
![Capture d’écran 2025-04-25 à 10 53 54](https://github.com/user-attachments/assets/d0c54aac-9238-4afb-ae41-50cab35415fa)

**Example :** 
![Capture d’écran 2025-04-25 à 10 43 25](https://github.com/user-attachments/assets/6e9496b9-5915-4485-af2e-266667acfd5c)
![Capture d’écran 2025-04-25 à 10 43 31](https://github.com/user-attachments/assets/8c372aae-3c72-473b-9f84-6eff4b78dc8d)
![Capture d’écran 2025-04-25 à 10 43 51](https://github.com/user-attachments/assets/1b8d92e7-d5ef-40c9-ad09-5f2a6d621d2a)