### PR TITLE
[a11y] Correction du bloc lien

### DIFF
--- a/layouts/partials/blocks/templates/links.html
+++ b/layouts/partials/blocks/templates/links.html
@@ -11,10 +11,8 @@
             <li itemscope itemtype="https://schema.org/WebPage">
               <div class="link-content">
                 {{ $title := partial "PrepareHTML" .title }}
-                {{ $a11y_title := printf "%s %s" $title .alt_title }}
                 {{ $url := .url }}
                 {{ $is_external := .external | default true }}
-                {{ $link_title := cond $is_external (safeHTML (i18n "commons.link.blank_aria" (dict "Title" $a11y_title))) $a11y_title }}
 
                 <link itemprop="url" href="{{ .url }}">
                 <a itemprop="relatedLink" href="{{ .url }}" {{ if $is_external -}} target="_blank" rel="noopener" {{- end }}>

--- a/layouts/partials/blocks/templates/links.html
+++ b/layouts/partials/blocks/templates/links.html
@@ -10,13 +10,12 @@
           {{- range .links }}
             <li itemscope itemtype="https://schema.org/WebPage">
               <div class="link-content">
-                {{ $title := partial "PrepareHTML" .title }}
                 {{ $url := .url }}
                 {{ $is_external := .external | default true }}
 
                 <link itemprop="url" href="{{ .url }}">
                 <a itemprop="relatedLink" href="{{ .url }}" {{ if $is_external -}} target="_blank" rel="noopener" {{- end }}>
-                  <span itemprop="name">{{- $title -}}</span>
+                  <span itemprop="name">{{- partial "PrepareHTML" .title -}}</span>
                   {{ if $is_external }}
                     <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
                   {{ end }}

--- a/layouts/partials/blocks/templates/links.html
+++ b/layouts/partials/blocks/templates/links.html
@@ -11,13 +11,13 @@
             <li itemscope itemtype="https://schema.org/WebPage">
               <div class="link-content">
                 {{ $title := partial "PrepareHTML" .title }}
-                {{ $a11y_title := .alt_title | default $title }}
+                {{ $a11y_title := printf "%s %s" $title .alt_title }}
                 {{ $url := .url }}
                 {{ $is_external := .external | default true }}
                 {{ $link_title := cond $is_external (safeHTML (i18n "commons.link.blank_aria" (dict "Title" $a11y_title))) $a11y_title }}
 
                 <link itemprop="url" href="{{ .url }}">
-                <a itemprop="relatedLink" href="{{ .url }}" title="{{ $link_title }}" {{ if $is_external -}} target="_blank" rel="noopener" {{- end }}>
+                <a itemprop="relatedLink" href="{{ .url }}" {{ if $is_external -}} target="_blank" rel="noopener" {{- end }}>
                   <span itemprop="name">{{- $title -}}</span>
                   {{ if $is_external }}
                     <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

L'usage du champ "texte alternative" peut créer des erreurs d'accessibilité. En effet le `title` d'un lien doit contenir le même texte que ce lien, permettre aux contributrices et contributeurs de choisir le contenu du `title` déplace la responsabilité de la conformité sur la contribution.

Deux solutions : 
- ajouter le titre du lien visible dans le `title` et y ajouter le `alt_title` pour permettre de préciser le lien
- retirer complètement l'attribut `title` (selon la reco Ideance VS Temesis

Il faut engager un échange entre Temesis et Ideance sur ce point.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)


L'implémentation actuelle vient de l'audit RGAA Temesis : 

https://github.com/osunyorg/theme/issues/548

https://github.com/osunyorg/theme/pull/594
