### PR TITLE
[a11y] Correction du `aria-hidden` sur les blocs de titre

### DIFF
--- a/layouts/partials/blocks/templates/title.html
+++ b/layouts/partials/blocks/templates/title.html
@@ -14,7 +14,7 @@
         tabindex="0"
         aria-label="{{ partial "PrepareHTML" $title }}"
       {{ end }}>
-      <h2 {{ if $is_collapsed }} aria-hidden="true" {{ end }}>{{ partial "PrepareHTML" $title }}</h2>
+      <h2>{{ partial "PrepareHTML" $title }}</h2>
     </div>
   {{ end }}
 {{ end }}

--- a/layouts/partials/blocks/templates/title.html
+++ b/layouts/partials/blocks/templates/title.html
@@ -12,7 +12,6 @@
         aria-expanded="false"
         role="button"
         tabindex="0"
-        aria-label="{{ partial "PrepareHTML" $title }}"
       {{ end }}>
       <h2>{{ partial "PrepareHTML" $title }}</h2>
     </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Il y a une grosse erreur sur les blocs de titre : un `aria-hidden=true` traîne sur le bloc de titre dépliant.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Source

Relevé lors de l'audit RGAA Rennes

<img width="1097" alt="image" src="https://github.com/user-attachments/assets/60fe587d-6eb3-4ff3-ac46-5187d5e6726e" />
