### PR TITLE
remove display information from header_cta

### DIFF
--- a/layouts/partials/commons/agenda/access.html
+++ b/layouts/partials/commons/agenda/access.html
@@ -1,6 +1,6 @@
-{{ if or .Params.text .Params.notes .Params.header_cta.display .Params.time_slots .Params.children .Params.dates }}
+{{ if or .Params.text .Params.notes .Params.header_cta .Params.time_slots .Params.children .Params.dates }}
   <div class="container event-access">
-    {{ if or .Params.text .Params.notes .Params.header_cta.display }}
+    {{ if or .Params.text .Params.notes .Params.header_cta }}
       {{ partial "commons/agenda/practicals.html" . }}
     {{ end }}
     {{ if or .Params.time_slots .Params.children .Params.dates }}

--- a/layouts/partials/header/cta.html
+++ b/layouts/partials/header/cta.html
@@ -1,11 +1,11 @@
 
-{{ if and .display .label }}
+{{ if .label }}
   {{ $is_external := .external | default false }}
   {{ $title := .label }}
   {{ $link_title := cond $is_external (safeHTML (i18n "commons.link.blank_aria" (dict "Title" $title))) $title }}
 
-  <a href="{{ .target | default "#"}}" title="{{ $link_title }}" 
-    class="btn {{ if not .target }} disabled {{ end }}" 
+  <a href="{{ .target | default "#" }}" title="{{ $link_title }}"
+    class="btn {{ if not .target }} disabled {{ end }}"
     {{ if $is_external -}} target="_blank" rel="noopener" {{- end }}
     >
       {{ .label }}

--- a/layouts/partials/header/hero.html
+++ b/layouts/partials/header/hero.html
@@ -10,7 +10,7 @@
 {{ $summary := .context.Params.summary | safeHTML }}
 {{ $subtitle_is_summary := false }}
 
-{{ $button := .button | default (cond .context.Params.header_cta.display .context.Params.header_cta nil) }}
+{{ $button := .button | default .context.Params.header_cta }}
 
 {{ $title_attribute := "" | safeHTMLAttr }}
 {{ if site.Params.search.active }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Retirer la vérification de la présence d'un `header_cta` via la donnée `display` pour simplifier la vérification de la présence de donnée.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [x] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/admin/issues/2952

## Modification non rétro-compatible !

Passer en synchro l'admin et le release du thème : https://github.com/osunyorg/admin/pull/2994 

Mettre à jour en soft release ces overrides : 

https://github.com/search?q=org%3Aosunyorg+header_cta.display+NOT+repo%3Aosunyorg%2Ftheme&type=code

