### PR TITLE
Bloc liens : ajout d'une classe s'il y a une image

### DIFF
--- a/layouts/partials/blocks/templates/links.html
+++ b/layouts/partials/blocks/templates/links.html
@@ -8,7 +8,7 @@
         {{ partial "blocks/top.html" $block.top }}
         <ul class="links">
           {{- range .links }}
-            <li itemscope itemtype="https://schema.org/WebPage">
+            <li itemscope itemtype="https://schema.org/WebPage" {{- if .image -}} class="with-image" {{- end -}}>
               <div class="link-content">
                 {{ $title := partial "PrepareHTML" .title }}
                 {{ $a11y_title := .alt_title | default $title }}


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout d'une classe `with-image` aux liens avec une image : 

![Capture d’écran 2025-05-20 à 14 53 08](https://github.com/user-attachments/assets/4f9bbd2c-da09-4252-932b-05d2503b1a5f)

(Pour inseam)

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱