### PR TITLE
Correction de la liste des enseignants

### DIFF
--- a/layouts/teachers/terms.html
+++ b/layouts/teachers/terms.html
@@ -1,3 +1,4 @@
 {{ define "main" }}
-  {{ partial "persons/section.html" . }}
+  {{ partial "teachers/section.html" . }}
 {{ end }}
+


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Une erreur d'appel de partial fait remonter les enseignements au lieu des enseignants sur la page "Enseignants".

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/bordeauxmontaigne-iut/issues/126

## Screenshots

Actuellement liste des enseignements :

<img width="553" height="472" alt="image" src="https://github.com/user-attachments/assets/4ac7b3ce-efd9-4193-b938-24486df27599" />

Après correction : 

<img width="850" height="755" alt="image" src="https://github.com/user-attachments/assets/0b4605b1-fb89-403a-9066-cc8dc737b514" />




