### PR TITLE
Utilisation de la fonction `uniq` dans les listes pour éviter les doublons

### DIFF
--- a/layouts/partials/posts/partials/posts.html
+++ b/layouts/partials/posts/partials/posts.html
@@ -5,7 +5,7 @@
     {{ $is_term := eq .Kind "term" }}
     <p>{{ i18n (cond $is_term "categories.no_post" "posts.none") }}</p>
   {{ end }}
-  {{ range .Paginator.Pages }}
+  {{ range (uniq .Paginator.Pages) }}
     {{  partial "posts/partials/post.html" 
         (dict 
           "post" .


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Pour gérer les doublons dans une catégorie ayant des enfants (ou taxo), on peut visiblement se baser sur l'utilisation de la fonction `uniq` dans nos range.

Sur Gaîté, par exemple, [ici](https://www.gaitelyrique.osuny.site/actualites/devenez-acteurice-de-l-epoque/) :
- On a 7 articles, quasiment tous ont des doublons
- Avec `uniq`, on s'assure que chaque item ne soit présent qu'une fois, on a bien nos 7 articles (`http://localhost:1313/actualites/devenez-acteurice-de-l-epoque/`)

Je n'ai pas étendu cette méthode à toutes nos listes, pour en discuter, mais cela n'a pas d'impact ni dans les blocs, ni dans les index.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/1057