### PR TITLE
Affichage du fil d'ariane au-dessus du footer

### DIFF
--- a/assets/sass/_theme/design-system/breadcrumb.sass
+++ b/assets/sass/_theme/design-system/breadcrumb.sass
@@ -59,3 +59,6 @@
             margin-right: var(--grid-gutter-negative)
             > ol
                 padding: 0 var(--grid-gutter)
+    // TODO: better gestion of footer spacing with/without block
+    .page-with-blocks .document-content + .container &
+        margin-bottom: -$spacing-5

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -70,7 +70,9 @@ params:
           truncate: 125
   breadcrumb:
     extendable: false
-    position: hero-start #  hero-start |  hero-end | after-hero | none
+    positions: 
+      - hero-start # hero-start | hero-end | after-hero
+      # - before-footer
   design:
     force_full_width: false
   summary:

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -24,6 +24,14 @@
         >
       {{ partial "commons/search/button.html" "fixed" }}
       {{- block "main" . }}{{- end }}
+      {{ if in site.Params.breadcrumb.positions "before-footer" }}
+        <div class="container breadcrumb-container">
+          {{ partial "commons/breadcrumbs.html" (dict
+              "context" .
+              "position" "before-footer"
+              ) }}
+        </div>
+      {{ end }}
       {{- partial "hooks/before-main-end" . -}}
     </main>
     {{- partial "footer/footer.html" . -}}

--- a/layouts/partials/commons/breadcrumbs.html
+++ b/layouts/partials/commons/breadcrumbs.html
@@ -1,6 +1,7 @@
 {{ $is_extendable := site.Params.breadcrumb.extendable }}
+{{ $position := .position | default "hero"}}
 
-{{ if .Params.breadcrumbs }}
+{{ if .context.Params.breadcrumbs }}
   <nav class="breadcrumb-nav {{ if $is_extendable }} breadcrumb-nav--extendable{{ end }}" aria-label="{{ i18n "commons.breadcrumb.title" }}">
 
     {{ if $is_extendable }}
@@ -11,12 +12,12 @@
 
     {{- $path := strings.TrimSuffix "/" .RelPermalink -}}
     {{- $length := len (split $path "/") }}
-    <ol id="breadcrumb"
+    <ol id="breadcrumb-{{ $position }}"
         itemscope itemtype="https://schema.org/BreadcrumbList" 
         class="breadcrumb {{ if $is_extendable }}extendable{{ end }}"
         {{ if $is_extendable }} data-extendable-focus-first="true" {{ end }}
         >
-      {{ range $index, $item := .Params.breadcrumbs }}
+      {{ range $index, $item := .context.Params.breadcrumbs }}
         <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="breadcrumb-item{{- if not $item.path }} active{{ end }}"{{- if not $item.path }} aria-current="page"{{ end }}>
           {{- if $item.path -}}
             <a itemprop="item" href="{{ $item.path }}">

--- a/layouts/partials/header/hero.html
+++ b/layouts/partials/header/hero.html
@@ -1,6 +1,7 @@
 
 {{ $direction := "" }}
-{{ $breadcrumb_is_after_hero := eq site.Params.breadcrumb.position "after-hero" }}
+{{ $breadcrumb_class := slice }}
+{{ $breadcrumb_is_after_hero := in site.Params.breadcrumb.positions "after-hero" }}
 {{ $display_breadcrumb := .breadcrumb | default true }}
 {{ $subtitle := .subtitle }}
 {{ if .image }}
@@ -26,15 +27,20 @@
   {{ end }}
 {{ end }}
 
-{{ $breadcrumb_class := printf "has-breadcrumb-%s" site.Params.breadcrumb.position }}
+{{ range site.Params.breadcrumb.positions }}
+  {{ if not (in . "footer") }}
+    {{ $breadcrumb_class = $breadcrumb_class | append (printf "has-breadcrumb-%s" .) }}
+  {{ end }}
+{{ end }}
+{{ $breadcrumb_class = delimit $breadcrumb_class " " }}
 
-<header class="hero {{ if .image }}hero--with-image hero--image-{{- $direction }}{{ end }} {{ if $breadcrumb_is_after_hero }} hero--no-margin {{ end }} {{ $breadcrumb_class }} ">
+<header class="hero {{ if .image }}hero--with-image hero--image-{{- $direction }}{{ end }} {{ if $breadcrumb_is_after_hero }} hero--no-margin {{ end -}} {{- $breadcrumb_class -}} ">
 
   {{- partial "hooks/after-hero-start" . -}}
 
   <div class="container">
-    {{ if and $display_breadcrumb (eq site.Params.breadcrumb.position "hero-start") }}
-      {{ partial "header/breadcrumbs.html" .context }}
+    {{ if and $display_breadcrumb (in site.Params.breadcrumb.positions "hero-start") }}
+      {{ partial "commons/breadcrumbs.html" (dict "context" .context) }}
     {{ end }}
     <div class="content">
       <div class="hero-text">
@@ -88,22 +94,22 @@
       {{ end }}
 
     </div>
-    {{ partial "hooks/before-hero-content-end.html" .context }}
+    {{ partial "hooks/before-hero-content-end.html" (dict "context" .context) }}
   </div>
 
   {{ if .hero_complement }}
     {{ partial .hero_complement .context }}
   {{ end }}
 
-  {{ if and $display_breadcrumb (eq site.Params.breadcrumb.position "hero-end") }}
+  {{ if and $display_breadcrumb (in site.Params.breadcrumb.positions "hero-end") }}
     <div class="container breadcrumb-container">
-      {{ partial "header/breadcrumbs.html" .context }}
+      {{ partial "commons/breadcrumbs.html" (dict "context" .context) }}
     </div>
   {{ end }}
 </header>
 
 {{ if and $display_breadcrumb $breadcrumb_is_after_hero }}
   <div class="container breadcrumb-container">
-    {{ partial "header/breadcrumbs.html" .context }}
+    {{ partial "commons/breadcrumbs.html" (dict "context" .context) }}
   </div>
 {{ end }}


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Option pertinente et nécessaire pour Afalab, qui permet de faire ceci : 
```
  breadcrumb:
    positions: 
      - hero-start
      - before-footer
```

Cela nécessite des ajustements html (config hugo, position par défaut dans le partial...) mais aussi un tricks css dû au fait que nous avons toujours un souci de marge avec ou sans bloc sur les pages d'index (j'ai fait un fix cracra mais il faut vraiment qu'on se penche sur ce sujet !)

Pour la config, ça veut dire repasser sur les sites qui ont un `hero-end` (18) ou `after-hero` (49), donc à voir s'il n'y a pas une méthode plus douce, peut-être une config indépendante du `breadcrumb.position` ?

## Niveau d'incidence

- [ ] Incidence faible 😌
- [X] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://www.figma.com/design/R80a7k2n4GJWdoLqZanYAd/Th%C3%A8me-Osuny--Community-?node-id=20187-118687&t=J2VSXibcU2AB0HKy-1

## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site Afalab

`http://localhost:1313/agenda/`
`http://localhost:1313/agenda/2024/online-debate-3-advancing-climate-justice/`


## Screenshots
![Capture d’écran 2025-06-30 à 14 23 23](https://github.com/user-attachments/assets/8d1e73c7-15db-4c28-a9ee-a4c59c38d837)
![Capture d’écran 2025-06-30 à 14 23 29](https://github.com/user-attachments/assets/6232b1e0-0133-4c96-92ea-978ccc04769a)


