### PR TITLE
Liens d'évitement vers le menu et la recherche

### DIFF
--- a/assets/sass/_theme/design-system/a11y.sass
+++ b/assets/sass/_theme/design-system/a11y.sass
@@ -17,9 +17,13 @@
     &:focus-within
         background: white
         transform: translateY(0)
+    @include media-breakpoint-up(desktop)
+        li
+            &.nav-accessibility__item--mobile
+                display: none
     @include media-breakpoint-down(desktop)
         li
-            &.nav-accessibility__menu, &.nav-accessibility__search
+            &.nav-accessibility__item--desktop
                 display: none
 
 .transcription

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -84,6 +84,7 @@ commons:
     menu: Go to menu
     menu_lang: Display language menu (English is currently selected)
     search: Go to search
+    menu_search: Go to menu and search
     shortcut_navigation: Navigation Links
     transcription: Transcription
     map_transcription : Transcription

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -80,6 +80,7 @@ commons:
     menu: Accéder au menu
     menu_lang: Accéder au menu des langues (actuellement Français)
     search: Accéder à la recherche
+    menu_search: Accéder au menu et à la recherche
     shortcut_navigation: Navigation d'accès rapide
     transcription: Transcription
     map_transcription : Données textuelles

--- a/i18n/pt.yml
+++ b/i18n/pt.yml
@@ -78,6 +78,7 @@ commons:
     menu: Acessar o menu
     menu_lang: Acessar o menu de idiomas (atualmente Francês)
     search: Acessar a busca
+    menu_search: Acessar o menu e busca
     shortcut_navigation: Navegação de acesso rápido
     transcription: Transcrição
     credits: "Direitos reservados: "

--- a/layouts/partials/commons/search/button.html
+++ b/layouts/partials/commons/search/button.html
@@ -1,7 +1,8 @@
 {{ $position := . }}
 {{ if and site.Params.search.active (in site.Params.search.positions $position) }}
   <button
-      class="search-button search-button--{{ $position }}" 
+      id="search-button-{{ $position }}"
+      class="search-button search-button--{{ $position }}"
       aria-expanded="false" 
       aria-label='{{- i18n (printf "commons.search.title") -}}'>
     <span>{{- i18n (printf "commons.search.title") -}}</span>

--- a/layouts/partials/header/accessibility.html
+++ b/layouts/partials/header/accessibility.html
@@ -1,9 +1,18 @@
 <nav aria-label="{{ i18n "commons.accessibility.shortcut_navigation"}}" class="nav-accessibility" id="nav-accessibility">
   <ul>
-    <li><a href="#main">{{ i18n "commons.accessibility.main_content" }}</a></li>
-    <li class="nav-accessibility__menu"><a href="#navigation">{{ i18n "commons.accessibility.menu" }}</a></li>
+    <li>
+      <a href="#main">{{ i18n "commons.accessibility.main_content" }}</a>
+    </li>
+    <li class="nav-accessibility__item--desktop">
+      <a href="#navigation">{{ i18n "commons.accessibility.menu" }}</a>
+    </li>
+    <li class="nav-accessibility__item--mobile">
+      <a href="#header-button">{{ i18n "commons.accessibility.menu" }}</a>
+    </li>
     {{ if site.Params.search.active }}
-      <li class="nav-accessibility__search"><a href="#search-button">{{ i18n "commons.accessibility.search" }}</a></li>
+      <li class="nav-accessibility__item--desktop">
+        <a href="#search-button">{{ i18n "commons.accessibility.search" }}</a>
+      </li>
     {{ end }}
   </ul>
 </nav>

--- a/layouts/partials/header/accessibility.html
+++ b/layouts/partials/header/accessibility.html
@@ -1,4 +1,6 @@
-<nav aria-label="{{ i18n "commons.accessibility.shortcut_navigation"}}" class="nav-accessibility" id="nav-accessibility">
+{{ $first_search := index (site.Params.search.positions) 0 }}
+
+<nav aria-label="{{ i18n "commons.accessibility.shortcut_navigation" }}" class="nav-accessibility" id="nav-accessibility">
   <ul>
     <li>
       <a href="#main">{{ i18n "commons.accessibility.main_content" }}</a>
@@ -6,13 +8,25 @@
     <li class="nav-accessibility__item--desktop">
       <a href="#navigation">{{ i18n "commons.accessibility.menu" }}</a>
     </li>
-    <li class="nav-accessibility__item--mobile">
-      <a href="#header-button">{{ i18n "commons.accessibility.menu" }}</a>
-    </li>
-    {{ if site.Params.search.active }}
-      <li class="nav-accessibility__item--desktop">
-        <a href="#search-button">{{ i18n "commons.accessibility.search" }}</a>
+    {{ if and site.Params.search.active (eq $first_search (or "primary" "upper-menu"))}}
+      <!-- Search in burger menu -->
+      <li class="nav-accessibility__item--mobile">
+        <a href="#header-button">{{ i18n "commons.accessibility.menu_search" }}</a>
       </li>
+      <li class="nav-accessibility__item--desktop">
+        <a href="#search-button-{{ $first_search }}">{{ i18n "commons.accessibility.search" }}</a>
+      </li>
+    {{ else }}
+      <!-- Link to burger menu without search -->
+      <li class="nav-accessibility__item--mobile">
+        <a href="#header-button">{{ i18n "commons.accessibility.menu" }}</a>
+      </li>
+      {{ if and site.Params.search.active $first_search }}
+        <!-- Search always accessible -->
+        <li>
+          <a href="#search-button-{{ $first_search }}">{{ i18n "commons.accessibility.search" }}</a>
+        </li>
+      {{ end }}
     {{ end }}
   </ul>
 </nav>

--- a/layouts/partials/header/button.html
+++ b/layouts/partials/header/button.html
@@ -1,4 +1,5 @@
 <button type="button"
+    id="header-button"
     aria-controls="navigation"
     aria-expanded="false"
     aria-label="{{ i18n "commons.menu.label" }}"


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [x] Ajustement
- [ ] Rangement

## Description
Quelques ajustements concernant les liens d'évitement.

Pour ne pas avoir de perte d'information sur mobile (accessibilité), j'ai rajouté un lien d'évitement vers le bouton (burger) du menu (visible uniquement sur mobile).

Concernant le raccourci vers la recherche, il n'était plus fonctionnel (pas d'ID sur le bouton de recherche). 
Comme il peut y avoir plusieurs boutons dans la même page, l'id ajouté dépend de la config de position. 
Pour les liens d'évitement, j'ai fait en sorte de cibler le bouton de la première option de la config.
Sachant que sur mobile, si c'est l'option "primary" ou "upper-menu" qui est utilisé, sur mobile le bouton est caché, j'ai fait en sorte mutualisé le lien avec le menu.

Il y a donc 3 cas gérés (en dehors du lien vers le : 

- Si pas de recherche activé sur le site 
 -> bouton menu mobile

- Si la recherche dans menu
 -> bouton menu et recherche mobile
 -> recherche desktop

- Recherche ailleurs
 -> bouton menu mobile
 -> recherche tout le temps 

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)
Cf issues https://github.com/osunyorg/theme/issues/1059 et https://github.com/osunyorg/theme/issues/1058


## URL de test sur example.osuny.org

example.osuny.org

## URL de test du site (optionnel)
https://metropole.rennes.osuny.site/



