### PR TITLE
Correction des titres des personnes et ajustement de l'alignement

### DIFF
--- a/assets/sass/_theme/sections/persons.sass
+++ b/assets/sass/_theme/sections/persons.sass
@@ -39,6 +39,8 @@ article.person
     @include media-breakpoint-down(lg)
         flex-direction: row
         gap: $spacing-3
+        .description
+            text-align: left
         // .description
         //     margin-top: $spacing-2
         .avatar
@@ -62,6 +64,12 @@ article.person
     @include grid(2, md)
     @include grid(4, lg)
     @include grid(6, xxl)
+    @include media-breakpoint-up(lg)
+        .avatar
+            margin-left: auto
+            margin-right: auto
+        .description
+            text-align: center
 
 .persons__section,
 .persons_categories__term,
@@ -72,14 +80,6 @@ article.person
     .page-with-blocks
         .persons
             margin-bottom: $spacing-5
-    .persons--grid
-        @include media-breakpoint-up(md)
-            .avatar
-                margin-left: auto
-                margin-right: auto
-            .person-name,
-            .person-role
-                text-align: center
 
 ol.persons--list
     @include list-reset

--- a/layouts/partials/persons/partials/person.html
+++ b/layouts/partials/persons/partials/person.html
@@ -1,7 +1,7 @@
 {{ $options := .options | default site.Params.persons.index.options }}
 {{ $heading_tag := partial "GetHeadingTag" (dict 
   "level" .heading_level 
-  "attributes" "class='person-title' itemprop='name'"
+  "attributes" "class='person-name' itemprop='name'"
 )}}
 {{ $person := .person }}
 {{ $role := .role }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Correction de la class du titre d'une personne.

Ajustement de l'alignement entre `md` et `lg`.  

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots

Avant : 

<img width="952" height="549" alt="image" src="https://github.com/user-attachments/assets/52eeb614-c1ed-455f-9f4c-469208c61ee2" />

Après : 

<img width="826" height="469" alt="image" src="https://github.com/user-attachments/assets/5c337761-5937-4a50-8771-a7a01730ded0" />

