### PR TITLE
Correction de la nav vide dans le footer

### DIFF
--- a/layouts/partials/footer/social.html
+++ b/layouts/partials/footer/social.html
@@ -1,6 +1,6 @@
 {{ $menu := partial "GetMenu" "social" }}
 
-{{ if $menu }}
+{{ if $menu.item }}
   {{ partial "commons/menu.html"
     (dict
       "kind"        "social"

--- a/layouts/partials/footer/social.html
+++ b/layouts/partials/footer/social.html
@@ -1,6 +1,6 @@
 {{ $menu := partial "GetMenu" "social" }}
 
-{{ if $menu.item }}
+{{ if $menu.items }}
   {{ partial "commons/menu.html"
     (dict
       "kind"        "social"


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Le menu "social" est toujours actif, mais sans items, on avait donc en permanence une nav vide.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱