### PR TITLE
Suppression du l'erreur généré par l'absence de text pour le QR Code

### DIFF
--- a/layouts/partials/pagedjs/partials/qr.html
+++ b/layouts/partials/pagedjs/partials/qr.html
@@ -9,9 +9,8 @@
 {{- $loading := or .loading "" }}
 
 {{- /* Validate arguments. */}}
-{{- $errors := false}}
+{{- $errors := false }}
 {{- if not $text }}
-  {{- errorf "The %q shortcode requires a %q argument. See %s" .Name "text" .Position }}
   {{- $errors = true }}
 {{- end }}
 

--- a/layouts/partials/pagedjs/partials/qr.html
+++ b/layouts/partials/pagedjs/partials/qr.html
@@ -8,14 +8,8 @@
 {{- $title := or .title "" }}
 {{- $loading := or .loading "" }}
 
-{{- /* Validate arguments. */}}
-{{- $errors := false }}
-{{- if not $text }}
-  {{- $errors = true }}
-{{- end }}
-
 {{- /* Render image. */}}
-{{- if not $errors }}
+{{- if $text }}
   {{- $opts := dict "level" $level "scale" $scale "targetDir" $targetDir }}
   {{- with images.QR $text $opts -}}
     <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}"


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Une erreur de compilation du site était déclenché si un QR Code ne pouvait être généré dans la version pagedjs.

On retire cette génération d'erreur, le cas reste géré en condition.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


