### PR TITLE
Bloc campus : adresse illisible

### DIFF
--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -67,10 +67,6 @@
                         justify-content: space-between
                     .media
                         width: columns(4)
-                    .more
-                        line-height: 1
-                    &:where(.media)
-                        border: 4px solid red
 
     &--grid
         @include in-page-with-sidebar

--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -54,6 +54,7 @@
                         &:not(:only-child)
                             .location-description
                                 grid-row: 1 / 3
+                                grid-column: 2
                             address
                                 margin-top: auto
                                 grid-row: 2

--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -5,16 +5,16 @@
         gap: calc(var(--grid-gutter) / 2)
         justify-content: flex-end
         position: relative
-        &-title a
-            @include stretched-link(after)
-            text-decoration: none
+        &-title
+            margin-bottom: $spacing-1
+            a
+                @include stretched-link(after)
+                text-decoration: none
         .more
             @include hover-translate-icon(after)
             @include meta
             @include icon(arrow-right-line, after)
                 margin-left: $spacing-2
-            margin-top: $spacing-1
-        address
             margin-top: $spacing-1
         .media
             width: 100%
@@ -46,12 +46,10 @@
                         width: columns(2)
                 @include in-page-without-sidebar
                     &-content
-                        display: grid
-                        grid-gap: $spacing-2 var(--grid-gutter)
+                        @include grid(2, $gap-y: 0)
                         position: relative
-                        grid-template-columns: 1fr 1fr
                         &:only-child
-                            grid-template-columns: 1fr 1fr 1fr
+                            @include grid(3)
                             .location-description
                                 grid-column: 3
                         &:not(:only-child)

--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -14,7 +14,8 @@
             @include icon(arrow-right-line, after)
                 margin-left: $spacing-2
             margin-top: $spacing-1
-
+        address
+            margin-top: $spacing-1
         .media
             width: 100%
             img
@@ -39,6 +40,8 @@
                 &-content
                     flex: 1
                 @include in-page-with-sidebar
+                    address + .location-description
+                        margin-top: $spacing-2
                     .media
                         width: columns(2)
                 @include in-page-without-sidebar
@@ -74,8 +77,11 @@
             @include grid(2)
         @include in-page-without-sidebar
             @include grid(3)
-        .location-title
-            @include h3
+        .location
+            .location-title
+                @include h3
+            address + .location-description
+                margin-top: $spacing-2
 
 .locations__term
     .hero

--- a/assets/sass/_theme/sections/locations.sass
+++ b/assets/sass/_theme/sections/locations.sass
@@ -42,20 +42,31 @@
                     .media
                         width: columns(2)
                 @include in-page-without-sidebar
-                    &-content,
+                    &-content
+                        display: grid
+                        grid-gap: $spacing-2 var(--grid-gutter)
+                        position: relative
+                        grid-template-columns: 1fr 1fr
+                        &:only-child
+                            grid-template-columns: 1fr 1fr 1fr
+                            .location-description
+                                grid-column: 3
+                        &:not(:only-child)
+                            .location-description
+                                grid-row: 1 / 3
+                            address
+                                margin-top: auto
+                                grid-row: 2
                     &-description
                         display: flex
-                    &-content
-                        gap: var(--grid-gutter)
-                    &-description
                         flex-direction: column
                         justify-content: space-between
-                    &-title
-                        min-width: columns(4)
                     .media
                         width: columns(4)
                     .more
                         line-height: 1
+                    &:where(.media)
+                        border: 4px solid red
 
     &--grid
         @include in-page-with-sidebar


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Problème : 

<img width="1907" height="843" alt="Capture d’écran 2025-08-18 à 14 58 16" src="https://github.com/user-attachments/assets/cab18154-2f5f-4df5-8384-3b0c7c27957a" />

Pour éviter d'utiliser une position absolue, on créé une grid permettant de manipuler les éléments à l'intérieur de `.location-content` et on ajoute des comportements spécifiques en fonction de la présence ou non d'image (pour respecter l'intégration actuelle).

Aussi, un petit nettoyage des espaces verticaux s'imposait.

Deux remarques : 
- Pertinent d'homogénéiser l'image pour que ça fonctionne comme les autres bloc : un blanc s'il n'y a pas d'image ?
- J'aurais bien passé l'adresse en meta, mais p-e est-ce du spécifique ?

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

Index : `http://localhost:1313/fr/campus/`
Bloc : `http://localhost:1313/fr/blocks/blocs-de-liste/campus-1/`

## URL de test du site IUT de Bordeaux

Bloc utilisé en semi-largeur : https://www.iut.u-bordeaux.fr/nous-decouvrir/notre-institut/

## Screenshots
### Alignement corrigé : 
<img width="1919" height="783" alt="Capture d’écran 2025-08-18 à 16 31 45" src="https://github.com/user-attachments/assets/b726a126-cf5f-4cd1-a9d8-d52039610826" />

### Espacements verticaux : 
<img width="1367" height="956" alt="Capture d’écran 2025-08-18 à 16 31 08" src="https://github.com/user-attachments/assets/c4ee60b5-eb7b-4c5f-b2f8-6f092e1110e7" />
<img width="1919" height="941" alt="Capture d’écran 2025-08-18 à 16 31 28" src="https://github.com/user-attachments/assets/fea0b02f-ce64-42dd-bf5a-d20dada255e7" />
<img width="1291" height="844" alt="Capture d’écran 2025-08-18 à 16 31 15" src="https://github.com/user-attachments/assets/672d3cf1-84fd-4a1f-91d3-d814637234d3" />
