### PR TITLE
Agenda : options pour masquer les archives et années

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -127,6 +127,8 @@ params:
     date_format: false # You can add date format to override the date from static (two_lines) 
     time_format: false # You can add time format to override the time from static (from.hour & to.hour)
     index:
+      archives: true
+      years: true
       group_by_date: "Monday 2 January 2006"
       highlight_exhibitions:
         active: true

--- a/layouts/partials/events/section/archives.html
+++ b/layouts/partials/events/section/archives.html
@@ -1,2 +1,6 @@
-{{ partial "events/section/archives/latest.html" . }}
-{{ partial "events/section/archives/years.html" . }}
+{{ if site.Params.events.index.archives }}
+  {{ partial "events/section/archives/latest.html" . }}
+{{ end }}
+{{ if site.Params.events.index.years }}
+  {{ partial "events/section/archives/years.html" . }}
+{{ end }}

--- a/layouts/partials/events/section/archives/years.html
+++ b/layouts/partials/events/section/archives/years.html
@@ -1,7 +1,7 @@
 {{ $years := .Pages }}
 {{ with $years.ByTitle.Reverse }}
   <div class="container events-archives-years">
-    <h2 class="sr-only">{{ i18n "events.archives.by_year" }}</h2>
+    <h2>{{ i18n "events.archives.by_year" }}</h2>
     <ol>
       {{ range . }}
         {{ if .Params.is_year }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Affichage du titre pour les années.

Ajout d'une option de site pour permettre de masquer les archives et/ou les années sur la page agenda : 

```
params:
    events:
      index:
        archives: true
        years: true
```

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
