### PR TITLE
Reprise des liens sur les icônes du footer

### DIFF
--- a/assets/sass/_theme/design-system/footer.sass
+++ b/assets/sass/_theme/design-system/footer.sass
@@ -117,8 +117,10 @@ footer#document-footer
                 display: flex
                 justify-content: flex-end
                 position: relative
-                a::after
-                    display: none
+                a
+                    @include stretched-link(before)
+                    &::after
+                        display: none
                 &.facebook
                     @include icon(facebook-fill, after)
                 &.instagram


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

- Arnaud avait relevé que c'est dommage de ne pas pouvoir cliquer sur l'icône (si je me souviens bien)
- Sur la gaîté en mode icon only on perdait le lien !

J'ai donc rajouté un `stretched-links` sur le lien.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

Home

## URL de test du site Gaîté Lyrique

Home