### PR TITLE
Fil d'ariane réduit en mobile

### DIFF
--- a/assets/js/theme/design-system/extendables.js
+++ b/assets/js/theme/design-system/extendables.js
@@ -1,4 +1,4 @@
-import { a11yClick } from '../utils/a11y';
+import { a11yClick, getFocusableElements } from '../utils/a11y';
 
 var osuny = window.osuny || {};
 
@@ -13,7 +13,8 @@ osuny.Extendable = function (element) {
     this.options = {
         // This attribute determine if extendable should close others when opened
         closeSiblings: this.element.getAttribute('data-extendable-close-siblings'),
-        autoClose: this.element.getAttribute('data-extendable-auto-close')
+        autoClose: this.element.getAttribute('data-extendable-auto-close'),
+        focusFirst: this.element.getAttribute('data-extendable-focus-first')
     };
 
     this.listen();
@@ -73,6 +74,17 @@ osuny.Extendable.prototype.toggle = function (opened, fromOutside) {
     if (!this.state.opened && this.state.openedByButton && !fromOutside) {
         this.state.openedByButton.focus();
         this.state.openedByButton = null;
+    }
+
+    if (this.state.opened && this.options.focusFirst) {
+        this.focusFirstElement();
+    }
+};
+
+osuny.Extendable.prototype.focusFirstElement = function () {
+    var focusableElements = getFocusableElements(this.element);
+    if (focusableElements.length > 0) {
+        focusableElements[0].focus();
     }
 };
 

--- a/assets/js/theme/utils/a11y.js
+++ b/assets/js/theme/utils/a11y.js
@@ -9,7 +9,8 @@ var osuny = window.osuny || {},
     ariaHideBodyChildren,
     setDefaultAltToImages,
     parentQuerySelector,
-    setDescribedBy;
+    setDescribedBy,
+    getFocusableElements;
 
 a11yClick = function (element, action) {
     element.addEventListener('click', action);
@@ -86,6 +87,12 @@ setDescribedBy = function () {
     });
 };
 
+getFocusableElements = function (element) {
+    var focusables = 'a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]), [contenteditable="true"]';
+    var elements = element.querySelectorAll(focusables);
+    return Array.from(elements).filter(el => !el.disabled && el.tabIndex >= 0);
+}
+
 setDescribedBy();
 
 export {
@@ -94,5 +101,6 @@ export {
     setAriaVisibility,
     ariaHideBodyChildren,
     setDefaultAltToImages,
-    parentQuerySelector
+    parentQuerySelector,
+    getFocusableElements
 };

--- a/assets/js/theme/utils/focus-trap.js
+++ b/assets/js/theme/utils/focus-trap.js
@@ -1,3 +1,5 @@
+import { getFocusableElements } from '../utils/a11y';
+
 export function focusTrap(event, element, isOpened) {
     if (!isOpened || event.key !== 'Tab') {
         return;
@@ -13,11 +15,12 @@ export function focusTrap(event, element, isOpened) {
     handleTabLoop(event, firstFocusable, lastFocusable, element);
 }
 
-function getFocusableElements(element) {
-    const focusables = 'a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]), [contenteditable="true"]';
-    const elements = element.querySelectorAll(focusables);
-    return Array.from(elements).filter(el => !el.disabled && el.tabIndex >= 0);
-}
+// // Replace by getFocusableElements
+// function getFocusableElements(element) {
+//     const focusables = 'a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]), [contenteditable="true"]';
+//     const elements = element.querySelectorAll(focusables);
+//     return Array.from(elements).filter(el => !el.disabled && el.tabIndex >= 0);
+// }
 
 function handleTabLoop(event, firstFocusable, lastFocusable, element) {
     const goingBackward = event.shiftKey;

--- a/assets/js/theme/utils/focus-trap.js
+++ b/assets/js/theme/utils/focus-trap.js
@@ -15,13 +15,6 @@ export function focusTrap(event, element, isOpened) {
     handleTabLoop(event, firstFocusable, lastFocusable, element);
 }
 
-// // Replace by getFocusableElements
-// function getFocusableElements(element) {
-//     const focusables = 'a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]), [contenteditable="true"]';
-//     const elements = element.querySelectorAll(focusables);
-//     return Array.from(elements).filter(el => !el.disabled && el.tabIndex >= 0);
-// }
-
 function handleTabLoop(event, firstFocusable, lastFocusable, element) {
     const goingBackward = event.shiftKey;
     const focusTarget = goingBackward ? lastFocusable : firstFocusable;

--- a/assets/sass/_theme/design-system/breadcrumb.sass
+++ b/assets/sass/_theme/design-system/breadcrumb.sass
@@ -28,6 +28,9 @@
         button
             display: none
     @include media-breakpoint-down(desktop)
+        li
+            a
+                text-decoration-color: var(--color-border)
         &--extendable
             ol
                 height: auto
@@ -44,6 +47,8 @@
                         display: inline
                         padding-left: 0
                         white-space: initial
+                        > a, > span
+                            display: inline-block
                 // When expanded
                 &[aria-expanded="true"]
                     display: none

--- a/assets/sass/_theme/design-system/breadcrumb.sass
+++ b/assets/sass/_theme/design-system/breadcrumb.sass
@@ -25,27 +25,31 @@
 
 .breadcrumb-nav
     &--extendable
-        ol
-            height: auto
         button
-            @include button-reset
-            @include link
-            @include meta
-            padding: 0
-            // When not expanded
-            + .extendable
-                display: none
-                li
-                    display: inline
-                    padding-left: 0
-                    white-space: initial
-            // When expanded
-            &[aria-expanded="true"]
-                display: none
+            display: none
+    @include media-breakpoint-down(desktop)
+        &--extendable
+            ol
+                height: auto
+            button
+                @include button-reset
+                @include link
+                @include meta
+                display: block
+                padding: 0
+                // When not expanded
                 + .extendable
-                    display: block
-    &:where:not(.breadcrumb-nav--extendable)
-        @include media-breakpoint-down(desktop)
+                    display: none
+                    li
+                        display: inline
+                        padding-left: 0
+                        white-space: initial
+                // When expanded
+                &[aria-expanded="true"]
+                    display: none
+                    + .extendable
+                        display: block
+        &:where:not(.breadcrumb-nav--extendable)
             margin-left: var(--grid-gutter-negative)
             margin-right: var(--grid-gutter-negative)
             > ol

--- a/assets/sass/_theme/design-system/breadcrumb.sass
+++ b/assets/sass/_theme/design-system/breadcrumb.sass
@@ -24,8 +24,29 @@
                 color: $breadcrumb-icon-color
 
 .breadcrumb-nav
-    @include media-breakpoint-down(desktop)
-        margin-left: var(--grid-gutter-negative)
-        margin-right: var(--grid-gutter-negative)
-        > ol
-            padding: 0 var(--grid-gutter)
+    &--extendable
+        ol
+            height: auto
+        button
+            @include button-reset
+            @include link
+            @include meta
+            padding: 0
+            // When not expanded
+            + .extendable
+                display: none
+                li
+                    display: inline
+                    padding-left: 0
+                    white-space: initial
+            // When expanded
+            &[aria-expanded="true"]
+                display: none
+                + .extendable
+                    display: block
+    &:where:not(.breadcrumb-nav--extendable)
+        @include media-breakpoint-down(desktop)
+            margin-left: var(--grid-gutter-negative)
+            margin-right: var(--grid-gutter-negative)
+            > ol
+                padding: 0 var(--grid-gutter)

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -69,7 +69,7 @@ params:
           source: "Summary" # "Summary" | "meta_description"
           truncate: 125
   breadcrumb:
-    extendable: true
+    extendable: false
     position: hero-start #  hero-start |  hero-end | after-hero | none
   design:
     force_full_width: false

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -70,6 +70,7 @@ params:
           truncate: 125
   breadcrumb:
     position: hero-start #  hero-start |  hero-end | after-hero | none
+    extendable: true
   design:
     force_full_width: false
   summary:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -69,8 +69,8 @@ params:
           source: "Summary" # "Summary" | "meta_description"
           truncate: 125
   breadcrumb:
-    position: hero-start #  hero-start |  hero-end | after-hero | none
     extendable: true
+    position: hero-start #  hero-start |  hero-end | after-hero | none
   design:
     force_full_width: false
   summary:

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -97,7 +97,9 @@ commons:
     other: Auteur·rices
   backtotop: Haut de page
   biography: Biographie
-  breadcrumb: Fil d’ariane
+  breadcrumb: 
+    show: Voir le fil d'ariane
+    title: Fil d’ariane
   click_to_copy:
     aria_label: Cliquez pour copier {{ .description }}
     button_title: Cliquez pour copier

--- a/layouts/partials/header/breadcrumbs.html
+++ b/layouts/partials/header/breadcrumbs.html
@@ -1,8 +1,17 @@
+{{ $is_extendable := site.Params.breadcrumb.extendable }}
+
 {{ if .Params.breadcrumbs }}
-  <nav class="breadcrumb-nav" aria-label="{{ i18n "commons.breadcrumb" }}">
+  <nav class="breadcrumb-nav {{ if $is_extendable }} breadcrumb-nav--extendable{{ end }}" aria-label="{{ i18n "commons.breadcrumb.title" }}">
+
+    {{ if $is_extendable }}
+      <button class="link" aria-controls="breadcrumb" aria-expanded="false">{{ i18n "commons.breadcrumb.show" }}</button>
+    {{ end }}
+
     {{- $path := strings.TrimSuffix "/" .RelPermalink -}}
     {{- $length := len (split $path "/") }}
-    <ol itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb">
+    <ol id="breadcrumb"
+        itemscope itemtype="https://schema.org/BreadcrumbList" 
+        class="breadcrumb {{ if $is_extendable }}extendable{{ end }}">
       {{ range $index, $item := .Params.breadcrumbs }}
         <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="breadcrumb-item{{- if not $item.path }} active{{ end }}"{{- if not $item.path }} aria-current="page"{{ end }}>
           {{- if $item.path -}}

--- a/layouts/partials/header/breadcrumbs.html
+++ b/layouts/partials/header/breadcrumbs.html
@@ -11,7 +11,9 @@
     {{- $length := len (split $path "/") }}
     <ol id="breadcrumb"
         itemscope itemtype="https://schema.org/BreadcrumbList" 
-        class="breadcrumb {{ if $is_extendable }}extendable{{ end }}">
+        class="breadcrumb {{ if $is_extendable }}extendable{{ end }}"
+        {{ if $is_extendable }} data-extendable-focus-first="true" {{ end }}
+        >
       {{ range $index, $item := .Params.breadcrumbs }}
         <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="breadcrumb-item{{- if not $item.path }} active{{ end }}"{{- if not $item.path }} aria-current="page"{{ end }}>
           {{- if $item.path -}}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Suite à l'audit RGAA réalisé par Ideance pour la Metropôle de Rennes, le fil d'ariane en mobile ne répond pas au critère : 

> 10.11
> 
> Pour chaque page web, les contenus peuvent-ils être présentés sans perte d’information ou de fonctionnalité et sans avoir recours soit à un défilement vertical pour une fenêtre ayant une hauteur de 256 px, soit à un défilement horizontal pour une fenêtre ayant une largeur de 320 px (hors cas particuliers) ?

Temesis ne partage pas que le scroll horizontal du fil d'ariane en mobile soit une non-conformité. La solution s'oriente vers une option configurable pour chaque site :

```
params:
  breadcrumb:
    extendable: false
```

En attendant un travail de migration plus fine sur les sites existants, la configuration reste à "faux" par défaut.

## Comportement

Le comportement du fil d'ariane est calqué sur le DSFR : [https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/fil-d-ariane/](https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/fil-d-ariane/)


## Screenshots

Pas d'influence en desktop : 

<img width="1057" alt="Capture d’écran 2025-05-26 à 12 23 45" src="https://github.com/user-attachments/assets/b5cf0572-edc6-425e-a6d0-1e821d75e429" />

En mobile un bouton apparaît : 

<img width="324" alt="Capture d’écran 2025-05-26 à 12 21 09" src="https://github.com/user-attachments/assets/26f57100-ee6f-4904-87bf-0b1128ee9295" />

<img width="321" alt="Capture d’écran 2025-05-26 à 12 23 39" src="https://github.com/user-attachments/assets/fc9ccfc8-3ff0-4dc6-b745-e716993a3195" />


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱