### PR TITLE
Événement : ajout d'une traduction à l'anglais

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -88,6 +88,14 @@ commons:
     transcription: Transcription
     map_transcription : Transcription
     credits: "Rights reserved: "
+  add_to_calendar:
+    title: Add to my calendar
+    ical: Download an .ICS file
+    google: Google Calendar
+    office: Office 365
+    outlook: Microsoft Outlook
+    regular_event: Add the entire event period to my calendar
+    yahoo: Yahoo! Calendar
   authors:
     one: Author
     other: Authors


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

En passant sur les événements de CIDS, on remarque un blanc devant l'icône du calendrier : 

![Capture d’écran 2025-05-20 à 16 06 25](https://github.com/user-attachments/assets/3ce7506b-a700-41d1-a3de-91cb942fa347)

Il n'y avait pas de traduction anglaise !

![Capture d’écran 2025-05-20 à 16 06 04](https://github.com/user-attachments/assets/514fcbe9-6508-4ffc-b404-250284bf99b7)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱