### PR TITLE
Bloc fichiers : gestion des textes long

### DIFF
--- a/assets/sass/_theme/blocks/files.sass
+++ b/assets/sass/_theme/blocks/files.sass
@@ -6,8 +6,8 @@
             align-items: start
             display: flex
             position: relative
-            flex-wrap: wrap
             &.with-image
+                flex-wrap: wrap
                 figure
                     flex: 1
                 picture


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Les blocs fichiers avec un texte long chassait le bloc de texte en dessous du pictos.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


## Screenshots

Avant : 

![image](https://github.com/user-attachments/assets/1016a999-3f11-4887-8f00-f63b943e7917)


Après : 

![image](https://github.com/user-attachments/assets/bd63805d-19e0-4f26-b780-1cfcea9e311b)


