### PR TITLE
Personnes et organisations : afficher les labels des RS uniquement sur les single

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -301,13 +301,14 @@ params:
           logo: false
           summary: true
   persons:
+    contact_details:
+      with_labels: true
     index:
       layout: grid # grid | list
       options:
         summary: true
         image: true
         link: true
-      
     single:
       backlinks: false
       events:

--- a/layouts/partials/commons/contact-details.html
+++ b/layouts/partials/commons/contact-details.html
@@ -1,13 +1,15 @@
 {{ $subject := .subject }}
 {{ $name := $subject.Title }}
-{{ $with_socials_labels := .with_socials_labels | default true }}
+{{ $with_labels := .with_labels | default true }}
 {{ with $subject.Params.contact_details }}
   <div class="contacts-details">
     {{ if or .websites .social_networks .emails .phone_numbers .phone_professional .postal_address }}
       <ul>
         {{ with .websites.website }}
           <li class="website">
-            <span>{{ i18n "commons.contact.website" }}</span>
+            {{ if $with_labels }}
+              <span>{{ i18n "commons.contact.website" }}</span>
+            {{ end }}
             <a href="{{ chomp .value | safeURL }}" target="_blank" rel="noopener" itemprop="url" title="{{ safeHTML (i18n "commons.contact.socials.label.website" (dict "name" $name )) }}">
               {{ chomp .label }}
               <span class="sr-only"> - {{ safeHTML (i18n "commons.link.blank") }}</span>
@@ -18,20 +20,24 @@
         {{ partial "commons/socials" (dict
             "context" .
             "name" $name
-            "with_labels" $with_socials_labels
+            "with_labels" $with_labels
             "in_itemscope" true
           ) }}
 
         {{ with .phone_numbers }}
           {{ with or .phone_mobile .phone }}
             <li class="phone">
-              <span>{{ i18n "commons.contact.phone.label" }}</span>
+              {{ if $with_labels }}
+                <span>{{ i18n "commons.contact.phone.label" }}</span>
+              {{ end }}
               <a href="{{ chomp .value | safeURL }}" itemprop="telephone" title='{{ safeHTML (i18n "commons.contact.phone.a11y_label" (dict "phone_number" .label )) }}'>{{ .label }}</a>
             </li>
           {{ end }}
           {{ with .phone_professional }}
             <li class="phone">
-              <span>{{ i18n "commons.contact.phone_professional.label" }}</span>
+              {{ if $with_labels }}
+                <span>{{ i18n "commons.contact.phone_professional.label" }}</span>
+              {{ end }}
               <a href="{{ chomp .value | safeURL }}" itemprop="telephone" title='{{ safeHTML (i18n "commons.contact.phone_professional.a11y_label" (dict "phone_number" .label )) }}'>{{ .label }}</a>
             </li>
           {{ end }}
@@ -39,7 +45,9 @@
 
         {{ with .postal_address }}
           <li class="address">
-            <span class="meta">{{ i18n "commons.contact.address" }}</span>
+            {{ if $with_labels }}
+              <span class="meta">{{ i18n "commons.contact.address" }}</span>
+            {{ end }}
             {{ partial "commons/address.html" . }}
           </li>
         {{ end }}

--- a/layouts/partials/commons/contact-details.html
+++ b/layouts/partials/commons/contact-details.html
@@ -1,6 +1,7 @@
-{{ $name := .Title }}
-
-{{ with .Params.contact_details }}
+{{ $subject := .subject }}
+{{ $name := $subject.Title }}
+{{ $with_socials_labels := .with_socials_labels | default true }}
+{{ with $subject.Params.contact_details }}
   <div class="contacts-details">
     {{ if or .websites .social_networks .emails .phone_numbers .phone_professional .postal_address }}
       <ul>
@@ -17,7 +18,7 @@
         {{ partial "commons/socials" (dict
             "context" .
             "name" $name
-            "with_labels" true
+            "with_labels" $with_socials_labels
             "in_itemscope" true
           ) }}
 

--- a/layouts/partials/organizations/single.html
+++ b/layouts/partials/organizations/single.html
@@ -22,7 +22,7 @@
 
       {{ partial "taxonomies/single-list-container.html" . }}
 
-      {{ partial "commons/contact-details.html" . }}
+      {{ partial "commons/contact-details.html" (dict "subject" .) }}
     </div>
 
     {{ partial "organizations/partials/logo.html" . }}

--- a/layouts/partials/persons/partials/layouts/list/list.html
+++ b/layouts/partials/persons/partials/layouts/list/list.html
@@ -21,7 +21,10 @@
       </div>
 
       {{ if and $options.contact $person.Params.contact_details }}
-        {{ partial "commons/contact-details.html" $person }}
+        {{ partial "commons/contact-details.html" (dict
+            "subject" $person
+            "with_socials_labels" false
+          ) }}
       {{ end }}
     </li>
   {{- end -}}

--- a/layouts/partials/persons/partials/layouts/list/list.html
+++ b/layouts/partials/persons/partials/layouts/list/list.html
@@ -23,7 +23,7 @@
       {{ if and $options.contact $person.Params.contact_details }}
         {{ partial "commons/contact-details.html" (dict
             "subject" $person
-            "with_socials_labels" false
+            "with_labels" site.Params.persons.contact_details.with_labels
           ) }}
       {{ end }}
     </li>

--- a/layouts/partials/persons/partials/person.html
+++ b/layouts/partials/persons/partials/person.html
@@ -32,7 +32,7 @@
     {{ if and $options.contact $person.Params.contact_details }}
       {{ partial "commons/contact-details.html" (dict
           "subject" $person
-          "with_socials_labels" false
+          "with_labels" site.Params.persons.contact_details.with_labels
         ) }}
     {{ end }}
     {{ if eq $layout "large" }}

--- a/layouts/partials/persons/partials/person.html
+++ b/layouts/partials/persons/partials/person.html
@@ -29,8 +29,11 @@
         {{ end }}
       </div>
     {{ end }}
-    {{ if and $options.contact $person.Params.contact_details}}
-      {{ partial "commons/contact-details.html" $person }}
+    {{ if and $options.contact $person.Params.contact_details }}
+      {{ partial "commons/contact-details.html" (dict
+          "subject" $person
+          "with_socials_labels" false
+        ) }}
     {{ end }}
     {{ if eq $layout "large" }}
       <p class="more meta" aria-hidden="true">{{- i18n "commons.more" -}}</p>

--- a/layouts/partials/persons/single.html
+++ b/layouts/partials/persons/single.html
@@ -76,7 +76,7 @@
 
     {{ partial "taxonomies/single-list-container.html" . }}
 
-    {{ partial "commons/contact-details.html" . }}
+    {{ partial "commons/contact-details.html" (dict "subject" .) }}
   </div>
 
   {{ partial "contents/list.html" . }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Par défaut, n'afficher que les labels des réseaux sociaux sur les singles des personnes et des organisations, et les masquer dans les items.

Ajout d'une option pour gérer choisir l'affichage ou non des labels dans les blocs de liste des personnes.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots

<img width="469" alt="image" src="https://github.com/user-attachments/assets/2e8b8a52-afa8-4ad0-92d5-b487c7216e10" />

<img width="1019" alt="image" src="https://github.com/user-attachments/assets/d6e8f421-1410-4fd8-8f4a-1e8343a4eb4e" />

