### PR TITLE
fix permission and github_token

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -4,7 +4,8 @@ on:
     types:
       - prereleased
       - released
-permissions: {}
+permissions:
+  contents: write
 jobs:
   update_version_file:
     runs-on: ubuntu-latest
@@ -28,7 +29,7 @@ jobs:
       - name: Commit & Push
         uses: Andro999b/push@v1.3
         with:
-          github_token: ${{ secrets.OSUNY_BOT_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: main
           force: true
           message: 'Write version to file'


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Correction des permissions et ajustement du github_token qui n'était pas vraiment utilisé

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
