### PR TITLE
Enlever `nav` du selecteur sass pour `.primary-menu`

### DIFF
--- a/assets/sass/_theme/design-system/header.sass
+++ b/assets/sass/_theme/design-system/header.sass
@@ -216,7 +216,7 @@ body
             opacity: 0
 
 header#document-header
-    nav.primary-menu
+    .primary-menu
         padding-bottom: $header-nav-padding-y
         padding-top: $header-nav-padding-y
         @include media-breakpoint-up(desktop)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Pour faciliter les ajustements d'architecture mais garder l'héritage des styles


## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)
https://github.com/osunyorg/theme/issues/1079 


## URL de test sur example.osuny.org
example.osuny.org

## URL de test du site (optionnel)



## Screenshots


