### PR TITLE
Gestion des guillemets dans les citations incises

### DIFF
--- a/assets/sass/_theme/configuration/typography.sass
+++ b/assets/sass/_theme/configuration/typography.sass
@@ -152,3 +152,7 @@ $link-underline-offset: 0.2em !default
 $link-underline-thickness: 1px !default
 $link-transition: text-decoration-color $color-duration ease !default
 $link-unhover-decoration-color-alpha: 0.3 !default
+
+// Quote
+$inline-quotation-tag-open: '“' !default
+$inline-quotation-tag-close: '”' !default

--- a/assets/sass/_theme/design-system/typography.sass
+++ b/assets/sass/_theme/design-system/typography.sass
@@ -213,6 +213,12 @@ blockquote, .blockquote
     @include blockquote
     font-style: italic
 
+q
+    &::before
+        content: #{$inline-quotation-tag-open}
+    &::after
+        content: #{$inline-quotation-tag-close}
+
 p
     margin-top: 0
     margin-bottom: 0
@@ -330,4 +336,3 @@ sup
         @include icon($name)
         &::before
             margin-inline-end: pxToRem(5)
-


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Gestion des citations incises dans les éditeurs de texte.

Pour modifier le caractère, configurer les variables `sass` :

```
$inline-quotation-tag-open: '“'
$inline-quotation-tag-close: '”'
```

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


