### PR TITLE
Filtre des publications de recherche

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -263,6 +263,8 @@ params:
   publications:
     index:
       group_by_year: false
+    filters:
+      anr: false
   volumes:
     default_image: false
   locations:

--- a/layouts/partials/FilterPublications
+++ b/layouts/partials/FilterPublications
@@ -1,5 +1,5 @@
 {{ $publications := . }}
-{{ $filter := site.Params.publications.index.filters }}
+{{ $filter := site.Params.publications.filters }}
 
 {{ with $filter.anr }}
   {{ $publications = where $publications "Params.anr_project_references" "intersect" . }}

--- a/layouts/partials/FilterPublications
+++ b/layouts/partials/FilterPublications
@@ -1,0 +1,8 @@
+{{ $publications := . }}
+{{ $filter := site.Params.publications.index.filters }}
+
+{{ with $filter.anr }}
+  {{ $publications = where $publications "Params.anr_project_references" "intersect" . }}
+{{ end }}
+
+{{ return $publications }}

--- a/layouts/partials/persons/single.html
+++ b/layouts/partials/persons/single.html
@@ -12,7 +12,10 @@
 {{ $researcher := site.GetPage (printf "/researchers/%s" $slug) }}
 
 {{ $posts := where $author.Pages "Section" "posts" }}
+
 {{ $publications := where $researcher.Pages "Section" "publications" }}
+{{ $publications = partial "FilterPublications" $publications }}
+
 {{ $papers := where $researcher.Pages "Section" "papers" }}
 
 {{ partial "persons/single/hero.html" . }}

--- a/layouts/partials/persons/single/publications.html
+++ b/layouts/partials/persons/single/publications.html
@@ -1,5 +1,5 @@
 {{ $researcher := .researcher }}
-{{ $publications := .publications }}
+{{ $publications := partial "FilterPublications" .publications }}
 
 <section class="person-publications">
   <div class="top">

--- a/layouts/partials/publications/partials/publications.html
+++ b/layouts/partials/publications/partials/publications.html
@@ -1,7 +1,11 @@
+{{ $publications := where .Site.Pages "Section" .Type }}
+{{ $filtered_publications := partial "FilterPublications" $publications }}
+{{ $paginator := .Paginate $filtered_publications 2 }}
+
 <div class="publications">
   {{ if site.Params.publications.index.group_by_year }}
-    {{ $publications := .Paginator.Pages.GroupByDate "2006" }}
-    {{ range $publications }}
+    {{ $publications = $filtered_publications.GroupByDate "2006" }}
+    {{ range $paginator.Pages }}
       <section>
         <h2 class="publications-year">{{ .Key }}</h2>
         {{ range .Pages }}
@@ -10,7 +14,7 @@
       </section>
     {{ end }}
   {{ else }}
-    {{ range .Paginator.Pages }}
+    {{ range $paginator.Pages }}
       {{ partial "publications/partials/publication.html" (dict "publication" . ) }}
     {{ end }}
   {{ end }}

--- a/layouts/partials/publications/partials/publications.html
+++ b/layouts/partials/publications/partials/publications.html
@@ -1,11 +1,7 @@
-{{ $publications := where .Site.Pages "Section" .Type }}
-{{ $filtered_publications := partial "FilterPublications" $publications }}
-{{ $paginator := .Paginate $filtered_publications 2 }}
-
 <div class="publications">
   {{ if site.Params.publications.index.group_by_year }}
-    {{ $publications = $filtered_publications.GroupByDate "2006" }}
-    {{ range $paginator.Pages }}
+    {{ $pages := .Paginator.Pages.GroupByDate "2006" "asc" }}
+    {{ range $pages }}
       <section>
         <h2 class="publications-year">{{ .Key }}</h2>
         {{ range .Pages }}
@@ -14,7 +10,7 @@
       </section>
     {{ end }}
   {{ else }}
-    {{ range $paginator.Pages }}
+    {{ range .Paginator.Pages }}
       {{ partial "publications/partials/publication.html" (dict "publication" . ) }}
     {{ end }}
   {{ end }}

--- a/layouts/partials/publications/partials/publications.html
+++ b/layouts/partials/publications/partials/publications.html
@@ -1,6 +1,6 @@
 <div class="publications">
   {{ if site.Params.publications.index.group_by_year }}
-    {{ $pages := .Paginator.Pages.GroupByDate "2006" "asc" }}
+    {{ $pages := .Paginator.Pages.GroupByDate "2006" }}
     {{ range $pages }}
       <section>
         <h2 class="publications-year">{{ .Key }}</h2>

--- a/layouts/partials/publications/partials/publications.html
+++ b/layouts/partials/publications/partials/publications.html
@@ -1,7 +1,7 @@
 <div class="publications">
   {{ if site.Params.publications.index.group_by_year }}
-    {{ $pages := .Paginator.Pages.GroupByDate "2006" }}
-    {{ range $pages }}
+    {{ $publications_by_years := .Paginator.Pages.GroupByDate "2006" }}
+    {{ range $publications_by_years }}
       <section>
         <h2 class="publications-year">{{ .Key }}</h2>
         {{ range .Pages }}

--- a/layouts/partials/publications/section.html
+++ b/layouts/partials/publications/section.html
@@ -4,11 +4,10 @@
   {{ partial "contents/list.html" . }}
 
   <div class="container">
-    {{ $publications := where .Site.Pages "Section" .Type }}
-    {{ $filtered_publications := partial "FilterPublications" $publications }}
-    {{ $paginator := .Paginate $filtered_publications }}
+    {{ $publications := partial "FilterPublications" .Pages }}
+    {{ $paginator := .Paginate $publications }}
 
-    {{ partial "publications/single/statistics.html" $paginator }}
+    {{ partial "publications/single/statistics.html" $publications }}
     {{ partial "publications/partials/publications.html" . }}
     {{ partial "commons/pagination.html" . }}
   </div>

--- a/layouts/partials/publications/section.html
+++ b/layouts/partials/publications/section.html
@@ -1,12 +1,14 @@
 {{ partial "publications/section/hero.html" . }}
 <div class="document-content">
 
-  {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" . }}
-  {{ end }}
+  {{ partial "contents/list.html" . }}
 
   <div class="container">
-    {{ partial "publications/single/statistics.html" . }}
+    {{ $publications := where .Site.Pages "Section" .Type }}
+    {{ $filtered_publications := partial "FilterPublications" $publications }}
+    {{ $paginator := .Paginate $filtered_publications }}
+
+    {{ partial "publications/single/statistics.html" $paginator }}
     {{ partial "publications/partials/publications.html" . }}
     {{ partial "commons/pagination.html" . }}
   </div>

--- a/layouts/partials/publications/single/statistics.html
+++ b/layouts/partials/publications/single/statistics.html
@@ -1,6 +1,6 @@
 <div class="publications-statistics">
   <ol>
-    {{ range first 6 (.Pages.GroupByDate "2006") }}
+    {{ range first 6 (.GroupByDate "2006") }}
       <li>
         <p>
           <b>{{ len .Pages }}</b>


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajouter la possibilité de filtrer les publications par numéro ANR : 

### Exemple 

Dans config.yaml :

```
publications:
    filters:
      anr:
        - ANR-23-IACL-0001
        - ANR-10-IAHU-0004
        - ANR-19-P3IA-0002
```

## Doc

http://localhost:1310/docs/website/configurer-le-site/hugo/publications/

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
