### PR TITLE
Mettre les contacts des organisations sur deux colonnes

### DIFF
--- a/assets/sass/_theme/sections/organizations.sass
+++ b/assets/sass/_theme/sections/organizations.sass
@@ -115,7 +115,8 @@
             &:not(:first-child)
                 margin-top: $spacing-5
         .contacts-details
-            @include grid(2, md)
+            ul
+                @include grid(2, md)
     @include media-breakpoint-down(md)
         .document-content
             .organization-logo


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Passer les contacts d'une organisation sur deux colonnes.

<img width="1576" alt="image" src="https://github.com/user-attachments/assets/f1c237c3-154b-416a-b85b-d953a2b60aaf" />


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


