### PR TITLE
Précision des espacements dans l'agenda

### DIFF
--- a/assets/sass/_theme/sections/events/section.sass
+++ b/assets/sass/_theme/sections/events/section.sass
@@ -13,10 +13,11 @@
                 margin-bottom: $spacing-3
                 &:where(:not(:first-child))
                     margin-top: $spacing-5
-    .container + .container
-        margin-top: $spacing-4
-        @include media-breakpoint-up(up)
-            margin-top: $spacing-5
+    .document-content
+        > .container + .container
+            margin-top: $spacing-4
+            @include media-breakpoint-up(up)
+                margin-top: $spacing-5
 
 .events__section
     .events-archives-years


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Scope trop large, effet de bord dans le footer (container + container)

<img width="1392" height="377" alt="Capture d’écran 2025-09-18 à 17 07 43" src="https://github.com/user-attachments/assets/2d0e9580-9ea6-4ab2-b623-c16c4af4482b" />


## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test du site (optionnel)

https://www.campusartmediterranee.fr/agenda/

## Screenshots

<img width="1919" height="531" alt="Capture d’écran 2025-09-18 à 17 09 23" src="https://github.com/user-attachments/assets/657e4c17-d25d-44bb-b54a-2aeb3703e669" />

