### PR TITLE
Bloc fichiers : ajout de l'image d'aperçu

### DIFF
--- a/assets/sass/_theme/blocks/files.sass
+++ b/assets/sass/_theme/blocks/files.sass
@@ -6,6 +6,16 @@
             align-items: start
             display: flex
             position: relative
+            flex-wrap: wrap
+            &.with-image
+                figure
+                    flex: 1
+                picture
+                    margin-bottom: $spacing-2
+                    order: -1
+                    width: 100%
+                    img
+                        width: columns(2)
         a
             @include stretched-link(before)
             @include small

--- a/layouts/partials/blocks/templates/files.html
+++ b/layouts/partials/blocks/templates/files.html
@@ -11,12 +11,6 @@
             {{ if ne .id "" }}
               {{ if partial "GetMedia" .id }}
                 <li {{- if .image }} class="with-image" {{- end }}>
-                  {{ with .image }}
-                    {{ partial "commons/image.html" (dict
-                        "image"    .
-                        "sizes"    site.Params.image_sizes.blocks.call_to_action
-                      )}}
-                  {{ end }}
                   <figure>
                     {{ partial "commons/download-link" (dict 
                       "id" .id
@@ -24,6 +18,12 @@
                       "with_caption" true
                     ) }}
                   </figure>
+                  {{ with .image }}
+                    {{ partial "commons/image.html" (dict
+                        "image"    .
+                        "sizes"    site.Params.image_sizes.blocks.call_to_action
+                      )}}
+                  {{ end }}
                 </li>
               {{ end -}}
             {{ end -}}

--- a/layouts/partials/blocks/templates/files.html
+++ b/layouts/partials/blocks/templates/files.html
@@ -10,7 +10,13 @@
           {{- range .files }}
             {{ if ne .id "" }}
               {{ if partial "GetMedia" .id }}
-                <li>
+                <li {{- if .image }} class="with-image" {{- end }}>
+                  {{ with .image }}
+                    {{ partial "commons/image.html" (dict
+                        "image"    .
+                        "sizes"    site.Params.image_sizes.blocks.call_to_action
+                      )}}
+                  {{ end }}
                   <figure>
                     {{ partial "commons/download-link" (dict 
                       "id" .id


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Nécessaire pour le conservatoire et surtout disponible en admin, on fait un ajout de l'image dans le html et un léger remaniement en css, deux questions : 
- Est-ce que l'image peut-être enfant direct du `li` et non de la `figure` ? C'est arrangeant pour l'icône de téléchargement mais peut-être que ce n'est pas idéal.
- Est-ce qu'il faut paramétrer le nombre de colonnes que prend l'image en config (css ou hugo) ?

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`/fr/blocks/blocks-techniques/fichiers/`

## URL de test du site Gaîté Lyrique

`/presse/`

## Screenshots

**Example**

![image](https://github.com/user-attachments/assets/0b298bcd-1c8e-4130-b998-f5c4c815aecb)
![image](https://github.com/user-attachments/assets/44be6db8-ca83-4ced-a6ae-ba142ea61a35)

**Gaîté Lyrique**

![image](https://github.com/user-attachments/assets/061b907f-9e05-4f3e-aec5-faea21f7a149)