### PR TITLE
Balise `main` : ajout d'helpers pour faciliter les ré-écritures

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,16 +16,9 @@
     {{- partial "header/accessibility.html" -}}
     {{- partial "hooks/before-header" . -}}
     {{- partial "header/header.html" . -}}
-    <main
-        id="main"
-        {{ if .Params.contents }}
-          class="page-with-blocks"
-        {{ end }}
-        {{ if .Params.ignore.in_search }}
-          data-pagefind-ignore
-        {{ else if site.Params.search.active }}
-          data-pagefind-body
-        {{ end }}
+    <main id="main"
+        {{ partial "GetMainClass" . | safeHTMLAttr }}
+        {{ partial "GetMainSearchAttributes" . | safeHTMLAttr }}
         >
       {{ partial "commons/search/button.html" "fixed" }}
       {{- block "main" . }}{{- end }}

--- a/layouts/partials/GetMainClass
+++ b/layouts/partials/GetMainClass
@@ -1,0 +1,7 @@
+{{ $classAttribute := "" }}
+
+{{ if .Params.contents }}
+  {{ $classAttribute = "class='page-with-blocks'" }}
+{{ end }}
+
+{{ return $classAttribute }}

--- a/layouts/partials/GetMainSearchAttributes
+++ b/layouts/partials/GetMainSearchAttributes
@@ -1,0 +1,9 @@
+{{ $attribute := "" }}
+
+{{ if .Params.ignore.in_search }}
+  {{ $attribute = "data-pagefind-ignore" }}
+{{ else if site.Params.search.active }}
+  {{ $attribute = "data-pagefind-body" }}
+{{ end }}
+
+{{ return $attribute }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [x] Rangement

## Description

Ajout de deux helpers pour la balise `main` des pages : 

- `GetMainClass` : permet d'ajouter des classes en fonction du contenu en override
- `GetMainSearchAttributes` : permet d'ajouter les règles d'indexation dans la recherche pagefind


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
