### PR TITLE
Ajustement de la taille de l'image des personnes

### DIFF
--- a/assets/sass/_theme/sections/organizations.sass
+++ b/assets/sass/_theme/sections/organizations.sass
@@ -115,7 +115,8 @@
             &:not(:first-child)
                 margin-top: $spacing-5
         .contacts-details
-            @include grid(2, md)
+            ul
+                @include grid(2, md)
     @include media-breakpoint-down(md)
         .document-content
             .organization-logo

--- a/assets/sass/_theme/sections/organizations.sass
+++ b/assets/sass/_theme/sections/organizations.sass
@@ -115,8 +115,7 @@
             &:not(:first-child)
                 margin-top: $spacing-5
         .contacts-details
-            ul
-                @include grid(2, md)
+            @include grid(2, md)
     @include media-breakpoint-down(md)
         .document-content
             .organization-logo

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -480,8 +480,8 @@ params:
       persons:
         grid:
           mobile:   90
-          tablet:   360
-          desktop:  255
+          tablet:   220
+          desktop:  150
         large:
           mobile:   400
           tablet:   360


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

L'audit RGESN en court sur les sites de Rennes nous a signalé que l'image des personnes étaient un peu trop grande sur desktop. 

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


