### PR TITLE
Alignement du texte du dropdown des formations

### DIFF
--- a/assets/sass/_theme/sections/diplomas.sass
+++ b/assets/sass/_theme/sections/diplomas.sass
@@ -80,6 +80,8 @@ ul.diplomas
         a
             font-size: $body-size
             line-height: $body-line-height
+            @include media-breakpoint-down(desktop)
+                justify-content: flex-end
         @include media-breakpoint-up(desktop)
             left: auto
             right: 0

--- a/assets/sass/_theme/sections/diplomas.sass
+++ b/assets/sass/_theme/sections/diplomas.sass
@@ -79,9 +79,8 @@ ul.diplomas
     .dropdown-menu
         a
             font-size: $body-size
+            justify-content: flex-end
             line-height: $body-line-height
-            @include media-breakpoint-down(desktop)
-                justify-content: flex-end
         @include media-breakpoint-up(desktop)
             left: auto
             right: 0


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Les dropdowns des formations ne s'alignaient plus correctement à droite du fait de la rationalisation des dropdowns (mobile et desktop), il faut rajouter un `justify-content: flex-end` pour permettre l'alignement désiré.

![Capture d’écran 2025-05-26 à 12 40 57](https://github.com/user-attachments/assets/59079ca2-9f53-495e-a7cb-8edb3482d50b) ![Capture d’écran 2025-05-26 à 12 41 47](https://github.com/user-attachments/assets/77d2c1d9-a6e8-4802-ba94-a15773bc4dc4)

![image](https://github.com/user-attachments/assets/327b0777-62a2-47dd-b688-1bf44712ad01)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1314/fr/offre-de-formation/`

## URL de test du site Beaux Arts

`http://localhost:1313/formations/`

## Screenshots

Mobile :
![Capture d’écran 2025-05-26 à 12 40 46](https://github.com/user-attachments/assets/fcf88798-1113-4c4b-b247-f9220829ecd6)  ![Capture d’écran 2025-05-26 à 12 45 51](https://github.com/user-attachments/assets/31f69081-e8fa-4e7f-9c9a-2ebf7114115b)

Desktop : 
![Capture d’écran 2025-05-26 à 12 46 31](https://github.com/user-attachments/assets/92d47ca8-cad3-4b0b-81c5-46fb7e666220)
![Capture d’écran 2025-05-26 à 12 47 21](https://github.com/user-attachments/assets/f528bb56-ce96-4701-b3ea-1a5e36e7654f)