### PR TITLE
Carte d'organisations : masquer le placeholder d'une organisation sans image

### DIFF
--- a/assets/sass/_theme/blocks/organizations.sass
+++ b/assets/sass/_theme/blocks/organizations.sass
@@ -22,6 +22,8 @@
                     width: columns(2)
                 .media
                     margin-bottom: 0
+                    &:empty
+                        display: none
                 .organization-content
                     padding: $spacing-1 $spacing-2
                     width: 100%
@@ -33,6 +35,7 @@
                 .organization-summary
                     margin-bottom: 0
                     margin-top: $spacing-1
+                
             &-content
                 margin: 0
                 width: 100%


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Masquer le placeholder d'une organisation sans image.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots

Avant : 

<img width="243" alt="image" src="https://github.com/user-attachments/assets/3e17044a-ffff-4bb9-8c9e-b8154da67cd5" />

Après : 

<img width="216" alt="image" src="https://github.com/user-attachments/assets/3842fa1c-448f-4659-9491-b10f5e5c35af" />



