### PR TITLE
Séparation des locales des backlinks entre personnes et organisations

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -315,6 +315,11 @@ formats:
   gz: Compressed archive
   tar: Compressed archive
 organizations:
+  backlinks:
+    events: Events mentioning
+    pages: Pages mentioning
+    posts: Posts mentioning
+    projects: Projects mentioning
   count:
     one: "1 organization"
     other: "{{ .Count }} organizations"

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -195,6 +195,12 @@ commons:
     upper: Menu d'accès rapide
   more: En savoir plus
   more_aria: En savoir plus sur “{{ .Title }}“
+  organizations:
+    backlinks:
+      events: Événements mentionnant
+      pages: Pages mentionnant
+      posts: Actualités mentionnant
+      projects: Projets mentionnant
   pagination:
     first: Première page
     label: Pagination

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -195,12 +195,6 @@ commons:
     upper: Menu d'accès rapide
   more: En savoir plus
   more_aria: En savoir plus sur “{{ .Title }}“
-  organizations:
-    backlinks:
-      events: Événements mentionnant
-      pages: Pages mentionnant
-      posts: Actualités mentionnant
-      projects: Projets mentionnant
   pagination:
     first: Première page
     label: Pagination
@@ -344,6 +338,11 @@ organizations:
     other: "{{ .Count }} organisations"
   logo: Logo
   none: Aucune organisation
+  backlinks:
+    events: Événements mentionnant
+    pages: Pages mentionnant
+    posts: Actualités mentionnant
+    projects: Projets mentionnant
 pages:
   count:
     one: "1 page"

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -333,16 +333,16 @@ formats:
   gz: Compressed archive
   tar: Compressed archive
 organizations:
-  count:
-    one: "1 organisation"
-    other: "{{ .Count }} organisations"
-  logo: Logo
-  none: Aucune organisation
   backlinks:
     events: Événements mentionnant
     pages: Pages mentionnant
     posts: Actualités mentionnant
     projects: Projets mentionnant
+  count:
+    one: "1 organisation"
+    other: "{{ .Count }} organisations"
+  logo: Logo
+  none: Aucune organisation
 pages:
   count:
     one: "1 page"

--- a/i18n/pt.yml
+++ b/i18n/pt.yml
@@ -266,6 +266,14 @@ formats:
   gz: Arquivo compactado
   tar: Arquivo compactado
 organizations:
+  backlinks:
+    events: Eventos mencionando
+    pages: Páginas mencionando
+    posts: Notícias mencionando
+    projects: Projetos mencionando
+  count:
+    one: "1 organização"
+    other: "{{ .Count }} organizações"
   logo: Logotipo
   none: Nenhuma organização
 pages:

--- a/i18n/pt.yml
+++ b/i18n/pt.yml
@@ -82,6 +82,7 @@ commons:
     transcription: Transcrição
     credits: "Direitos reservados: "
   search:
+    label: Pesquisa
     title: Buscar
     close: Fechar a busca
   backtotop: Topo da página

--- a/layouts/partials/contents/backlinks.html
+++ b/layouts/partials/contents/backlinks.html
@@ -1,9 +1,11 @@
 {{ $about := .Title }}
 {{ $params := "" }}
+{{ $type := .Type }}
 
 <div class="backlinks">
   {{ with .Params.backlinks.current_website }}
     {{ with .events }}
+      {{ $title := i18n (printf "%s.backlinks.events" $type) }}
       {{ $params = partial "GetLayoutAndOptions" (dict 
           "param" "persons.single.events"
           "default" "events.index"
@@ -13,7 +15,7 @@
           "top" (dict
             "active" true
             "title" (dict
-              "value" (printf "%s %s" (i18n "persons.backlinks.events") $about)
+              "value" (printf "%s %s" $title $about)
               "heading" 2
             )
           )
@@ -31,6 +33,7 @@
       ) }}
     {{ end }}
     {{ with .pages }}
+      {{ $title := i18n (printf "%s.backlinks.pages" $type) }}
       {{ $params = partial "GetLayoutAndOptions" (dict 
           "param" "persons.single.pages"
           "default" "pages.index"
@@ -40,7 +43,7 @@
           "top" (dict
             "active" true
             "title" (dict
-              "value" (printf "%s %s" (i18n "persons.backlinks.pages") $about)
+              "value" (printf "%s %s" $title $about)
               "heading" 2
             )
           )
@@ -58,6 +61,7 @@
       ) }}
     {{ end }}
     {{ with .projects }}
+      {{ $title := i18n (printf "%s.backlinks.projects" $type) }}
       {{ $params = partial "GetLayoutAndOptions" (dict 
           "param" "persons.single.projects"
           "default" "projects.index"
@@ -67,7 +71,7 @@
           "top" (dict
             "active" true
             "title" (dict
-              "value" (printf "%s %s" (i18n "persons.backlinks.projects") $about)
+              "value" (printf "%s %s" $title $about)
               "heading" 2
             )
           )
@@ -85,6 +89,7 @@
       ) }}
     {{ end }}
     {{ with .posts }}
+      {{ $title := i18n (printf "%s.backlinks.posts" $type) }}
       {{ $params = partial "GetLayoutAndOptions" (dict 
           "param" "persons.single.posts"
           "default" "posts.index"
@@ -94,7 +99,7 @@
           "top" (dict
             "active" true
             "title" (dict
-              "value" (printf "%s %s" (i18n "persons.backlinks.posts") $about)
+              "value" (printf "%s %s" $title $about)
               "heading" 2
             )
           )


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Dans les backlinks, partial utilisé pour les personnes et les organisations, on se reposait uniquement sur les loca de `persons`, empêchant la personnalisation des titres des backlinks des organisations.

Ici on ajoute ces locales, on utilise une variable `$title` pour rendre le code plus lisible et on ajoute à la traduction portugaise un oubli.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`/fr/organisations/noesya/`

## URL de test du site Campus Arts Méditerranée

`/organisations/atelier-codaccioni-7e/`
