### PR TITLE
Affichage des catégories enfants dans une catégorie

### DIFF
--- a/assets/sass/_theme/sections/categories.sass
+++ b/assets/sass/_theme/sections/categories.sass
@@ -6,6 +6,14 @@ body:where([class*="_categories__term"])
     .project-categories
         --block-space-y: #{$block-space-y}
         margin-bottom: var(--block-space-y)
+    > .category-children
+        margin-bottom: var(--block-space-y)
+        ul
+            @include list-reset
+            display: flex
+            gap: var(--grid-gutter)
+        .posts_category-title
+            @include meta
 
 .category-item
     .articles-count

--- a/assets/sass/_theme/sections/categories.sass
+++ b/assets/sass/_theme/sections/categories.sass
@@ -20,6 +20,20 @@ body:where([class*="_categories__term"])
         @include meta
         color: var(--color-text-alt)
 
+.children-categories-list
+    margin-bottom: var(--grid-gutter)
+    margin-top: var(--grid-gutter)
+    .dropdown
+        @include dropdown(".children-categories")
+    .children-categories
+        ul
+            @include list-reset
+    @include media-breakpoint-up(md)
+        gap: $spacing-3
+        .children-categories
+            min-width: max-content
+            margin-left: -$spacing-1
+
 .categories
     .media:empty
         display: none // Is this generic ?

--- a/assets/sass/_theme/sections/categories.sass
+++ b/assets/sass/_theme/sections/categories.sass
@@ -20,19 +20,17 @@ body:where([class*="_categories__term"])
         @include meta
         color: var(--color-text-alt)
 
-.children-categories-list
-    margin-bottom: var(--grid-gutter)
-    margin-top: var(--grid-gutter)
-    .dropdown
-        @include dropdown(".children-categories")
-    .children-categories
-        ul
-            @include list-reset
-    @include media-breakpoint-up(md)
-        gap: $spacing-3
-        .children-categories
-            min-width: max-content
-            margin-left: -$spacing-1
+.children-categories
+    ul
+        @include list-reset
+        @include meta
+        align-items: baseline
+        display: flex
+        flex-wrap: wrap
+        column-gap: $spacing-3
+        row-gap: $spacing-2
+        margin-bottom: var(--grid-gutter)
+        margin-top: var(--grid-gutter)
 
 .categories
     .media:empty

--- a/layouts/partials/categories/single.html
+++ b/layouts/partials/categories/single.html
@@ -13,6 +13,21 @@
 
   {{ partial "contents/list.html" . }}
 
+  {{ if .Params.children}}
+    <div class="container category-children">
+      <ul>
+        {{ range .Params.children }}
+          <li>
+            {{ partial "categories/partials/category" (dict 
+                  "category" .
+                  "options" (dict "summary" false)
+                ) }}
+          </li>
+        {{ end }}
+      </ul>
+    </div>
+  {{ end }}
+
   <div class="container">
     {{ $section_type := strings.TrimSuffix "_categories" .Type }}
     {{ $list_partial := printf "%s/partials/%s.html" $section_type $section_type }}

--- a/layouts/partials/categories/single.html
+++ b/layouts/partials/categories/single.html
@@ -13,19 +13,8 @@
 
   {{ partial "contents/list.html" . }}
 
-  {{ if .Params.children}}
-    <div class="container category-children">
-      <ul>
-        {{ range .Params.children }}
-          <li>
-            {{ partial "categories/partials/category" (dict 
-                  "category" .
-                  "options" (dict "summary" false)
-                ) }}
-          </li>
-        {{ end }}
-      </ul>
-    </div>
+  {{ with .Params.children }}
+    {{ partial "categories/single/categories.html" . }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/categories/single/categories.html
+++ b/layouts/partials/categories/single/categories.html
@@ -1,0 +1,21 @@
+{{ $categories := . }}
+<div class="container children-categories-list">
+  <div class="dropdown">
+    <button aria-controls="categories-{{ i18n "categories.label" }}" aria-expanded="false">
+      {{ i18n "categories.label" }}
+    </button>
+    <div class="extendable children-categories" id="categories-{{ i18n "categories.label" }}" data-extendable-close-siblings="true" data-extendable-auto-close="true">
+      <ul>
+        {{ range $categories }}
+          {{ $category := site.GetPage .path }}
+          {{ with $category }}
+            <li>
+              <a href="{{ .Permalink }}">{{ .Title }}</a>
+            </li>
+          {{ end }}
+        {{ end }}
+        </ul>
+      </div>
+    </div>
+    </ul>
+  </div>

--- a/layouts/partials/categories/single/categories.html
+++ b/layouts/partials/categories/single/categories.html
@@ -1,21 +1,13 @@
 {{ $categories := . }}
-<div class="container children-categories-list">
-  <div class="dropdown">
-    <button aria-controls="categories-{{ i18n "categories.label" }}" aria-expanded="false">
-      {{ i18n "categories.label" }}
-    </button>
-    <div class="extendable children-categories" id="categories-{{ i18n "categories.label" }}" data-extendable-close-siblings="true" data-extendable-auto-close="true">
-      <ul>
-        {{ range $categories }}
-          {{ $category := site.GetPage .path }}
-          {{ with $category }}
-            <li>
-              <a href="{{ .Permalink }}">{{ .Title }}</a>
-            </li>
-          {{ end }}
-        {{ end }}
-        </ul>
-      </div>
-    </div>
+<div class="container children-categories">
+  <ul aria-label="{{ i18n "categories.label" }}">
+    {{ range $categories }}
+      {{ $category := site.GetPage .path }}
+      {{ with $category }}
+        <li>
+          <a href="{{ .Permalink }}">{{ .Title }}</a>
+        </li>
+      {{ end }}
+    {{ end }}
     </ul>
   </div>


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

**Gaîté**

Utilisation du partiel `category` au plus bas niveau pour afficher les enfants d'une catégories avant les items (posts, events, etc).

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site Gaîté Lyrique

`actualites/fabrique-de-lepoque/devenez-acteurice-de-l-epoque/`

## Screenshots
<img width="1468" alt="image" src="https://github.com/user-attachments/assets/b698af06-d064-47ae-9bf7-a5fe810d1660" />
 
Mobile : 

![image](https://github.com/user-attachments/assets/92282f00-8934-407e-b6ac-57951d97564e) ![image](https://github.com/user-attachments/assets/a7cc5161-812e-470c-8ff2-209da78e4ad7)