### PR TITLE
Correctif du partial "site" du footer

### DIFF
--- a/layouts/partials/footer/site.html
+++ b/layouts/partials/footer/site.html
@@ -4,8 +4,10 @@
   <div itemscope itemtype="https://schema.org/CollegeOrUniversity">
     <meta itemprop="logo" content="{{ $logo }}">
     <p itemprop="name">{{ htmlUnescape (trim .name "\n") }}</p>
-    {{ with .contact_details.postal_address }} 
-      {{ partial "commons/address.html" . }}
+    {{ with .contact_details }}
+      {{ with .postal_address }}
+        {{ partial "commons/address.html" . }}
+      {{ end }}
       {{- with .phone_numbers.phone -}}
         <p>
           <a itemprop="telephone" href="{{.value}}">{{ .label }}</a>
@@ -18,8 +20,10 @@
   <div itemscope itemtype="https://schema.org/ResearchOrganization">
     <meta itemprop="logo" content="{{ $logo }}">
     <p itemprop="name">{{ htmlUnescape (trim .name "\n") }}</p>
-    {{ with .contact_details.postal_address }} 
-      {{ partial "commons/address.html" . }}
+    {{ with .contact_details }} 
+      {{ with .postal_address }}
+        {{ partial "commons/address.html" . }}
+      {{ end}}
       {{- with .phone_numbers.phone -}}
           <p>
             <a itemprop="telephone" href="{{.value}}">{{ .label }}</a>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Actuellement `phone_numbers` était dans le `with .postal_address` alors qu'il est au même niveau : 

```
contact_details:
  postal_address:
    data:
      address_name: >-
      ...
  phone_numbers:
    phone:
      label: >-
        04 91 82 83 10
      value: >-
        tel:0491828310
```

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱