### PR TITLE
Affichage du bloc d'orga dans la page d'une organisation

### DIFF
--- a/assets/sass/_theme/sections/organizations.sass
+++ b/assets/sass/_theme/sections/organizations.sass
@@ -93,7 +93,7 @@
         @include media-breakpoint-up(desktop)
             font-size: $lead-sidebar-size-desktop
     .document-content
-        .organization-logo
+        [itemprop="articleBody"] + .organization-logo
             figcaption
                 text-align: right
                 @include meta
@@ -130,5 +130,5 @@
                 gap: var(--grid-gutter)
             [itemprop="articleBody"]
                 width: columns(8)
-            .organization-logo
-                width: columns(3)
+                + .organization-logo
+                    width: columns(3)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Le scope du logo situé en haut de la page d'une organisation n'était pas assez strict, de fait, avec un bloc d'orga dans une page d'organisation, les logo sont énormes : 
![Capture d’écran 2025-06-02 à 15 42 43](https://github.com/user-attachments/assets/99e54010-35c7-495c-aebd-55bbadc2b161)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test du site Campus Art Méditerranée

`/organisations/atelier-codaccioni-7e/`

## Screenshots

![Capture d’écran 2025-06-02 à 15 42 31](https://github.com/user-attachments/assets/ae059dad-254c-4fd4-b7c1-88f1d2e2934d)