### PR TITLE
Ajustement du formatage de la date d'un timeslot dans un événement

### DIFF
--- a/layouts/partials/commons/agenda/dates.html
+++ b/layouts/partials/commons/agenda/dates.html
@@ -25,7 +25,8 @@
     <ul id="all-dates" class="extendable-list">
       {{ range $index, $time_slot := . }}
         <li class="event-time-slot" itemprop="subEvent">
-          <span class="date" itemprop="startDate" content="{{ .start.datetime }}">{{ $time_slot.start.date | time.Format site.Params.events.single.time_slots.date_format }}</span>
+          {{ $event_date := $time_slot.start.date | time.Format site.Params.events.single.time_slots.date_format }}
+          <span class="date" itemprop="startDate" content="{{ .start.datetime }}">{{ $event_date | strings.FirstUpper }}</span>
           <p class="hours">
             {{ if $time_slot.start.datetime }}
               <time datetime="{{ .start.time }}">{{ $time_slot.start.datetime | time.Format site.Params.events.single.time_slots.time_format }}</time>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

En changeant le format de la date (normalement sans jour), on obtient une phrase sans majuscule, on peut utiliser la fonction `strings.FirstUpper` de Hugo pour palier ce problème.

![image](https://github.com/user-attachments/assets/89daa392-0127-41fd-a2e0-ab3a4dcbf2aa)

La config à ajouter pour tester : 
```yml
  events:
    single:
      time_slots:
        date_format: ":date_full"
```

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`/agenda/2024/anne-charlotte-finel-respiro/`

## URL de test du site Gaîté Lyrique

`/agenda/2025/art-food/`

## Screenshots

![image](https://github.com/user-attachments/assets/6647ff93-54b3-43b7-9227-f23482779dc4)