### PR TITLE
Projet : single taxonomies

### DIFF
--- a/layouts/partials/projects/single.html
+++ b/layouts/partials/projects/single.html
@@ -7,7 +7,8 @@
 
   {{ partial "projects/single/sidebar.html" . }}
 
-  {{ if .Params.design.full_width }}
+  {{ $taxonomies_position := partial "GetTaxonomiesPosition" . }}
+  {{ if and .Params.design.full_width .Params.taxonomies (eq $taxonomies_position "content") }}
     <div class="container">
       {{ partial "taxonomies/single-list-container.html" . }}
     </div>

--- a/layouts/partials/projects/single.html
+++ b/layouts/partials/projects/single.html
@@ -8,7 +8,9 @@
   {{ partial "projects/single/sidebar.html" . }}
 
   {{ if .Params.design.full_width }}
-    {{ partial "taxonomies/single-list-container.html" . }}
+    <div class="container">
+      {{ partial "taxonomies/single-list-container.html" . }}
+    </div>
   {{ end }}
 
   {{ partial "projects/single/summary.html" (dict


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Il manque un container autour des taxonomies quand un projet est en pleine largeur et la config de la position de la taxonomie à `content` (par défaut).

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱



