### PR TITLE
Correction des cartes à l'intérieur de titre replié

### DIFF
--- a/assets/js/theme/design-system/Maps.js
+++ b/assets/js/theme/design-system/Maps.js
@@ -22,6 +22,15 @@ osuny.Map.prototype.init = function () {
     this.setMarkers();
     this.fitToMapBounds();
     this.setAccessibility();
+    window.addEventListener('resize', this.resize.bind(this));
+};
+
+osuny.Map.prototype.resize = function () {
+    if (this.popups.length === 1) {
+        this.map.closePopup(this.popups[0]);
+        this.map.openPopup(this.popups[0]);
+        this.fitToMapBounds();
+    }
 };
 
 osuny.Map.prototype.setMap = function () {

--- a/assets/js/theme/design-system/extendables.js
+++ b/assets/js/theme/design-system/extendables.js
@@ -81,6 +81,7 @@ osuny.Extendable.prototype.toggle = function (opened, fromOutside) {
 
     if (this.state.opened) {
         window.dispatchEvent(new Event(window.osuny.EVENTS.EXTENDABLE_HAS_OPEN));
+        window.dispatchEvent(new Event('resize'));
     }
 };
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Lorsqu'une carte est contenue dans un titre replié, le rendu ne se met pas à l'échelle correctement lorsqu'on ouvre le contenu sous le titre. Pour réparer, on force une événement de resize au moment de l'ouverture, et s'il n'y a qu'un marker présent, on ferme puis réouvre ce marker afin qu'il s'affiche correctement.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


## Screenshots

Avant : 

<img width="643" alt="image" src="https://github.com/user-attachments/assets/98c9088a-4c91-42be-862c-1c51890c007f" />


Après : 

<img width="1300" alt="image" src="https://github.com/user-attachments/assets/e5cefc40-4dff-4f41-aed5-4cccec81bc3d" />


