### PR TITLE
Correction de l'ordre d'affichage des événements 

### DIFF
--- a/layouts/partials/events/partials/events.html
+++ b/layouts/partials/events/partials/events.html
@@ -1,18 +1,7 @@
 {{ $collection := where .events "Params.parent" "eq" nil }}
-{{ $layout := site.Params.events.index.layout }}
 {{ $per_page := .per_page | default site.Params.events.index.per_page }}
 {{ $order := .order | default "asc" }}
 
-{{/* {{ if $is_archive }}
-  {{ $order = "desc" }}
-{{ else }}
-  {{ $collection = where $collection "Params.dates.archive" false }}
-{{ end }}  */}}
-{{/*  {{ $collection = where $collection "Params.date" "2025-02-22" }}
-{{ $collection = where $collection "Params.dates.from.day" "2025-01-14" }}  */}}
-{{/*  {{ $agenda := $collection.GroupByDate site.Params.events.index.group_by_date $order }}  */}}
-
-{{/*  {{ $collection := where $collection "Params.dates" "ne" nil }}  */}}
 {{ $agenda := $collection.GroupByDate site.Params.events.index.group_by_date $order }}
 {{ $paginator := .context.Paginate $agenda $per_page }}
 

--- a/layouts/partials/events_categories/single.html
+++ b/layouts/partials/events_categories/single.html
@@ -14,9 +14,7 @@
     {{ partial "events/section/exhibitions.html" $exhibitions }}
   {{ end }}
 
-  {{ $per_page := site.Params.events.index.per_page }}
   <div class="container">
-
     {{ $futur_and_current := where .Pages "Section" "events" }}
     {{ $futur_and_current = where $futur_and_current "Params.dates.archive" false }}
     {{ $futur_and_current_group := $futur_and_current.GroupByDate site.Params.events.index.group_by_date "asc" }}
@@ -24,9 +22,10 @@
     {{ $archived := where .Pages "Section" "events" }}
     {{ $archived = where $archived "Params.dates.archive" true }}
     {{ $archived_group := $archived.GroupByDate site.Params.events.index.group_by_date "desc" }}
+
     {{ $agenda := $futur_and_current_group | append $archived_group }}
 
-    {{ $paginator := .Paginate $agenda $per_page }}
+    {{ $paginator := .Paginate $agenda site.Params.events.index.per_page }}
 
     {{ if not $paginator.PageGroups }}
       <p class="none">{{ i18n "events.none" }}</p>

--- a/layouts/partials/events_categories/single.html
+++ b/layouts/partials/events_categories/single.html
@@ -15,16 +15,15 @@
   {{ end }}
 
   <div class="container">
-    {{ $futur_and_current := where .Pages "Section" "events" }}
-    {{ $futur_and_current = where $futur_and_current "Params.dates.archive" false }}
+    {{ $events := where .Pages "Section" "events" }}
+
+    {{ $futur_and_current := where $events "Params.dates.archive" false }}
     {{ $futur_and_current_group := $futur_and_current.GroupByDate site.Params.events.index.group_by_date "asc" }}
 
-    {{ $archived := where .Pages "Section" "events" }}
-    {{ $archived = where $archived "Params.dates.archive" true }}
+    {{ $archived := where $events "Params.dates.archive" true }}
     {{ $archived_group := $archived.GroupByDate site.Params.events.index.group_by_date "desc" }}
 
     {{ $agenda := $futur_and_current_group | append $archived_group }}
-
     {{ $paginator := .Paginate $agenda site.Params.events.index.per_page }}
 
     {{ if not $paginator.PageGroups }}

--- a/layouts/partials/events_categories/single.html
+++ b/layouts/partials/events_categories/single.html
@@ -13,14 +13,31 @@
     {{ $exhibitions := where .Pages "Section" "exhibitions" }}
     {{ partial "events/section/exhibitions.html" $exhibitions }}
   {{ end }}
-  <div class="container">
-    {{ $events := where .Pages "Section" "events" }}
 
-    {{ partial "events/partials/events.html" (dict
-        "events" $events
-        "context" .
-        "order" "desc"
-      )}}
+  {{ $per_page := site.Params.events.index.per_page }}
+  <div class="container">
+
+    {{ $futur_and_current := where .Pages "Section" "events" }}
+    {{ $futur_and_current = where $futur_and_current "Params.dates.archive" false }}
+    {{ $futur_and_current_group := $futur_and_current.GroupByDate site.Params.events.index.group_by_date "asc" }}
+
+    {{ $archived := where .Pages "Section" "events" }}
+    {{ $archived = where $archived "Params.dates.archive" true }}
+    {{ $archived_group := $archived.GroupByDate site.Params.events.index.group_by_date "desc" }}
+    {{ $agenda := $futur_and_current_group | append $archived_group }}
+
+    {{ $paginator := .Paginate $agenda $per_page }}
+
+    {{ if not $paginator.PageGroups }}
+      <p class="none">{{ i18n "events.none" }}</p>
+    {{ else }}
+      {{ partial "events/partials/agenda.html" (dict
+        "layout" site.Params.events.index.layout
+        "options" site.Params.events.index.options
+        "agenda" $paginator.PageGroups
+      ) }}
+    {{ end }}
+
     {{ partial "commons/pagination.html" . }}
   </div>
 </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Dans les catégories des événements, il faut afficher : 
- Les événements présents et futurs dans l'ordre chronologique
- Les événements passés dans l'ordre antéchronologique

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/1154


