### PR TITLE
Ajout d'option pour autoriser des domaines dans les CSP

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -25,6 +25,7 @@ markup:
 pagination:
   pagerSize: 36
 params:
+  additive_cors: ''
   debug:
     active: false
     productionUrl: ""

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -25,7 +25,7 @@ markup:
 pagination:
   pagerSize: 36
 params:
-  additive_cors: ''
+  additional: ''
   debug:
     active: false
     productionUrl: ""

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -25,7 +25,7 @@ markup:
 pagination:
   pagerSize: 36
 params:
-  additional: ''
+  additional_cors: ''
   debug:
     active: false
     productionUrl: ""

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -25,7 +25,7 @@ markup:
 pagination:
   pagerSize: 36
 params:
-  additional_cors: ''
+  additional_csp: ''
   debug:
     active: false
     productionUrl: ""

--- a/layouts/partials/head/csp.html
+++ b/layouts/partials/head/csp.html
@@ -3,7 +3,7 @@
       content="
         default-src 'self' {{ delimit . " " }}
         {{ if or (not hugo.IsProduction) site.Params.debug.active }}'unsafe-inline'{{ end }}
-        {{ with site.Params.additional }}{{ . }}{{ end }}
+        {{ with site.Params.additional_cors }}{{ . }}{{ end }}
         {{ if site.Params.search.active }}'wasm-unsafe-eval'{{ end }};
       " />
 {{- end -}}

--- a/layouts/partials/head/csp.html
+++ b/layouts/partials/head/csp.html
@@ -3,7 +3,7 @@
       content="
         default-src 'self' {{ delimit . " " }}
         {{ if or (not hugo.IsProduction) site.Params.debug.active }}'unsafe-inline'{{ end }}
-        {{ with site.Params.additive_cors }}{{ . }}{{ end }}
+        {{ with site.Params.additional }}{{ . }}{{ end }}
         {{ if site.Params.search.active }}'wasm-unsafe-eval'{{ end }};
       " />
 {{- end -}}

--- a/layouts/partials/head/csp.html
+++ b/layouts/partials/head/csp.html
@@ -3,7 +3,7 @@
       content="
         default-src 'self' {{ delimit . " " }}
         {{ if or (not hugo.IsProduction) site.Params.debug.active }}'unsafe-inline'{{ end }}
-        {{ with site.Params.additional_cors }}{{ . }}{{ end }}
+        {{ with site.Params.additional_csp }}{{ . }}{{ end }}
         {{ if site.Params.search.active }}'wasm-unsafe-eval'{{ end }};
       " />
 {{- end -}}

--- a/layouts/partials/head/csp.html
+++ b/layouts/partials/head/csp.html
@@ -3,6 +3,7 @@
       content="
         default-src 'self' {{ delimit . " " }}
         {{ if or (not hugo.IsProduction) site.Params.debug.active }}'unsafe-inline'{{ end }}
+        {{ with site.Params.additive_cors }}{{ . }}{{ end }}
         {{ if site.Params.search.active }}'wasm-unsafe-eval'{{ end }};
       " />
 {{- end -}}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Donner la possibilité d'ajouter des domaines depuis le fichier `config.yml` dans les Content Security Policy du site.

```
params:
  additional_csp: app.sig.rennesmetropole.fr
```

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
