### PR TITLE
Ajout d'un hook au début du hero

### DIFF
--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -191,8 +191,8 @@ commons:
     social: Menu réseaux sociaux
     title: Menu
     upper: Menu d'accès rapide
-  more: En savoir plus
-  more_aria: En savoir plus sur “{{ .Title }}“
+  more: Découvrir
+  more_aria: Découvrir “{{ .Title }}“
   pagination:
     first: Première page
     label: Pagination

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -191,8 +191,8 @@ commons:
     social: Menu réseaux sociaux
     title: Menu
     upper: Menu d'accès rapide
-  more: Découvrir
-  more_aria: Découvrir “{{ .Title }}“
+  more: En savoir plus
+  more_aria: En savoir plus sur “{{ .Title }}“
   pagination:
     first: Première page
     label: Pagination

--- a/layouts/partials/header/hero.html
+++ b/layouts/partials/header/hero.html
@@ -30,7 +30,9 @@
 {{ $breadcrumb_class := printf "has-breadcrumb-%s" site.Params.breadcrumb.position }}
 
 <header class="hero {{ if .image }}hero--with-image hero--image-{{- $direction }}{{ end }} {{ if $breadcrumb_is_after_hero }} hero--no-margin {{ end }} {{ $breadcrumb_class }} ">
+
   {{- partial "hooks/after-hero-start" . -}}
+
   <div class="container">
     {{ if and $display_breadcrumb (eq site.Params.breadcrumb.position "hero-start") }}
       {{ partial "header/breadcrumbs.html" .context }}

--- a/layouts/partials/header/hero.html
+++ b/layouts/partials/header/hero.html
@@ -30,6 +30,7 @@
 {{ $breadcrumb_class := printf "has-breadcrumb-%s" site.Params.breadcrumb.position }}
 
 <header class="hero {{ if .image }}hero--with-image hero--image-{{- $direction }}{{ end }} {{ if $breadcrumb_is_after_hero }} hero--no-margin {{ end }} {{ $breadcrumb_class }} ">
+  {{- partial "hooks/after-hero-start" . -}}
   <div class="container">
     {{ if and $display_breadcrumb (eq site.Params.breadcrumb.position "hero-start") }}
       {{ partial "header/breadcrumbs.html" .context }}


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout d'un hook au début du hero pour pouvoir bénéficier de la marge qui distancie le hero du haut de page (et donc de la nav horizontale), pour Gaîté.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site Gaîté Lyrique

Accueil

## Screenshots

<img width="1469" alt="Capture d’écran 2025-05-05 à 11 55 20" src="https://github.com/user-attachments/assets/dde2672e-04ad-4375-96e8-668358327b8d" />