### PR TITLE
Mixin icon : gestion des espaces insécables après l'icône

### DIFF
--- a/assets/sass/_theme/utils/icons.sass
+++ b/assets/sass/_theme/utils/icons.sass
@@ -24,8 +24,11 @@
         speak: never
         text-transform: none
         @if $non-breaking
-            content: " #{map-get($icons, $icon-name)}"
             display: inline
+            @if $pseudo-element == "after"
+                content: " #{map-get($icons, $icon-name)}"
+            @if $pseudo-element == "before"
+                content: "#{map-get($icons, $icon-name)} "
         @content // TODO : important de documenter ça
 
 @mixin icon-block($icon-name: '', $pseudo-element: before, $non-breaking: false)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

En utilisant l'option `$non-breaking` du mixin sass `icon`, on gère la position de l'espace insécable en fonction de si l'icône se situe avant ou après le contenu. Cela évite d'avoir un espace vide avant une icône placée avant le texte. 

> N.B : L'usage est rare mais possible.  

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots

<img width="372" alt="image" src="https://github.com/user-attachments/assets/a0d19234-3c80-424f-89cf-fb1bb354d0d4" />

