### PR TITLE
Bloc événements : gestion des dates des événements récurrents et homogénéisation des format d'heures

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -120,7 +120,6 @@ params:
         show_name: true
     sitemap:
       ignore_children: false
-    time_format: "15h04"
   categories:
     index:
       layout: grid # alternate | cards | grid | large | list
@@ -134,7 +133,6 @@ params:
   events:
     default_image: false
     date_format: false # You can add date format to override the date from static (two_lines) 
-    time_format: false # You can add time format to override the time from static (from.hour & to.hour)
     # sitemap:
     #   ignore_children: true
     filters:
@@ -196,7 +194,7 @@ params:
         date_format: ":date_long"
     list:
       time_slots:
-        date_format: ":date_short"
+        date_format: ":date_long"
     # share_links: # Optional
     #   enabled: true
     #   email: false
@@ -209,7 +207,6 @@ params:
   exhibitions:
     default_image: false
     date_format: false # You can add date format to override the date from static (two_lines) 
-    time_format: false # You can add time format to override the time from static (from.hour & to.hour)
     index:
       group_by_date: "Monday 2 January <span>2006</span>"
       highlight_exhibitions: true

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -120,6 +120,7 @@ params:
         show_name: true
     sitemap:
       ignore_children: false
+    time_format: "15h04"
   categories:
     index:
       layout: grid # alternate | cards | grid | large | list
@@ -193,7 +194,9 @@ params:
         position: content # hero | content
       time_slots:
         date_format: ":date_long"
-        time_format: "15h04"
+    list:
+      time_slots:
+        date_format: ":date_short"
     # share_links: # Optional
     #   enabled: true
     #   email: false
@@ -219,7 +222,6 @@ params:
         subtitle: true
         summary: true
       per_page: 10
-      
       truncate_description: 200 # Set to 0 to disable truncate
     single:
       calendar_links: false

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -227,6 +227,7 @@ commons:
     pause: Carousel is playing. Pause the carousel.
     play: Carousel is currently paused. Start the carousel.
     previous: Go to the previous element
+  time_format: 15:04
   toc: 
     title: Table of contents
     button_label: ", current - Table of contents"

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -235,6 +235,7 @@ commons:
     pause: Carrousel en cours de lecture. Mettre en pause le carrousel.
     play: Carrousel actuellement en pause. Démarrer le carrousel.
     previous: Aller à l'élément précédent
+  time_format: 15h04
   toc: 
     title: Table des matières
     button_label: ", en cours - Table des matières"

--- a/i18n/pt.yml
+++ b/i18n/pt.yml
@@ -199,6 +199,7 @@ commons:
     pause: Pausar o carrossel
     play: Iniciar o carrossel
     previous: Ir para o item anterior
+  time_format: 15:04
   toc: 
     title: Índice
     button_label: ", atual - Índice"

--- a/layouts/partials/commons/agenda/dates.html
+++ b/layouts/partials/commons/agenda/dates.html
@@ -28,11 +28,12 @@
           {{ $event_date := $time_slot.start.date | time.Format site.Params.events.single.time_slots.date_format }}
           <span class="date" itemprop="startDate" content="{{ .start.datetime }}">{{ $event_date | strings.FirstUpper }}</span>
           <p class="hours">
+            {{ $time_format := ( i18n "commons.time_format" ) }}
             {{ if $time_slot.start.datetime }}
-              <time datetime="{{ .start.time }}">{{ $time_slot.start.datetime | time.Format site.Params.events.single.time_slots.time_format }}</time>
+              <time datetime="{{ .start.time }}">{{ $time_slot.start.datetime | time.Format $time_format }}</time>
             {{ end }}
             {{ if $time_slot.end.datetime }}
-              <time datetime="{{ .end.time }}">{{ $time_slot.end.datetime | time.Format site.Params.events.single.time_slots.time_format }}</time>
+              <time datetime="{{ .end.time }}">{{ $time_slot.end.datetime | time.Format $time_format }}</time>
             {{ end }}
           </p>
           {{ with $time_slot.place }}

--- a/layouts/partials/commons/item/schedule.html
+++ b/layouts/partials/commons/item/schedule.html
@@ -1,25 +1,37 @@
 {{ $dates := .dates }}
 {{ $time_slot := .time_slot }}
+{{ $is_repeating := .is_repeating }}
 {{ $on_two_lines := .on_two_lines }}
 {{ $type := .type }}
 {{ $date_format := index site.Params $type "date_format" }}
-{{ $time_format := index site.Params $type "time_format" }}
+{{ $time_format := ( i18n "commons.time_format" ) }}
 
 {{ if or $dates.computed.short $dates.computed.two_lines.short $time_slot }}
   <div class="{{ $type }}-schedule">
     <p class="{{ $type }}-dates">
       {{ $formated_date := $dates.computed.short }}
+
       {{ if $on_two_lines }}
         {{ $formated_date = $dates.computed.two_lines.short }}
       {{ end }}
+
       {{ with $date_format }}
-        {{ $formated_date = time.Format . $dates.from.day }}
+        {{ $formated_date = $dates.from.day | time.Format . }}
         {{ if ne $dates.from.day $dates.to.day }}
-          {{ $formated_date = printf "<span>%s</span><span>%s</span>" $formated_date ( time.Format . $dates.to.day ) }}
+          {{ $formated_date = printf "<span>%s</span><span>%s</span>" $formated_date ( $dates.to.day | time.Format . ) }}
         {{ end }}
       {{ end }}
+
+      {{ if and $is_repeating $time_slot }}
+        {{ $date_format = index site.Params $type "list.time_slots.date_format" }}
+        {{ with $time_slot }}
+          {{ $formated_date = .start.date | time.Format site.Params.events.list.time_slots.date_format }}
+        {{ end }}
+      {{ end }}
+      
       {{ partial "PrepareHTML" $formated_date }}
     </p>
+
     {{- if $time_slot }}
       {{- $hour := "" -}}
       <p class="{{ $type }}-time">

--- a/layouts/partials/events/partials/event.html
+++ b/layouts/partials/events/partials/event.html
@@ -66,6 +66,7 @@
         {{ partial "events/partials/event/schedule.html" (dict 
             "dates" .Params.dates
             "time_slot" .Params.current_time_slot
+            "time_slots" .Params.time_slots
             "on_two_lines" (ne $layout "list")
           )}}
       {{ end }}

--- a/layouts/partials/events/partials/event/hours.html
+++ b/layouts/partials/events/partials/event/hours.html
@@ -2,10 +2,10 @@
   <p class="event-hours">
     <span>
       {{- if .start.datetime -}}
-        <time datetime="{{ .start.time }}">{{- .start.datetime | time.Format site.Params.events.single.time_slots.time_format -}}</time>
+        <time datetime="{{ .start.time }}">{{- .start.datetime | time.Format ( i18n "commons.time_format" ) -}}</time>
       {{- end -}}
       {{- if .end.datetime -}}
-        <time datetime="{{ .end.time }}">{{- .end.datetime | time.Format site.Params.events.single.time_slots.time_format -}}</time>
+        <time datetime="{{ .end.time }}">{{- .end.datetime | time.Format ( i18n "commons.time_format" ) -}}</time>
       {{- end -}}
     </span>
   </p>

--- a/layouts/partials/events/partials/event/schedule.html
+++ b/layouts/partials/events/partials/event/schedule.html
@@ -1,6 +1,7 @@
 {{ partial "commons/item/schedule.html" (dict
     "dates" .dates
     "time_slot" .time_slot
+    "is_repeating" (gt .time_slots 1)
     "layout" .layout
     "type" "event"
   ) }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

### Affichage de la date du jour d'un événement récurrent dans un bloc. Possibilité de modifier le format dans la date en config : 

```config.yaml
params:
  events:
    list:
      time_slots:
        date_format: ":date_long"
```

### Gestion du format de l'heure de façon homogène dans les clés de traduction : 

```fr.yml
commons:
    time_format: 15h04 
```

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Incidence

Modifier les config des sites utilisant la clé de config : `event.time_format`

