### PR TITLE
Mixin de mise en forme carrousel

### DIFF
--- a/assets/js/theme/utils/breakpoints.js
+++ b/assets/js/theme/utils/breakpoints.js
@@ -4,8 +4,8 @@ const breakpoints = {
     md: 768,
     lg: 992,
     xl: 1200,
-    xxl: 1400,
-    xxxl: 1920
+    xxl: 1440,
+    xxxl: 1600
 };
 
 const isMobile = function() {

--- a/assets/js/theme/utils/breakpoints.js
+++ b/assets/js/theme/utils/breakpoints.js
@@ -4,7 +4,8 @@ const breakpoints = {
     md: 768,
     lg: 992,
     xl: 1200,
-    xxl: 1400
+    xxl: 1400,
+    xxxl: 1920
 };
 
 const isMobile = function() {

--- a/assets/sass/_theme/blocks/organizations.sass
+++ b/assets/sass/_theme/blocks/organizations.sass
@@ -5,7 +5,15 @@
                 @include stretched-link(before)
                 @include icon(links-line, after, true)
                     position: relative
-
+    &--carousel
+        @include layout-carousel
+        .slider
+            @include in-page-with-sidebar
+                .slider-slide
+                    width: columns(3)
+            @include in-page-without-sidebar
+                .slider-slide
+                    width: columns(2)
     &--map
         position: relative
         .block-content

--- a/assets/sass/_theme/blocks/organizations.sass
+++ b/assets/sass/_theme/blocks/organizations.sass
@@ -10,7 +10,7 @@
         .slider
             @include in-page-with-sidebar
                 .slider-slide
-                    width: columns(3)
+                    width: columns(2)
             @include in-page-without-sidebar
                 .slider-slide
                     width: columns(2)

--- a/assets/sass/_theme/blocks/posts.sass
+++ b/assets/sass/_theme/blocks/posts.sass
@@ -294,33 +294,23 @@
                     margin-top: $spacing-5
 
     &--carousel
-        overflow: hidden
-        z-index: 0
-        .post
-            word-break: break-word
-            margin-right: calc(var(--grid-gutter))
-            .media
-                img
-                    aspect-ratio: 1.55
-        @include media-breakpoint-down(desktop)
-            .slider-arrows
-                width: columns(12)
-            .post
-                width: columns(10)
+        @include layout-carousel
         @include in-page-with-sidebar
             .post
-                width: columns(3)
                 .post-title,
                 .post-subtitle
                     @include h4
-            .slider-arrows
-                justify-content: space-between
-                width: columns(7)
-            @include media-breakpoint-down(xl)
-                .post
-                    width: columns(4)
+            .slider
+                .slider-slide
+                    width: columns(5)
                 .slider-arrows
-                    width: columns(8)
+                    justify-content: space-between
+                    width: columns(6)
+                @include media-breakpoint-up(xxl)
+                    .slider-slide
+                        width: columns(4)
+                    .slider-arrows
+                        width: columns(5)
         @include in-page-without-sidebar
             .block-content
                 display: flex
@@ -328,11 +318,10 @@
                 .top
                     flex-shrink: 0
                     width: columns(3)
-                .post
-                    width: columns(4)
-                .slider-arrows
-                    justify-content: space-between
-                    width: columns(9)
+                .slider
+                    .slider-arrows
+                        justify-content: space-between
+                        width: columns(9)
 
 // Move this part to blocks/categories when categories block is ready
 .block-posts

--- a/assets/sass/_theme/blocks/posts.sass
+++ b/assets/sass/_theme/blocks/posts.sass
@@ -301,12 +301,10 @@
                 .post-subtitle
                     @include h4
             .slider
-                .slider-slide
-                    width: columns(5)
                 .slider-arrows
                     justify-content: space-between
-                    width: columns(6)
-                @include media-breakpoint-up(xxl)
+                    width: columns(4)
+                @include media-breakpoint-down(xxxl)
                     .slider-slide
                         width: columns(4)
                     .slider-arrows

--- a/assets/sass/_theme/configuration/spacings.sass
+++ b/assets/sass/_theme/configuration/spacings.sass
@@ -1,6 +1,6 @@
 // Breakpoints
 // TODO: réécrire en sass les mixins bootstrap
-$grid-breakpoints: (xs: 0, sm: 576px, md: 768px, desktop: 992px, lg: 992px, xl: 1200px, xxl: 1440px, xxxl: 1920px) !default
+$grid-breakpoints: (xs: 0, sm: 576px, md: 768px, desktop: 992px, lg: 992px, xl: 1200px, xxl: 1440px, xxxl: 1600px) !default
 
 // Grid System 
 $grid-gutter: pxToRem(24) !default

--- a/assets/sass/_theme/design-system/layouts/carousel.sass
+++ b/assets/sass/_theme/design-system/layouts/carousel.sass
@@ -1,0 +1,17 @@
+@mixin layout-carousel
+    overflow: hidden
+    .slider
+        .slider-list
+            @include list-reset
+            gap: var(--grid-gutter)
+        @include media-breakpoint-down(desktop)
+            .slider-arrows
+                width: columns(12)
+            .slider-slide
+                width: columns(10)
+        @include in-page-with-sidebar
+            .slider-slide
+                width: columns(3)
+        @include in-page-without-sidebar
+            .slider-slide
+                width: columns(4)

--- a/assets/sass/_theme/hugo-osuny.sass
+++ b/assets/sass/_theme/hugo-osuny.sass
@@ -17,6 +17,7 @@
 @import design-system/layouts/item
 @import design-system/layouts/alternate
 @import design-system/layouts/cards
+@import design-system/layouts/carousel
 @import design-system/layouts/grid
 @import design-system/layouts/large
 @import design-system/layouts/list

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -429,6 +429,10 @@ params:
     posts:
       slider:
         arrows: true
+    organizations:
+      slider:
+        arrows: true
+        progression: true
     testimonials:
       slider:
         pagination: true

--- a/layouts/partials/organizations/partials/layouts/carousel/carousel.html
+++ b/layouts/partials/organizations/partials/layouts/carousel/carousel.html
@@ -1,0 +1,39 @@
+{{ $logo_index := .logo_index }}
+{{ $options := .options }}
+{{ $layout := .layout }}
+{{ $heading_level := .heading_level | default 2 }}
+
+<div class="organizations">
+  <ul data-slider="{{ site.Params.blocks.organizations.slider | encoding.Jsonify }}">
+    {{- range .organizations }}
+      {{ if .path }}
+        {{ with site.GetPage .path }}
+          <li>
+            {{ partial "organizations/partials/organization.html" (dict
+                "organization" .
+                "options" $options
+                "layout" $layout
+                "heading_level" $heading_level
+              ) }}
+          </li>
+        {{ end }}
+      {{ else }}
+        <li>
+          {{ partial "organizations/partials/organization.html" (dict
+              "organization" (dict
+                "Title" .name
+                "Permalink" .url
+                "Params" (dict 
+                  "logo" .logo
+                  "external" true
+                )
+              )
+              "options" $options
+              "layout" $layout
+              "heading_level" $heading_level
+            ) }}
+        </li>
+      {{ end }}
+    {{ end -}}
+  </ul>
+</div>


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Création d'un mixin `layout-carousel` pour permettre une mise en forme simple des blocs en carousel.

On prépare la mise en forme carousel pour le bloc organisation.

Reprise légère et simplification du mode carousel du bloc pages.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots

<img width="1440" height="791" alt="Capture d’écran 2025-08-04 à 12 00 35" src="https://github.com/user-attachments/assets/9376b955-53d9-4352-90b8-03e152956e4e" />

<img width="1440" height="690" alt="Capture d’écran 2025-08-04 à 12 00 15" src="https://github.com/user-attachments/assets/0bd00a5d-e463-4315-9f40-a21bf6c829af" />

<img width="1440" height="789" alt="Capture d’écran 2025-08-04 à 12 11 26" src="https://github.com/user-attachments/assets/d798bfbf-10f7-4542-b4c8-bb992e29a85b" />

<img width="1440" height="786" alt="Capture d’écran 2025-08-04 à 12 11 55" src="https://github.com/user-attachments/assets/fbaa3a4a-1727-4ee1-aabe-93ad0995c865" />



