### PR TITLE
Ajout d'une option pour l'exclusion de page dans le sitemap

### DIFF
--- a/content/pages/system/typography.html
+++ b/content/pages/system/typography.html
@@ -4,8 +4,9 @@ title: >-
 design:
   full_width: true
 
-search_ignore: true
-sitemap_ignore: true
+ignore:
+  in_search: true
+  in_sitemap: true
 
 contents:
   - kind: block

--- a/content/pages/system/typography.html
+++ b/content/pages/system/typography.html
@@ -4,6 +4,9 @@ title: >-
 design:
   full_width: true
 
+search_ignore: true
+sitemap_ignore: true
+
 contents:
   - kind: block
     template: chapter

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -112,6 +112,8 @@ params:
       taxonomies:
         display: true
         position: content
+    sitemap:
+      ignore_children: false
   categories:
     index:
       layout: grid # alternate | cards | grid | large | list
@@ -126,6 +128,8 @@ params:
     default_image: false
     date_format: false # You can add date format to override the date from static (two_lines) 
     time_format: false # You can add time format to override the time from static (from.hour & to.hour)
+    # sitemap:
+    #   ignore_children: true
     index:
       archives: true
       years: true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,7 +16,12 @@
     {{- partial "header/accessibility.html" -}}
     {{- partial "hooks/before-header" . -}}
     {{- partial "header/header.html" . -}}
-    <main{{ if .Params.contents }} class="page-with-blocks"{{ end }} id="main" {{ if site.Params.search.active }}data-pagefind-body{{ end }}>
+    <main
+        id="main"
+        {{ if .Params.contents }} class="page-with-blocks"{{ end }} 
+        {{ if site.Params.search.active }}data-pagefind-body{{ end }}
+        {{ if .Params.search_ignore }}data-pagefind-ignore{{ end }}
+        >
       {{ partial "commons/search/button.html" "fixed" }}
       {{- block "main" . }}{{- end }}
       {{- partial "hooks/before-main-end" . -}}

--- a/layouts/pages/sitemap.html
+++ b/layouts/pages/sitemap.html
@@ -28,7 +28,7 @@
           <ul>
             {{ range (where .Site.Pages "Type" "pages") }}
               {{ if eq .Parent.Path "/pages" }}
-                {{ if not .Params.sitemap_ignore }}
+                {{ if not .Params.ignore.in_sitemap }}
                   <li>
                     <a href="{{ .Permalink }}">{{ safeHTML .Title }}</a>
                     {{ if .Pages }}
@@ -52,7 +52,6 @@
               <h2>
                 <a href="{{ $permalink }}">{{ safeHTML .Title }}</a>
               </h2>
-
               {{ $ignore_children := partial "GetSiteParamWithDefault" (dict
                   "param" (printf "%s.sitemap.ignore_children" .Type)
                   "default" "default.sitemap.ignore_children"
@@ -60,7 +59,7 @@
               {{ if not $ignore_children }}
                 <ul>
                   {{ range where .Site.Pages "Section" .Type }}
-                    {{ if not .Params.sitemap_ignore }}
+                    {{ if not .Params.ignore.in_sitemap }}
                       {{ if ne $permalink .Permalink }}
                         <li><a href="{{ .Permalink }}">{{ safeHTML .Title }}</a></li>
                       {{ end }}
@@ -68,7 +67,6 @@
                   {{ end }}
                 </ul>
               {{ end }}
-
             </div>
           </div>
         </div>

--- a/layouts/pages/sitemap.html
+++ b/layouts/pages/sitemap.html
@@ -28,12 +28,14 @@
           <ul>
             {{ range (where .Site.Pages "Type" "pages") }}
               {{ if eq .Parent.Path "/pages" }}
-                <li>
-                  <a href="{{ .Permalink }}">{{ safeHTML .Title }}</a>
-                  {{ if .Pages }}
-                    {{ partial "pages/partials/sitemap-recursive-pages.html" .}}
-                  {{ end }}
-                </li>
+                {{ if not .Params.sitemap_ignore }}
+                  <li>
+                    <a href="{{ .Permalink }}">{{ safeHTML .Title }}</a>
+                    {{ if .Pages }}
+                      {{ partial "pages/partials/sitemap-recursive-pages.html" .}}
+                    {{ end }}
+                  </li>
+                {{ end }}
               {{ end }}
             {{ end }}
           </ul>
@@ -46,17 +48,27 @@
         {{ $permalink := .Permalink }}
         <div class="block block-sitemap" id="{{ .Type }}">
           <div class="container">
-            <div class="block-content">              
+            <div class="block-content">
               <h2>
                 <a href="{{ $permalink }}">{{ safeHTML .Title }}</a>
               </h2>
-              <ul>
-                {{ range where .Site.Pages "Section" .Type }}
-                  {{ if ne $permalink .Permalink }}
-                    <li><a href="{{ .Permalink }}">{{ safeHTML .Title }}</a></li>
+
+              {{ $ignore_children := partial "GetSiteParamWithDefault" (dict
+                  "param" (printf "%s.sitemap.ignore_children" .Type)
+                  "default" "default.sitemap.ignore_children"
+                ) }}
+              {{ if not $ignore_children }}
+                <ul>
+                  {{ range where .Site.Pages "Section" .Type }}
+                    {{ if not .Params.sitemap_ignore }}
+                      {{ if ne $permalink .Permalink }}
+                        <li><a href="{{ .Permalink }}">{{ safeHTML .Title }}</a></li>
+                      {{ end }}
+                    {{ end }}
                   {{ end }}
-                {{ end }}
-              </ul>
+                </ul>
+              {{ end }}
+
             </div>
           </div>
         </div>

--- a/layouts/partials/pages/partials/sitemap-recursive-pages.html
+++ b/layouts/partials/pages/partials/sitemap-recursive-pages.html
@@ -1,10 +1,12 @@
 <ul>
   {{ range .Pages }}
-    <li>
-      <a href="{{ .Permalink }}">{{ safeHTML .Title }}</a>
-      {{ if .Pages }}
-        {{ partial "pages/partials/sitemap-recursive-pages.html" . }}
-      {{ end }}
-    </li>
+    {{ if not .Params.sitemap_ignore }}
+      <li>
+        <a href="{{ .Permalink }}">{{ safeHTML .Title }}</a>
+        {{ if .Pages }}
+          {{ partial "pages/partials/sitemap-recursive-pages.html" . }}
+        {{ end }}
+      </li>
+    {{ end }}
   {{ end }}
 </ul>

--- a/layouts/partials/pages/partials/sitemap-recursive-pages.html
+++ b/layouts/partials/pages/partials/sitemap-recursive-pages.html
@@ -1,6 +1,6 @@
 <ul>
   {{ range .Pages }}
-    {{ if not .Params.sitemap_ignore }}
+    {{ if not .Params.ignore.in_sitemap }}
       <li>
         <a href="{{ .Permalink }}">{{ safeHTML .Title }}</a>
         {{ if .Pages }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Pour garantir une bonne accessibilité, le sitemap doit être nettoyé. Pour gérer des sites avec beaucoup de contenu, une option peut-être ajouter au global ou par section : 

Au global : 

```
default:
  sitemap:
    ignore_children: false
```

Par section : 

```
events:
  sitemap:
    ignore_children: false
```

De plus, le sitemap ne listera pas les objets qui ont un paramètre "sitemap_ignore: true". Il est intéressant d'exclure les années et les mois de tous les sites.

```
---
title: >-
  Design typographique
design:
  full_width: true

sitemap_ignore: true
```

On en profite pour ajouter une option pour exclure des éléments de la recherche pagefind.js par objet avec le paramètre `search_ignore` : 

```
---
title: >-
  Design typographique
design:
  full_width: true

search_ignore: true
```

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱
