### PR TITLE
Bloc pages : ajout d'une option pour la grille (et les cartes ?)

### DIFF
--- a/assets/sass/_theme/configuration/blocks.sass
+++ b/assets/sass/_theme/configuration/blocks.sass
@@ -57,6 +57,8 @@ $block-pages-card-page-background: var(--color-background) !default
 $block-pages-card-page-color: var(--color-text) !default
 $block-pages-card-page-background-hover: var(--color-accent) !default
 $block-pages-card-page-color-hover: var(--color-background) !default
+$block-pages-grid-columns: 3 !default
+$block-pages-card-columns: 3 !default
 
 // Block posts
 $block-posts-grid-columns: 3 !default

--- a/assets/sass/_theme/sections/pages.sass
+++ b/assets/sass/_theme/sections/pages.sass
@@ -52,8 +52,11 @@
                 margin-top: $spacing-3
     .grid, .cards
         @include grid(2, desktop)
-        @include in-page-without-sidebar
-            @include grid(3)
+    @include in-page-without-sidebar
+        .grid
+            @include grid($block-pages-grid-columns)
+        .cards
+            @include grid($block-pages-card-columns)
 
 .pages
     .page


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Pour la gaîté, on doit afficher les pages sur une grille de 2 éléments au lieu de 2.
C'est un cas que l'on a déjà eu, notamment pour cids/mids si ma mémoire est bonne.

Comme on avait cette option en configuration pour le bloc posts, je l'ai décliné dans les pages pour les grilles, et pourquoi pas pour les cartes (plus de doutes sur ce layout-ci).

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`/blocks/blocs-de-liste/pages/`

## URL de test du site Gaîté lyrique

`/privatisation/`

## Screenshots

![image](https://github.com/user-attachments/assets/dfd1b5b0-2a13-4441-9eaa-49eb0c73434b)