### PR TITLE
Ajouter des options d'affichage à une actualités

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -336,9 +336,12 @@ params:
         summary: true
         subtitle: true
       truncate_description: 200 # Set to 0 to disable truncate
-      
     single:
-      author_signature: false
+      options:
+        authors: true
+        reading_time: true
+        signature: false
+        updated_at: true
     # share_links: # Optional
     #   enabled: true
     #   email: false

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -240,6 +240,7 @@ commons:
     title: Table des matières
     button_label: ", en cours - Table des matières"
   "true": Oui
+  updated_at: Mis à jour le
   units:
     GB: Go
     MB: Mo

--- a/layouts/partials/posts/single.html
+++ b/layouts/partials/posts/single.html
@@ -17,7 +17,7 @@
 
   {{ partial "posts/single/after-contents.html" . }}
 
-  {{ if and site.Params.posts.single.author_signature .Params.authors }}
+  {{ if and site.Params.posts.single.options.signature .Params.authors }}
     {{ partial "posts/single/signature.html" . }}
   {{ end }}
 

--- a/layouts/partials/posts/single/post-infos.html
+++ b/layouts/partials/posts/single/post-infos.html
@@ -13,9 +13,20 @@
     <time datetime="{{ .Date.Format "2006-01-02T15:04" }}">{{ .Date | time.Format site.Params.posts.date_format }}</time>
   </li>
 
-  {{ partial "authors/partials/authors.html" . }}
+  {{ if site.Params.posts.single.options.updated_at }}
+    <li>
+      <span>{{ i18n "commons.updated_at" }}</span>
+      <time datetime="{{ .Params.lastmod.Format "2006-01-02T15:04" }}">{{ .Params.lastmod | time.Format site.Params.posts.date_format }}</time>
+    </li>
+  {{ end }}
 
-  {{ partial "commons/reading-time.html" . }}
+  {{ if site.Params.posts.single.options.authors }}
+    {{ partial "authors/partials/authors.html" . }}
+  {{ end }}
+
+  {{ if site.Params.posts.single.options.reading_time }}
+    {{ partial "commons/reading-time.html" . }}
+  {{ end }}
 
   {{ if site.Params.posts.share_links.enabled | default site.Params.share_links.enabled }}
     {{ partial "commons/share/list-item.html" . }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Pouvoir afficher / masquer les éléments de l'article via des options de `config`:

```
posts:
  single:
    options:
      authors: true
      reading_time: true
      signature: false
      updated_at: true
```

On en profite pour rendre possible l'affichage de la dernière mise à jour de l'actualité.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
