### PR TITLE
Classe pour les blocs d'organisations avec logos

### DIFF
--- a/layouts/partials/blocks/templates/organizations.html
+++ b/layouts/partials/blocks/templates/organizations.html
@@ -12,6 +12,9 @@
 
 {{- with .block.data -}}
   {{ $options := .options }}
+  {{ if $options.logo }}
+    {{ $block_class = printf "%s %s" $block_class "organizations--with-images" }}
+  {{ end }}
   <div class="{{ $block_class }}">
     <div class="container">
       <div class="block-content">


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout d'une class `organizations--with-images` au bloc d'organisation pour éventuellement distinguer le style en fonction de l'absence ou la présence de logo (via l'option).

Ex Beaux Arts : 
![Capture d’écran 2025-06-12 à 17 46 37](https://github.com/user-attachments/assets/f4e3edd8-e839-4079-9517-864681264789)
![Capture d’écran 2025-06-12 à 17 46 43](https://github.com/user-attachments/assets/acbf3853-14d9-4012-89b0-03be15a3d8b2)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱