### PR TITLE
Layout grille : modifier la grille en fonction du nombre d'éléments dans une liste

### DIFF
--- a/assets/sass/_theme/blocks/posts.sass
+++ b/assets/sass/_theme/blocks/posts.sass
@@ -29,7 +29,10 @@
                 @include grid(2)
         @include in-page-without-sidebar
             .grid
-                @include grid($block-posts-grid-columns)
+                // @include grid($block-posts-grid-columns)
+                @include grid(3)
+                &--even
+                    @include grid(2)
                 .media picture img
                     width: 100%
     &--large

--- a/assets/sass/_theme/design-system/layouts/grid.sass
+++ b/assets/sass/_theme/design-system/layouts/grid.sass
@@ -16,3 +16,5 @@
         @include grid(2)
     @include in-page-without-sidebar
         @include grid($columns)
+        &.grid--even
+            @include grid(2)

--- a/assets/sass/_theme/sections/events/layouts.sass
+++ b/assets/sass/_theme/sections/events/layouts.sass
@@ -105,7 +105,9 @@
                 + .event
                     margin-top: $spacing-4
         @include in-page-without-sidebar
-            @include grid(3, desktop)
+            @include grid(3)
+            &.grid--even
+                @include grid(2)
 
     &--large
         .event

--- a/assets/sass/_theme/sections/pages.sass
+++ b/assets/sass/_theme/sections/pages.sass
@@ -54,6 +54,10 @@
         @include grid(2, desktop)
         @include in-page-without-sidebar
             @include grid(3)
+    .grid
+        &--even
+            @include in-page-without-sidebar
+                @include grid(2)
 
 .pages
     .page

--- a/assets/sass/_theme/sections/programs.sass
+++ b/assets/sass/_theme/sections/programs.sass
@@ -132,6 +132,9 @@ ol.programs:where(:not(.programs--grid))
     @include in-page-without-sidebar
         @include grid(2)
         @include grid(3, xl)
+        &.grid--even
+            @include grid(2)
+        
 
 .programs__section
     .hero

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -495,7 +495,7 @@ params:
         grid:
           mobile:   400
           tablet:   360
-          desktop:  690
+          desktop:  864
         large:
           mobile:   400
           tablet:   360
@@ -516,7 +516,7 @@ params:
         grid:
           mobile:   400
           tablet:   360
-          desktop:  555
+          desktop:  864
         large:
           mobile:   400
           tablet:   360
@@ -567,7 +567,7 @@ params:
         item:
           mobile:   350
           tablet:   990
-          desktop:  600
+          desktop:  864
         large:
           mobile:   360
           tablet:   555
@@ -655,7 +655,7 @@ params:
         item:
           mobile:   350
           tablet:   990
-          desktop:  600
+          desktop:  864
       papers:
         hero:
           mobile:   400
@@ -686,7 +686,7 @@ params:
         item:
           mobile:   350
           tablet:   450
-          desktop:  600
+          desktop:  864
       projects:
         hero:
           mobile:   400
@@ -728,7 +728,7 @@ params:
         item:
           mobile:   350
           tablet:   450
-          desktop:  600
+          desktop:  864
       publications:
         hero:
           mobile:   400

--- a/layouts/partials/blocks/templates/agenda.html
+++ b/layouts/partials/blocks/templates/agenda.html
@@ -9,7 +9,8 @@
       <div class="block-content">
         {{ partial "blocks/top.html" $block.top }}
         {{ if .events }}
-          <div class="events events--{{- $layout -}}">
+          {{ $parityClass := cond (modBool (.events | len) 2) "even" "odd" }}
+          <div class="events events--{{- $layout -}} {{- if eq $layout "grid" }} grid--{{ $parityClass }} {{ end -}}">
             {{ range .events }}
               {{ $event := site.GetPage .path }}
               {{ with $event }}

--- a/layouts/partials/blocks/templates/programs.html
+++ b/layouts/partials/blocks/templates/programs.html
@@ -14,8 +14,9 @@
       <div class="block-content">
         {{ partial "blocks/top.html" $block.top }}
 
-        {{ if eq $block.data.layout "grid" }}
-          <div class="programs-grid">
+        {{ if and (eq $block.data.layout "grid") .programs }}
+          {{ $parityClass := cond (modBool (.programs | len) 2) "even" "odd" }}
+          <div class="programs-grid grid--{{ $parityClass }}">
             {{ range .programs }}
               {{ $program := site.GetPage .path }}
               {{ $title := $program.Title | safeHTML }}

--- a/layouts/partials/categories/partials/layouts/grid/grid.html
+++ b/layouts/partials/categories/partials/layouts/grid/grid.html
@@ -2,15 +2,18 @@
 {{ $heading_level := .heading_level }}
 {{ $options := .options }}
 
-<ul class="categories categories--grid">
-  {{ range $categories }}
-    <li>
-      {{ partial "categories/partials/layouts/grid/grid-item.html" (dict
-          "category" .
-          "heading_level" $heading_level
-          "options" $options
-          "layout" "grid"
-        ) }}
-    </li>
-  {{ end }}
-</ul>
+{{ if $categories }}
+  {{ $parityClass := cond (modBool (.categories | len) 2) "even" "odd" }}
+  <ul class="categories categories--grid grid--{{ $parityClass }}">
+    {{ range $categories }}
+      <li>
+        {{ partial "categories/partials/layouts/grid/grid-item.html" (dict
+            "category" .
+            "heading_level" $heading_level
+            "options" $options
+            "layout" "grid"
+          ) }}
+      </li>
+    {{ end }}
+  </ul>
+{{ end }}

--- a/layouts/partials/pages/partials/layouts/grid/grid.html
+++ b/layouts/partials/pages/partials/layouts/grid/grid.html
@@ -5,7 +5,8 @@
         "attributes" "class='page-title'"
 )}}
 {{ with .pages }}
-  <div class="grid">
+  {{ $parityClass := cond (modBool (. | len) 2) "even" "odd" }}
+  <div class="grid grid--{{ $parityClass }}">
     {{ range . }}
       {{/*  Check if . is a map or page url, necessary when pages/list is called outside block context */}}
       {{- $path := false -}}

--- a/layouts/partials/posts/partials/layouts/grid/grid.html
+++ b/layouts/partials/posts/partials/layouts/grid/grid.html
@@ -1,8 +1,9 @@
 {{ $heading_level := .heading_level | default 3 }}
 {{ $heading := printf "h%d" $heading_level }}
 {{ $options := .options }}
+{{ $parityClass := cond (modBool (.posts | len) 2) "even" "odd" }}
 
-<div class="grid">
+<div class="grid grid--{{ $parityClass }}">
   {{ range $post := .posts -}}
     {{ with site.GetPage .path }}
       {{ partial "posts/partials/post.html" (dict 


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout d'une classe `grid--even/odd` se basant sur la parité ou non des blocs de liste en layout grid :

```
{{ $parityClass := cond (modBool (.categories | len) 2) "even" "odd" }}
  <ul class="categories categories--grid grid--{{ $parityClass }}">
```

Cela pose plusieurs questions : 
- Ce comportement doit-il s'appliquer uniquement si on a 3 ou moins d'items ? (par exemple avec 6 événements on a 3 lignes de 2)
- Quid de la config propre aux posts, permettant d'ajuster la grille via sass ?
- Faut-il ajouter de nouvelles options pour les tailles d'images, car les blocs utilisent donc tous la taille valable pour un item qui prend une bonne partie de l'écran (864px en général), même sur une rangée de 3 ?
- Faut-il appliquer ce paramètre aux projets, sachants qu'ils sont maquettés sur des rangées de 2 à chaque fois ?

## Niveau d'incidence

- [ ] Incidence faible 😌
- [X] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

http://localhost:1313/fr/blocks/grilles-des-blocs-de-liste/

## URL de test du site Gaîté Lyrique

Home : bloc "à venir, très prochainement" (2 events) et "Les prochaines rencontres..." (1 event)
