### PR TITLE
Bloc personnes : correction du niveau de titre

### DIFF
--- a/layouts/partials/blocks/templates/persons.html
+++ b/layouts/partials/blocks/templates/persons.html
@@ -43,6 +43,7 @@
               {{ $person := site.GetPage .path }}
               {{ partial "persons/partials/person.html" (dict
                   "options" $options
+                  "heading_level" $block.ranks.children
                   "person" $person
                   "role" .role
                   "layout" $layout

--- a/layouts/partials/blocks/templates/title.html
+++ b/layouts/partials/blocks/templates/title.html
@@ -14,7 +14,7 @@
         tabindex="0"
         aria-label="{{ partial "PrepareHTML" $title }}"
       {{ end }}>
-      <h2 {{ if $is_collapsed }} aria-hidden="true" {{ end }}>{{ partial "PrepareHTML" $title }}</h2>
+      <h2>{{ partial "PrepareHTML" $title }}</h2>
     </div>
   {{ end }}
 {{ end }}

--- a/layouts/partials/blocks/templates/title.html
+++ b/layouts/partials/blocks/templates/title.html
@@ -12,7 +12,6 @@
         aria-expanded="false"
         role="button"
         tabindex="0"
-        aria-label="{{ partial "PrepareHTML" $title }}"
       {{ end }}>
       <h2>{{ partial "PrepareHTML" $title }}</h2>
     </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Le niveau de titre n'était pas passé aux articles personnes.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

<img width="1084" alt="image" src="https://github.com/user-attachments/assets/915058b3-8fab-4be4-9a51-e13f703eec56" />


