### PR TITLE
Ajout d'un `hook` à la modal de recherche

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -176,7 +176,7 @@ params:
       calendar_links: false
       navigation:
         active: false
-      meta_in_sidebar: false
+      meta_in_sidebar: true
       summary:
         position: content # hero | content
       time_slots:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -176,7 +176,7 @@ params:
       calendar_links: false
       navigation:
         active: false
-      meta_in_sidebar: true
+      meta_in_sidebar: false
       summary:
         position: content # hero | content
       time_slots:

--- a/layouts/partials/commons/search/modal.html
+++ b/layouts/partials/commons/search/modal.html
@@ -6,5 +6,8 @@
             {{ i18n "commons.search.close" }}
         </button>
         <p role="heading" aria-level="1" class="sr-only">{{ i18n "commons.search.title" }}</p>
+
+        {{ partial "hooks/before-search-modal-end.html" . }}
     </div>
+
 {{ end }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout d'un hook `before-search-modal-end.html` afin de gérer le système de suggestions (module à venir).

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


