### PR TITLE
Retrait des dropdown de calendrier des événements archivés

### DIFF
--- a/layouts/partials/commons/agenda/dates.html
+++ b/layouts/partials/commons/agenda/dates.html
@@ -3,6 +3,7 @@
 {{ $is_parent := .Params.children }}
 {{ $is_simple_event := and .Params.dates (not .Params.time_slots) }}
 {{ $has_primary_date := or $is_repeating $multiple_dates_event $is_parent $is_simple_event }}
+{{ $is_archive := eq .Params.dates.status "archive" }}
 
 <div class="event-slots {{- if $is_parent }} parent-event {{ end }} {{ if $is_simple_event }} simple-event {{ end }}">
   <h2 class="events-slots-title">{{ i18n "commons.date" (cond $has_primary_date 2 1) }}</h2>
@@ -15,10 +16,12 @@
       {{ with .Params.place }}
         <span class="location" itemprop="location" itemscope itemtype="https://schema.org/Place">{{ . }}</span>
       {{ end }}
-      {{ partial "commons/agenda/dropdown-calendar.html" (dict
-          "index" "primary"
-          "calendar_links" .Params.dates.add_to_calendar
-        )}}
+      {{ if not $is_archive}}
+        {{ partial "commons/agenda/dropdown-calendar.html" (dict
+            "index" "primary"
+            "calendar_links" .Params.dates.add_to_calendar
+          )}}
+      {{ end }}
     </div>
   {{ end }}
   {{ with .Params.time_slots }}
@@ -39,10 +42,12 @@
           {{ with $time_slot.place }}
             <span class="location" itemprop="location">{{ . }}</span>
           {{ end }}
-          {{ partial "commons/agenda/dropdown-calendar.html" (dict
-              "index" $index
-              "calendar_links" $time_slot.add_to_calendar
-            )}}
+          {{ if not $is_archive}}
+            {{ partial "commons/agenda/dropdown-calendar.html" (dict
+                "index" $index
+                "calendar_links" $time_slot.add_to_calendar
+              )}}
+          {{ end }}
         </li>
       {{ end }}
     </ul>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description https://github.com/osunyorg/theme/issues/1137

Ça n'a pas de sens de laisser la possibilité d'ajouter un événement passé à un agenda.

On pourrait envisager 2 choses : 
- Juste enlever le dropdown
- Signaler que l'événement est passé pour éviter tout malentendu

2 niveaux : 
- si l'événement est totalement fini (.Params.dates.status)
- si le time slot est passé (pas de data précise)

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


