### PR TITLE
Correction d'un `li` vide lorsqu'il n'y a pas de catégories

### DIFF
--- a/layouts/partials/events/single/event-infos.html
+++ b/layouts/partials/events/single/event-infos.html
@@ -27,6 +27,7 @@
       {{ partial "taxonomies/single-list.html" . }}
     </li>
   {{ end }}
+
   {{ if site.Params.events.share_links.enabled | default site.Params.share_links.enabled }}
     <li>
       <span>{{ i18n "commons.share_on" }}</span>

--- a/layouts/partials/posts/single/post-infos.html
+++ b/layouts/partials/posts/single/post-infos.html
@@ -1,7 +1,7 @@
 <ul class="post-infos">
   {{ $taxonomies_position := partial "GetTaxonomiesPosition" . }}
   {{ if ne $taxonomies_position "hero" }}
-    {{ if or .Params.post_categories .Params.taxonomies }}
+    {{ if .Params.posts_categories }}
       <li>
         {{ partial "taxonomies/single-list.html" . }}
       </li>

--- a/layouts/partials/posts/single/post-infos.html
+++ b/layouts/partials/posts/single/post-infos.html
@@ -1,9 +1,11 @@
 <ul class="post-infos">
   {{ $taxonomies_position := partial "GetTaxonomiesPosition" . }}
   {{ if ne $taxonomies_position "hero" }}
-    <li>
-      {{ partial "taxonomies/single-list.html" . }}
-    </li>
+    {{ if or .Params.post_categories .Params.taxonomies }}
+      <li>
+        {{ partial "taxonomies/single-list.html" . }}
+      </li>
+    {{ end }}
   {{ end }}
 
   <li>

--- a/layouts/partials/projects/single/project-infos.html
+++ b/layouts/partials/projects/single/project-infos.html
@@ -2,9 +2,11 @@
 <ul class="project-infos">
   {{ $taxonomies_position := partial "GetTaxonomiesPosition" . }}
   {{ if ne $taxonomies_position "hero" }}
-    <li>
-      {{ partial "taxonomies/single-list.html" . }}
-    </li>
+    {{ if .Params.projects_categories }}
+      <li>
+        {{ partial "taxonomies/single-list.html" . }}
+      </li>
+    {{ end }}
   {{ end }}
 
   {{ with .Params.year }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

La vérification de la présence des catégories a été abîmé par l'ajout de l'option du placement des taxo / catégorie d'un post. Cette vérification permet de réparer la présence d'un `li` vide lorsqu'il n'y a pas de catégorie associé à un `post`.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


