### PR TITLE
Correction du titre de menu dropdown

### DIFF
--- a/layouts/partials/commons/menu-dropdown.html
+++ b/layouts/partials/commons/menu-dropdown.html
@@ -15,7 +15,11 @@
     {{ if .active }}
       <div class="container">
         <div class="dropdown-menu-heading">
-          <a href="{{ $parent.target }}" class="dropdown-menu-title">{{ $parent.title }}</a>
+          {{ if $parent.target }}
+            <a href="{{ $parent.target }}" class="dropdown-menu-title">{{ $parent.title }}</a>
+          {{ else }}
+            <p class="dropdown-menu-title">{{ $parent.title }}</p>
+          {{ end }}
           {{ if $parent.path }}
             {{ with partial "GetMenuSummary" (dict 
                 "summary" .summary


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Une balise `<a>` était utilisé même si ce le niveau n'est pas un lien. 

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

Correction audit RGAA Rennes

<img width="1076" alt="image" src="https://github.com/user-attachments/assets/14f26ef6-c4d9-406a-82a7-205b7b528eae" />



