### PR TITLE
[a11y] rendre focusable les figcaption dans les hero des pages

### DIFF
--- a/assets/sass/_theme/utils/shame.sass
+++ b/assets/sass/_theme/utils/shame.sass
@@ -98,7 +98,7 @@
         a
             color: inherit
             text-decoration-color: inherit
-        &:focus
+        &:focus, &:focus-within
             .credit
                 display: block
         @include media-breakpoint-up(desktop)

--- a/layouts/partials/commons/image-figure.html
+++ b/layouts/partials/commons/image-figure.html
@@ -36,7 +36,7 @@
       {{ end }}
 
       {{ if or .text .credit }}
-        <figcaption>
+        <figcaption tabindex="0">
           {{ with .text }}
             <div>{{ . | safeHTML }}</div>
           {{ end }}

--- a/layouts/partials/commons/image-figure.html
+++ b/layouts/partials/commons/image-figure.html
@@ -1,4 +1,5 @@
 {{ $in_gallery := .gallery | default false }}
+{{ $focusable_figcaption := .focusable_figcaption }}
 
 {{ if .image.id }}
   {{ $sizes := .sizes }}
@@ -36,7 +37,7 @@
       {{ end }}
 
       {{ if or .text .credit }}
-        <figcaption tabindex="0">
+        <figcaption {{ if $focusable_figcaption }} tabindex="0" {{ end }}>
           {{ with .text }}
             <div>{{ . | safeHTML }}</div>
           {{ end }}

--- a/layouts/partials/header/hero.html
+++ b/layouts/partials/header/hero.html
@@ -76,14 +76,12 @@
       {{ end }}
 
       {{ if .image }}
-        <!-- TODO Peut etre aligner la stucture des données avec les autres cas d'images -->
         {{ partial "commons/image-figure.html" (dict
-          "image" .image
-          "sizes" ( .sizes | default site.Params.image_sizes.design_system.hero )
-          "lazy" false
-          "focusable_figcaption" true
-          )
-        }}
+            "image" .image
+            "sizes" ( .sizes | default site.Params.image_sizes.design_system.hero )
+            "lazy" false
+            "focusable_figcaption" true
+          ) }}
       {{ end }}
 
       {{ if .hero_after_image_complement }}

--- a/layouts/partials/header/hero.html
+++ b/layouts/partials/header/hero.html
@@ -78,9 +78,10 @@
       {{ if .image }}
         <!-- TODO Peut etre aligner la stucture des données avec les autres cas d'images -->
         {{ partial "commons/image-figure.html" (dict
-          "image"    .image
-          "sizes"    ( .sizes | default site.Params.image_sizes.design_system.hero )
-          "lazy"      false
+          "image" .image
+          "sizes" ( .sizes | default site.Params.image_sizes.design_system.hero )
+          "lazy" false
+          "focusable_figcaption" true
           )
         }}
       {{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Rétablissement du comportement de focus sur les figcaption des hero (afin de les faire apparaître au clavier en plus du survol).

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


