### PR TITLE
Ajouter plus de flexibilité sur les données du logo (titre et lien)

### DIFF
--- a/layouts/partials/commons/logo.html
+++ b/layouts/partials/commons/logo.html
@@ -1,22 +1,50 @@
-{{ $logo := . }}
-{{ $file := false}}
+<!-- Logo(s) -->
+{{ $file := false }}
 {{ $file_darkmode := false }}
-{{ if eq (printf "%T" $logo) "string" }}
-  {{ $file = $logo }}
+{{ if eq (printf "%T" .logo) "string" }}
+  {{ $file = .logo }}
 {{ else }}
-  {{ $file = $logo.default }}
-  {{ $file_darkmode = $logo.darkmode }}
+  {{ $file = .logo.default }}
+  {{ $file_darkmode = .logo.darkmode }}
 {{ end }}
 
-<a class="logo {{- if $file_darkmode }} with-darkmode {{ end -}}" href="{{ site.Home.Permalink }}" title="{{ i18n "commons.index" (dict "Title" site.Title )}}">
+<!-- Title -->
+{{ $title := site.Title }}
+{{ if .title }}
+  {{ $title = .title }}
+{{ end }}
+
+<!-- Link -->
+{{ $link_href :=  site.Home.Permalink }}
+{{ if .link_href }}
+  {{ $link_href = .link_href }}
+{{ end }}
+{{ $link_external := false }}
+{{ if .link_external }}
+  {{ $link_external = .link_external }}
+{{ end }}
+
+<a class="logo {{- if $file_darkmode }} with-darkmode {{ end -}}"
+   href="{{ $link_href }}"
+   title="{{ if $link_external }}{{ i18n "commons.link.blank_aria" (dict "Title" $title) }}{{ else }} {{i18n "commons.index" (dict "Title" $title) }}{{ end }}"
+   {{ if $link_external }} target="_blank"{{ end }}>
+
   {{ if $file }}
     {{ $fileDimensions := partial "GetImageDimensions" (dict "context" . "file" $file "static" true) }}
-    <img src="{{ $file }}" alt="{{ site.Title }}" height="{{ index $fileDimensions 1 }}" width="{{ index $fileDimensions 0 }}">
+    <img src="{{ $file }}"
+         alt="{{ $title }}"
+         height="{{ index $fileDimensions 1 }}"
+         width="{{ index $fileDimensions 0 }}">
+
     {{ if $file_darkmode }}
       {{ $fileDimensions := partial "GetImageDimensions" (dict "context" . "file" $file_darkmode "static" true) }}
-      <img class="logo-darkmode" src="{{ $file_darkmode }}" alt="{{ site.Title }}" height="{{ index $fileDimensions 1 }}" width="{{ index $fileDimensions 0 }}">
+      <img class="logo-darkmode"
+           src="{{ $file_darkmode }}"
+           alt="{{ $title }}"
+           height="{{ index $fileDimensions 1 }}"
+           width="{{ index $fileDimensions 0 }}">
     {{ end }}
   {{ else }}
-    <span class="logo-text">{{ site.Title }}</span>
+    <span class="logo-text">{{ $title }}</span>
   {{ end }}
 </a>

--- a/layouts/partials/footer/logo.html
+++ b/layouts/partials/footer/logo.html
@@ -1,1 +1,1 @@
-{{ partial "commons/logo.html" site.Params.logo.footer }}
+{{ partial "commons/logo.html" (dict "logo" site.Params.logo.footer) }}

--- a/layouts/partials/header/logo.html
+++ b/layouts/partials/header/logo.html
@@ -1,1 +1,1 @@
-{{ partial "commons/logo.html" site.Params.logo.header }}
+{{ partial "commons/logo.html" (dict "logo" site.Params.logo.header) }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description
Ajout de variables au partial `commons/logo` pour lui permettre d'être utilisé dans d'autres contextes que ceux qui sont prévus de base dans le thème.

Pour le cas de Rennes, dans les sous-sites/sites thématiques, le logo principal renvoi vers le site de la métropole (titre et lien différents du site "actuel") + il y a un logo dans le footer qui renvoi vers une ressource externe.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)
https://github.com/osunyorg/rennes-theme/issues/40

## URL de test sur example.osuny.org

## URL de test du site (optionnel)
https://transport.metropole.rennes.fr/ (PR en draft sur le thème Rennes pour les ajustements liés à cette contrib) 
