### PR TITLE
Sections : ajout d'une option de layout aux taxonomies

### DIFF
--- a/assets/sass/_theme/design-system/taxonomies.sass
+++ b/assets/sass/_theme/design-system/taxonomies.sass
@@ -35,7 +35,6 @@
         margin-bottom: var(--grid-gutter)
         margin-top: var(--grid-gutter)
         flex-wrap: wrap
-        // justify-content: end
     &--inline
         @include grid(3)
         margin-bottom: $spacing-5

--- a/assets/sass/_theme/design-system/taxonomies.sass
+++ b/assets/sass/_theme/design-system/taxonomies.sass
@@ -22,12 +22,6 @@
                 margin-left: $spacing-1
 
 .taxonomies-list
-    align-items: baseline
-    display: flex
-    margin-bottom: var(--grid-gutter)
-    margin-top: var(--grid-gutter)
-    flex-wrap: wrap
-    // justify-content: end
     > p
         @include meta
     .dropdown
@@ -35,13 +29,18 @@
     .taxonomy-categories
         ul
             @include list-reset
+    &--dropdown
+        align-items: baseline
+        display: flex
+        margin-bottom: var(--grid-gutter)
+        margin-top: var(--grid-gutter)
+        flex-wrap: wrap
+        // justify-content: end
     &--inline
+        @include grid(3)
+        margin-bottom: $spacing-5
         .taxonomy-categories
             ul
-                display: flex
-                flex-wrap: wrap
-                gap: var(--grid-gutter)
-                margin-left: 0
                 a
                     @include meta
     @include media-breakpoint-down(md)
@@ -54,10 +53,11 @@
                     a
                         padding-left: var(--grid-gutter)
     @include media-breakpoint-up(md)
-        gap: $spacing-3
-        .taxonomy-categories
-            min-width: max-content
-            margin-left: -$spacing-1
+        &--dropdown
+            gap: $spacing-3
+            .taxonomy-categories
+                min-width: max-content
+                margin-left: -$spacing-1
 
 .taxonomies-single
     &, ul

--- a/assets/sass/_theme/design-system/taxonomies.sass
+++ b/assets/sass/_theme/design-system/taxonomies.sass
@@ -35,6 +35,15 @@
     .taxonomy-categories
         ul
             @include list-reset
+    &--inline
+        .taxonomy-categories
+            ul
+                display: flex
+                flex-wrap: wrap
+                gap: var(--grid-gutter)
+                margin-left: 0
+                a
+                    @include meta
     @include media-breakpoint-down(md)
         flex-direction: column
         .dropdown 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -110,7 +110,8 @@ params:
   default:
     index:
       taxonomies:
-        layout: dropdown # dropdown | inline
+        show_taxonomies_title: true
+        layout: inline # dropdown | inline
     single:
       taxonomies:
         display: true

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -111,7 +111,7 @@ params:
     index:
       taxonomies:
         show_name: true
-        layout: inline # dropdown | inline
+        layout: dropdown # dropdown | inline
     single:
       taxonomies:
         display: true

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -23,7 +23,7 @@ markup:
     renderer:
       unsafe: true
 pagination:
-  pagerSize: 3
+  pagerSize: 36
 params:
   debug:
     active: false

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -110,7 +110,7 @@ params:
   default:
     index:
       taxonomies:
-        show_taxonomies_title: true
+        show_name: true
         layout: inline # dropdown | inline
     single:
       taxonomies:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -108,6 +108,9 @@ params:
 
   # SECTIONS
   default:
+    index:
+      taxonomies:
+        layout: dropdown # dropdown | inline
     single:
       taxonomies:
         display: true

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -23,7 +23,7 @@ markup:
     renderer:
       unsafe: true
 pagination:
-  pagerSize: 36
+  pagerSize: 3
 params:
   debug:
     active: false

--- a/layouts/partials/IsFirstPage
+++ b/layouts/partials/IsFirstPage
@@ -1,7 +1,7 @@
 {{ $is_first_page := false }}
 {{ $paginator := .Paginator }}
 
-{{ if $paginator}}
+{{ if $paginator }}
   {{ if eq $paginator.PageNumber 1 }}
     {{ $is_first_page = true }}
   {{ end }}

--- a/layouts/partials/IsFirstPage
+++ b/layouts/partials/IsFirstPage
@@ -7,4 +7,4 @@
   {{ end }}
 {{ end }}
 
-{{ return $is_first_page}}
+{{ return $is_first_page }}

--- a/layouts/partials/IsFirstPage
+++ b/layouts/partials/IsFirstPage
@@ -1,0 +1,10 @@
+{{ $is_first_page := false }}
+{{ $paginator := .Paginator }}
+
+{{ if $paginator}}
+  {{ if eq $paginator.PageNumber 1 }}
+    {{ $is_first_page = true }}
+  {{ end }}
+{{ end }}
+
+{{ return $is_first_page}}

--- a/layouts/partials/administrators/section.html
+++ b/layouts/partials/administrators/section.html
@@ -7,7 +7,9 @@
       "context" .
     ) }}
 
-  {{ partial "contents/list.html" . }}
+  {{ if (partial "IsFirstPage" .) }}
+    {{ partial "contents/list.html" . }}
+  {{ end }}
 
   <div class="container">
     {{ partial "persons/partials/list-by-role.html" . }}

--- a/layouts/partials/categories/section.html
+++ b/layouts/partials/categories/section.html
@@ -11,7 +11,9 @@
       "block_wrapped" true
     ) }}
 
-  {{ partial "contents/list.html" . }}
+  {{ if (partial "IsFirstPage" .) }}
+    {{ partial "contents/list.html" . }}
+  {{ end }}
 
   <div class="container">
     {{ partial "categories/section/categories.html" . }}

--- a/layouts/partials/diplomas/section.html
+++ b/layouts/partials/diplomas/section.html
@@ -7,7 +7,9 @@
       "context" .
     ) }}
 
-  {{ partial "contents/list.html" . }}
+  {{ if (partial "IsFirstPage" .) }}
+    {{ partial "contents/list.html" . }}
+  {{ end }}
 
   <div class="container">
     {{ partial "diplomas/partials/diplomas.html" ( dict "diplomas" .Paginator.Pages ) }}

--- a/layouts/partials/events/section.html
+++ b/layouts/partials/events/section.html
@@ -10,13 +10,13 @@
     {{ partial "events/section/exhibitions.html" $exhibitions }}
   {{ end }}
 
-  {{ partial "contents/list.html" . }}
-
   {{ if .Params.section_taxonomies }}
     <div class="container">
       {{ partial "taxonomies/section-list.html" . }}
     </div>
   {{ end }}
+
+  {{ partial "contents/list.html" . }}
 
   <div class="container events-programme" id="events-programme">
     {{ $per_page := site.Params.events.index.per_page }}

--- a/layouts/partials/exhibitions/section.html
+++ b/layouts/partials/exhibitions/section.html
@@ -5,7 +5,9 @@
       "context" .
     ) }}
 
-  {{ partial "contents/list.html" . }}
+  {{ if (partial "IsFirstPage" .) }}
+    {{ partial "contents/list.html" . }}
+  {{ end }}
 
   <div class="container">
     {{ partial "taxonomies/section-list.html" . }}

--- a/layouts/partials/locations/section.html
+++ b/layouts/partials/locations/section.html
@@ -6,7 +6,9 @@
       "context" .
     ) }}
 
-  {{ partial "contents/list.html" . }}
+  {{ if (partial "IsFirstPage" .) }}
+    {{ partial "contents/list.html" . }}
+  {{ end }}
 
   <div class="container">
     {{ partial "locations/partials/locations.html" . }}

--- a/layouts/partials/organizations/section.html
+++ b/layouts/partials/organizations/section.html
@@ -1,5 +1,4 @@
 {{- $is_organizations_block_present := false -}}
-{{ $paginator := .Paginator }}
 
 {{ range .Params.contents }}
   {{- if eq .template "organizations" -}}
@@ -23,7 +22,6 @@
 
   {{ if (partial "IsFirstPage" .) }}
     {{ partial "contents/list.html" . }}
-  {{ end }}
 
   <div class="container">
     {{- if not $is_organizations_block_present -}}

--- a/layouts/partials/organizations/section.html
+++ b/layouts/partials/organizations/section.html
@@ -21,10 +21,8 @@
     </div>
   {{ end }}
 
-  {{ if $paginator}}
-    {{ if eq $paginator.PageNumber 1 }}
-      {{ partial "contents/list.html" . }}
-    {{ end }}
+  {{ if (partial "IsFirstPage" .) }}
+    {{ partial "contents/list.html" . }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/organizations/section.html
+++ b/layouts/partials/organizations/section.html
@@ -22,6 +22,7 @@
 
   {{ if (partial "IsFirstPage" .) }}
     {{ partial "contents/list.html" . }}
+  {{ end }}
 
   <div class="container">
     {{- if not $is_organizations_block_present -}}

--- a/layouts/partials/organizations/section.html
+++ b/layouts/partials/organizations/section.html
@@ -1,4 +1,6 @@
 {{- $is_organizations_block_present := false -}}
+{{ $paginator := .Paginator }}
+
 {{ range .Params.contents }}
   {{- if eq .template "organizations" -}}
     {{- $is_organizations_block_present = true -}}
@@ -13,11 +15,20 @@
       "with_container" true
     ) }}
 
-  {{ partial "contents/list.html" . }}
+  {{ if .Params.section_taxonomies }}
+    <div class="container">
+      {{ partial "taxonomies/section-list.html" . }}
+    </div>
+  {{ end }}
+
+  {{ if $paginator}}
+    {{ if eq $paginator.PageNumber 1 }}
+      {{ partial "contents/list.html" . }}
+    {{ end }}
+  {{ end }}
 
   <div class="container">
     {{- if not $is_organizations_block_present -}}
-      {{ partial "taxonomies/section-list.html" . }}
       {{ partial "organizations/partials/organizations.html" . }}
       {{ partial "commons/pagination.html" . }}
     {{ end }}

--- a/layouts/partials/persons/section.html
+++ b/layouts/partials/persons/section.html
@@ -28,6 +28,16 @@
       "block_wrapped" $summary_block
     ) }}
 
+  {{ if .Params.section_taxonomies }}
+    <div class="container">
+      {{ partial "taxonomies/section-list.html" . }}
+    </div>
+  {{ end }}
+
+  {{ if (partial "IsFirstPage" .) }}
+    {{ partial "contents/list.html" . }}
+  {{ end }}
+
   <div class="container">
     {{- if not $is_block_persons_present -}}
       {{ partial "persons/section/persons-taxonomies.html" . }}

--- a/layouts/partials/persons/section.html
+++ b/layouts/partials/persons/section.html
@@ -1,5 +1,4 @@
 {{- $is_block_persons_present := false -}}
-{{ $paginator := .Paginator }}
 
 {{ range .Params.contents }}
   {{- if eq .template "persons" -}}

--- a/layouts/partials/persons/section.html
+++ b/layouts/partials/persons/section.html
@@ -1,4 +1,6 @@
 {{- $is_block_persons_present := false -}}
+{{ $paginator := .Paginator }}
+
 {{ range .Params.contents }}
   {{- if eq .template "persons" -}}
     {{- $is_block_persons_present = true -}}
@@ -26,11 +28,8 @@
       "block_wrapped" $summary_block
     ) }}
 
-  {{ partial "contents/list.html" . }}
-
   <div class="container">
     {{- if not $is_block_persons_present -}}
-      {{ partial "taxonomies/section-list.html" . }}
       {{ partial "persons/section/persons-taxonomies.html" . }}
       {{ partial "persons/partials/list.html" .Paginator.Pages }}
       {{ partial "commons/pagination.html" . }}

--- a/layouts/partials/posts/section.html
+++ b/layouts/partials/posts/section.html
@@ -1,3 +1,5 @@
+{{ $paginator := .Paginator }}
+
 {{ partial "posts/section/hero.html" . }}
 <div class="document-content">
   {{ partial "posts/section/summary.html" (dict
@@ -5,10 +7,19 @@
       "context" .
     ) }}
 
-  {{ partial "contents/list.html" . }}
+    {{ if .Params.section_taxonomies }}
+      <div class="container">
+        {{ partial "taxonomies/section-list.html" . }}
+      </div>
+    {{ end }}
+
+    {{ if $paginator}}
+      {{ if eq $paginator.PageNumber 1 }}
+        {{ partial "contents/list.html" . }}
+      {{ end }}
+    {{ end }}
 
   <div class="container">
-    {{ partial "taxonomies/section-list.html" . }}
     {{ partial "posts/partials/posts.html" . }}
     {{ partial "commons/pagination.html" . }}
   </div>

--- a/layouts/partials/posts/section.html
+++ b/layouts/partials/posts/section.html
@@ -13,10 +13,8 @@
       </div>
     {{ end }}
 
-    {{ if $paginator}}
-      {{ if eq $paginator.PageNumber 1 }}
-        {{ partial "contents/list.html" . }}
-      {{ end }}
+    {{ if (partial "IsFirstPage" .) }}
+      {{ partial "contents/list.html" . }}
     {{ end }}
 
   <div class="container">

--- a/layouts/partials/posts/section.html
+++ b/layouts/partials/posts/section.html
@@ -1,5 +1,3 @@
-{{ $paginator := .Paginator }}
-
 {{ partial "posts/section/hero.html" . }}
 <div class="document-content">
   {{ partial "posts/section/summary.html" (dict

--- a/layouts/partials/projects/section.html
+++ b/layouts/partials/projects/section.html
@@ -1,5 +1,3 @@
-{{ $paginator := .Paginator }}
-
 {{ partial "projects/section/hero.html" . }}
 <div class="document-content">
   {{ partial "projects/section/summary.html" (dict

--- a/layouts/partials/projects/section.html
+++ b/layouts/partials/projects/section.html
@@ -13,11 +13,9 @@
       </div>
     {{ end }}
 
-  {{ if $paginator}}
-    {{ if eq $paginator.PageNumber 1 }}
+    {{ if (partial "IsFirstPage" .) }}
       {{ partial "contents/list.html" . }}
     {{ end }}
-  {{ end }}
   
   <div class="container">
     {{ partial "projects/partials/projects.html" . }}

--- a/layouts/partials/projects/section.html
+++ b/layouts/partials/projects/section.html
@@ -1,14 +1,25 @@
+{{ $paginator := .Paginator }}
+
 {{ partial "projects/section/hero.html" . }}
 <div class="document-content">
   {{ partial "projects/section/summary.html" (dict
       "with_container" true
       "context" .
     ) }}
-    
-  {{ partial "contents/list.html" . }}
+
+    {{ if .Params.section_taxonomies }}
+      <div class="container">
+        {{ partial "taxonomies/section-list.html" . }}
+      </div>
+    {{ end }}
+
+  {{ if $paginator}}
+    {{ if eq $paginator.PageNumber 1 }}
+      {{ partial "contents/list.html" . }}
+    {{ end }}
+  {{ end }}
   
   <div class="container">
-    {{ partial "taxonomies/section-list.html" . }}
     {{ partial "projects/partials/projects.html" . }}
     {{ partial "commons/pagination.html" . }}
   </div>

--- a/layouts/partials/publications/section.html
+++ b/layouts/partials/publications/section.html
@@ -1,6 +1,9 @@
 {{ partial "publications/section/hero.html" . }}
 <div class="document-content">
-  {{ partial "contents/list.html" . }}
+
+  {{ if (partial "IsFirstPage" .) }}
+    {{ partial "contents/list.html" . }}
+  {{ end }}
 
   <div class="container">
     {{ partial "publications/single/statistics.html" . }}

--- a/layouts/partials/researchers/section.html
+++ b/layouts/partials/researchers/section.html
@@ -7,7 +7,9 @@
       "context" .
     ) }}
 
-  {{ partial "contents/list.html" . }}
+  {{ if (partial "IsFirstPage" .) }}
+    {{ partial "contents/list.html" . }}
+  {{ end }}
 
   <div class="container">
     {{ partial "persons/partials/list-by-role.html" . }}

--- a/layouts/partials/taxonomies/section-list.html
+++ b/layouts/partials/taxonomies/section-list.html
@@ -18,6 +18,7 @@
               <div class="extendable taxonomy-categories" id="categories-{{ .name | anchorize }}" data-extendable-close-siblings="true" data-extendable-auto-close="true">
           {{ else }}
             <div class="taxonomy-categories">
+              <span>{{ .name }}</span>
           {{ end }}
             <ul>
             {{ range .categories }}

--- a/layouts/partials/taxonomies/section-list.html
+++ b/layouts/partials/taxonomies/section-list.html
@@ -18,7 +18,7 @@
               <div class="extendable taxonomy-categories" id="categories-{{ .name | anchorize }}" data-extendable-close-siblings="true" data-extendable-auto-close="true">
           {{ else }}
             <div class="taxonomy-categories">
-              <span>{{ .name }}</span>
+              {{ if site.Params.default.index.taxonomies.show_name }}<span>{{ .name }}</span>{{ end }}
           {{ end }}
             <ul>
             {{ range .categories }}

--- a/layouts/partials/taxonomies/section-list.html
+++ b/layouts/partials/taxonomies/section-list.html
@@ -3,29 +3,36 @@
 {{ $categories := where site.Pages "Section" $categories_kind }}
 {{ $taxonomies := .Params.section_taxonomies }}
 {{ $option := index site.Params $kind }}
+{{ $layout := site.Params.default.index.taxonomies.layout }}
 
 {{ with $option.index.taxonomies }}
-  <div class="taxonomies-list">
+  <div class="taxonomies-list taxonomies-list--{{ $layout }}">
     {{ if $taxonomies }}
       {{- range $taxonomies -}}
         {{ if .categories }}
-          <div class="dropdown">
-            <button aria-controls="categories-{{ .name | anchorize }}" aria-expanded="false">
-              {{ .name }}
-            </button>
-            <div class="extendable taxonomy-categories" id="categories-{{ .name | anchorize }}" data-extendable-close-siblings="true" data-extendable-auto-close="true">
-              <ul>
-                {{ range .categories }}
-                  {{ $category := site.GetPage .path }}
-                  {{ with $category }}
-                    <li>
-                      <a href="{{ .Permalink }}">{{ .Title }}</a>
-                    </li>
-                  {{ end }}
-                {{ end }}
+          {{ if eq $layout "dropdown" }}
+            <div class="dropdown">
+              <button aria-controls="categories-{{ .name | anchorize }}" aria-expanded="false">
+                {{ .name }}
+              </button>
+              <div class="extendable taxonomy-categories" id="categories-{{ .name | anchorize }}" data-extendable-close-siblings="true" data-extendable-auto-close="true">
+          {{ else }}
+            <div class="taxonomy-categories">
+          {{ end }}
+            <ul>
+            {{ range .categories }}
+              {{ $category := site.GetPage .path }}
+              {{ with $category }}
+                <li>
+                  <a href="{{ .Permalink }}">{{ .Title }}</a>
+                </li>
+              {{ end }}
+            {{ end }}
               </ul>
             </div>
-          </div>
+          {{ if eq $layout "dropdown" }}
+            </div>
+          {{ end }}
         {{- end -}}
       {{- end -}}
     {{- end -}}

--- a/layouts/partials/teachers/section.html
+++ b/layouts/partials/teachers/section.html
@@ -7,7 +7,9 @@
       "context" .
     ) }}
 
-  {{ partial "contents/list.html" . }}
+  {{ if (partial "IsFirstPage" .) }}
+    {{ partial "contents/list.html" . }}
+  {{ end }}
 
   <div class="container">
     {{ partial "persons/partials/list-by-role.html" . }}

--- a/layouts/partials/volumes/section.html
+++ b/layouts/partials/volumes/section.html
@@ -6,5 +6,7 @@
     {{ partial "commons/pagination.html" . }}
   </div>
 
-  {{ partial "contents/list.html" . }}
+  {{ if (partial "IsFirstPage" .) }}
+    {{ partial "contents/list.html" . }}
+  {{ end }}
 </div>


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout d'une option `layout` aux taxonomies dans les sections : drodown / inline (besoin Beaux Arts)
- layout inline
- affichage ou non en mode taxo

On en profite aussi pour : 
- passer les taxo au-dessus des blocs dans les sections
- mettre les blocs uniquement sur la première page

TODO : permettre l'override en fonction des objets (?)

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1314/fr/actualites/`

## URL de test du site Beaux Arts

`http://localhost:1313/magazine/`

## Screenshots

![Capture d’écran 2025-05-22 à 14 36 49](https://github.com/user-attachments/assets/02557071-51ed-4697-9632-380058e85fa3)
![Capture d’écran 2025-05-22 à 14 37 45](https://github.com/user-attachments/assets/5e0f3822-e429-440d-b4b3-e7153ff6ab80)

