### PR TITLE
Bloc CTA : image décalée sur grand écran

### DIFF
--- a/assets/sass/_theme/blocks/call_to_action.sass
+++ b/assets/sass/_theme/blocks/call_to_action.sass
@@ -197,7 +197,7 @@ $button-selector: "a:first-child"
                     align-items: flex-start
                     display: flex
                     flex-direction: column
-                    grid-column: 10/13
+                    grid-column: 9/13
                     margin-top: 0
                     a
                         margin-right: 0

--- a/assets/sass/_theme/blocks/call_to_action.sass
+++ b/assets/sass/_theme/blocks/call_to_action.sass
@@ -181,6 +181,9 @@ $button-selector: "a:first-child"
                 grid-column: 1/7
             > figure
                 grid-column: 9/13
+                align-items: end
+                display: flex
+                flex-direction: column
                 figcaption
                     margin-top: $spacing-2
         .call_to_action--without-image:not(.call_to_action--without-text)

--- a/assets/sass/_theme/blocks/call_to_action.sass
+++ b/assets/sass/_theme/blocks/call_to_action.sass
@@ -180,7 +180,7 @@ $button-selector: "a:first-child"
             > div
                 grid-column: 1/7
             > figure
-                grid-column: 8/13
+                grid-column: 9/13
                 figcaption
                     margin-top: $spacing-2
         .call_to_action--without-image:not(.call_to_action--without-text)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

- CTA accent : image pas sur la bonne largeur (5 colonnes au lieu de 4)
- CTA simple : image décalée vers la gauche

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/1200

## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/blocks-narratifs/appels-a-action/`

## Screenshots

<img width="1919" height="875" alt="Capture d’écran 2025-09-04 à 18 06 11" src="https://github.com/user-attachments/assets/261e2598-01d2-4473-a200-fa6402125069" />
<img width="1920" height="717" alt="Capture d’écran 2025-09-04 à 18 06 27" src="https://github.com/user-attachments/assets/43d1323a-a2e6-43b8-bdf4-7b2d3915d387" />


