### PR TITLE
Ajout d'un bouton `large` au design system

### DIFF
--- a/assets/sass/_theme/_variables.sass
+++ b/assets/sass/_theme/_variables.sass
@@ -127,7 +127,7 @@
   --btn-hover-border: #{$btn-hover-border}
   --btn-border-radius: #{$btn-border-radius}
   --btn-padding: #{$btn-padding}
-  --btn-padding-small: #{$btn-padding-small}
+  --btn-small-padding: #{$btn-small-padding}
   --btn-min-width: #{$btn-min-width}
   --btn-disabled-color: #{$btn-disabled-color}
   --btn-disabled-background: #{$btn-disabled-background}
@@ -135,7 +135,7 @@
   @include media-breakpoint-up(desktop)
     --btn-font-size: #{$btn-font-size-desktop}
     --btn-padding: #{$btn-padding-desktop}
-    --btn-padding-small: #{$btn-padding-small-desktop}
+    --btn-small-padding: #{$btn-small-padding-desktop}
     --btn-border: #{$btn-border-desktop}
     --btn-border-radius: #{$btn-border-radius-desktop}
     --btn-min-width: #{$btn-min-width-desktop}

--- a/assets/sass/_theme/_variables.sass
+++ b/assets/sass/_theme/_variables.sass
@@ -127,18 +127,22 @@
   --btn-hover-border: #{$btn-hover-border}
   --btn-border-radius: #{$btn-border-radius}
   --btn-padding: #{$btn-padding}
-  --btn-small-padding: #{$btn-small-padding}
   --btn-min-width: #{$btn-min-width}
   --btn-disabled-color: #{$btn-disabled-color}
   --btn-disabled-background: #{$btn-disabled-background}
   --btn-disabled-border: #{$btn-disabled-border}
+  --btn-small-font-size: #{$btn-small-font-size}
+  --btn-small-padding: #{$btn-small-padding}
+  --btn-large-font-size: #{$btn-large-font-size}
+  --btn-large-padding: #{$btn-large-padding}
   @include media-breakpoint-up(desktop)
     --btn-font-size: #{$btn-font-size-desktop}
     --btn-padding: #{$btn-padding-desktop}
-    --btn-small-padding: #{$btn-small-padding-desktop}
     --btn-border: #{$btn-border-desktop}
     --btn-border-radius: #{$btn-border-radius-desktop}
     --btn-min-width: #{$btn-min-width-desktop}
+    --btn-large-font-size: #{$btn-large-font-size-desktop}
+    --btn-large-padding: #{$btn-large-padding-desktop}
 
   // -------------- //
   //      GRID      //

--- a/assets/sass/_theme/configuration/components.sass
+++ b/assets/sass/_theme/configuration/components.sass
@@ -21,8 +21,10 @@ $btn-border-radius: pxToRem(4) !default
 $btn-border-radius-desktop: $btn-border-radius !default
 $btn-padding: pxToRem(12) pxToRem(10) !default
 $btn-padding-desktop: pxToRem(18) pxToRem(16) !default
-$btn-padding-small: pxToRem(6) pxToRem(10) !default
-$btn-padding-small-desktop: pxToRem(6) pxToRem(10) !default
+$btn-small-font-size: $btn-font-size !default
+$btn-small-font-size-desktop: $btn-font-size-desktop !default
+$btn-small-padding: pxToRem(6) pxToRem(10) !default
+$btn-small-padding-desktop: pxToRem(6) pxToRem(10) !default
 $btn-min-width: pxToRem(100) !default
 $btn-min-width-desktop: pxToRem(190) !default
 $btn-disabled-color: var(--color-text-alt) !default

--- a/assets/sass/_theme/configuration/components.sass
+++ b/assets/sass/_theme/configuration/components.sass
@@ -21,15 +21,21 @@ $btn-border-radius: pxToRem(4) !default
 $btn-border-radius-desktop: $btn-border-radius !default
 $btn-padding: pxToRem(12) pxToRem(10) !default
 $btn-padding-desktop: pxToRem(18) pxToRem(16) !default
-$btn-small-font-size: $btn-font-size !default
-$btn-small-font-size-desktop: $btn-font-size-desktop !default
-$btn-small-padding: pxToRem(6) pxToRem(10) !default
-$btn-small-padding-desktop: pxToRem(6) pxToRem(10) !default
 $btn-min-width: pxToRem(100) !default
 $btn-min-width-desktop: pxToRem(190) !default
 $btn-disabled-color: var(--color-text-alt) !default
 $btn-disabled-background: var(--color-background-alt) !default
 $btn-disabled-border: $btn-disabled-background !default
+
+$btn-small-font-size: $btn-font-size !default
+$btn-small-font-size-desktop: $btn-font-size-desktop !default
+$btn-small-padding: pxToRem(6) pxToRem(10) !default
+$btn-small-padding-desktop: pxToRem(6) pxToRem(10) !default
+
+$btn-large-font-size: $btn-font-size !default
+$btn-large-font-size-desktop: $btn-font-size-desktop !default
+$btn-large-padding: pxToRem(14) pxToRem(12) !default
+$btn-large-padding-desktop: pxToRem(20) pxToRem(18) !default
 
 // Chip
 $chip-background: var(--color-background) !default

--- a/assets/sass/_theme/design-system/button.sass
+++ b/assets/sass/_theme/design-system/button.sass
@@ -63,7 +63,7 @@
     --btn-hover-border: #{$btn-border-width} solid var(--btn-hover-background)
 
 .button--small
-    padding: var(--btn-padding-small)
+    padding: var(--btn-small-padding)
 
 @mixin link-icon($icon: false)
     @include button-reset

--- a/assets/sass/_theme/design-system/button.sass
+++ b/assets/sass/_theme/design-system/button.sass
@@ -63,7 +63,12 @@
     --btn-hover-border: #{$btn-border-width} solid var(--btn-hover-background)
 
 .button--small
+    font-size: var(--btn-small-font-size)
     padding: var(--btn-small-padding)
+
+.button--large
+    font-size: var(--btn-large-font-size)
+    padding: var(--btn-large-padding)
 
 @mixin link-icon($icon: false)
     @include button-reset

--- a/content/system/typography.html
+++ b/content/system/typography.html
@@ -53,6 +53,14 @@ contents:
           <button class="button--alt button--small">A small alternative button</button>
         </div>
 
+        <br>
+
+        <div>
+          <button class="button button--large">A  large button</button>
+          <button class="button--accent button--large">A large accent button</button>
+          <button class="button--alt button--large">A large alternative button</button>
+        </div>
+
       notes: >-
         
       alt: >-


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

1. Création d'une classe css et de ses variables pour les boutons larges.  Ajout de configuration de taille de typo pour les boutons small et large :
 
```
$btn-large-font-size: $btn-font-size !default
$btn-large-font-size-desktop: $btn-font-size-desktop !default
$btn-large-padding: pxToRem(14) pxToRem(12) !default
$btn-large-padding-desktop: pxToRem(20) pxToRem(18) !default
```

2.  Renommage des variables `btn-small` :

avant : 

```
$btn-padding-small: pxToRem(6) pxToRem(10) !default
```

après : 

```
$btn-small-padding: pxToRem(6) pxToRem(10) !default
```


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


## Screenshots

<img width="672" alt="image" src="https://github.com/user-attachments/assets/ee27dc7a-da00-45d7-8cba-36a8ddcf6e3a" />

