### PR TITLE
Découpage en 2 jobs du workflow de release

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -2,9 +2,10 @@ name: Write version to file
 on:
   release:
     types:
+      - prereleased
       - released
 jobs:
-  build:
+  update_version_file:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -30,7 +31,12 @@ jobs:
           branch: main
           force: true
           message: 'Write version to file'
-
+  notify_autoupdate:
+    # This job runs only for full releases
+    if: ${{ github.event.release.prerelease == false }}
+    needs: update_version_file
+    runs-on: ubuntu-latest
+    steps:
       - name: Autoupdate Osuny theme
         uses: dkershner6/post-api-call-action@v1
         with:


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Avant, le workflow se déclenchait à chaque full release (excluant les pre-releases). Cependant, en cas de pre-release, le fichier `osuny-theme-version` ne se mettait pas à jour.

A partir de maintenant :
- Le workflow se déclenche à chaque pre-release ET release
- L'écriture du fichier `osuny-theme-version` est systématique
- La notification d'auto-update côté admin est spécifique aux full releases et se déclenche après le job précédent
- En bel effet de bord, cela permettra dans l'admin serveur de voir quels sites ont été mis à jour sur des pre-releases

## Niveau d'incidence

- [ ] Incidence faible 😌
- [x] Incidence moyenne 😲
- [ ] Incidence forte 😱
