### PR TITLE
Correction des appels de partials dans les campus

### DIFF
--- a/layouts/partials/locations/single.html
+++ b/layouts/partials/locations/single.html
@@ -11,7 +11,7 @@
     ) }}
 
   {{ partial "contents/list.html" . }}
-  {{ partial "partials/locations/single/diplomas.html" . }}
+  {{ partial "locations/single/diplomas.html" . }}
 </div>
 {{ $address_geolocation := .Params.contact_details.postal_address.geolocation }}
 {{ if and $address_geolocation.longitude $address_geolocation.latitude }}

--- a/layouts/partials/locations/single/diplomas.html
+++ b/layouts/partials/locations/single/diplomas.html
@@ -12,7 +12,7 @@
       <ol class="programs">
         {{- range . -}}
           {{ $program := site.GetPage .path }}
-          {{- partial "partials/programs/partials/program.html" (dict
+          {{- partial "programs/partials/program.html" (dict
             "program" $program
             "heading" "h3"
             "options" site.Params.locations.single.programs.options


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Correction des chemins des partials des diplômes et programmes dans les campus, car en version de hugo 147 example ne compilait plus plus.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱