### PR TITLE
Agenda : style des heures de fin

### DIFF
--- a/assets/sass/_theme/sections/events/layouts.sass
+++ b/assets/sass/_theme/sections/events/layouts.sass
@@ -269,10 +269,16 @@
                     left: 0
                     top: 0
                     margin-top: $spacing-3
+                    time + time
+                        @include meta
                 &--child
                     padding-left: offset(1)
                     .event-hours
                         margin-top: $spacing-3
+                        time + time
+                            display: block
+                            &::before
+                                margin-left: 0
                     &:where(:not(.event--with-image))
                         .event-content
                             margin-left: offset(3)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Correction de l'affichage des heures de fin.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots

Avant : 

<img width="559" alt="image" src="https://github.com/user-attachments/assets/c746f360-848f-4840-bf63-5b53b026762a" />

<img width="626" alt="image" src="https://github.com/user-attachments/assets/67945c40-2503-4e2b-b62f-40b93041b316" />


Après : 

<img width="826" alt="image" src="https://github.com/user-attachments/assets/4dff848e-1d3d-430d-aad6-6dbac04e6d48" />

<img width="832" alt="image" src="https://github.com/user-attachments/assets/c7d5a807-b86b-48cd-ae51-141eca1a3cc0" />
