### PR TITLE
Option de ratio d'image pour les `item` des Pages

### DIFF
--- a/assets/sass/_theme/configuration/sections.sass
+++ b/assets/sass/_theme/configuration/sections.sass
@@ -1,6 +1,9 @@
 // Sections
 $article-media-aspect-ratio: 2 !default
 
+// Pages
+$page-media-aspect-ratio: 16 / 9 !default
+
 $post-time-color: var(--color-text-alt) !default
 // Si layout posts grid (ne concerne pas les blocks posts)
 $posts-grid-columns: $block-posts-grid-columns !default

--- a/assets/sass/_theme/sections/pages.sass
+++ b/assets/sass/_theme/sections/pages.sass
@@ -45,7 +45,7 @@
                 &:empty
                     display: none
                 img
-                    aspect-ratio: 16/9
+                    aspect-ratio: $page-media-aspect-ratio
                     object-fit: cover
                     width: 100%
             @include media-breakpoint-down(desktop)


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout d'une variable sass : 
```
$page-media-aspect-ratio: 16 / 9
```

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

