### PR TITLE
Blocs de pied de page

### DIFF
--- a/assets/sass/_theme/utils/sidebar.sass
+++ b/assets/sass/_theme/utils/sidebar.sass
@@ -1,11 +1,13 @@
 @mixin in-page-with-sidebar
     @include media-breakpoint-up(desktop)
-        body:not(.full-width) &
+        body:not(.full-width) main &
             @content
 
 @mixin in-page-without-sidebar
     @include media-breakpoint-up(desktop)
         main > .blocks &,
+        main > .blocks &,
+        .footer-blocks &,
         body.full-width &
             @content
 

--- a/assets/sass/_theme/utils/sidebar.sass
+++ b/assets/sass/_theme/utils/sidebar.sass
@@ -6,8 +6,7 @@
 @mixin in-page-without-sidebar
     @include media-breakpoint-up(desktop)
         main > .blocks &,
-        main > .blocks &,
-        .footer-blocks &,
+        .contents-full-width &,
         body.full-width &
             @content
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -16,7 +16,10 @@
       ) }}
 
     {{ if .Params.contents }}
-      {{ partial "contents/list.html" . }}
+      {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
     {{ else }}
       {{ partial "pages/partials/children.html" . }}
     {{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -17,9 +17,9 @@
 
     {{ if .Params.contents }}
       {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+          "context" . 
+          "contents" .Params.contents
+        ) }}
     {{ else }}
       {{ partial "pages/partials/children.html" . }}
     {{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -16,10 +16,10 @@
       ) }}
 
     {{ if .Params.contents }}
-      {{ partial "contents/list.html" (dict 
-          "context" . 
-          "contents" .Params.contents
-        ) }}
+      {{ partial "contents/list.html" (dict
+        "context" .
+        "contents" .Params.contents
+      ) }}
     {{ else }}
       {{ partial "pages/partials/children.html" . }}
     {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -14,10 +14,10 @@
       ) }}
 
     {{ if .Params.contents }}
-      {{ partial "contents/list.html" (dict 
-          "context" . 
-          "contents" .Params.contents
-        ) }}
+      {{ partial "contents/list.html" (dict
+        "context" .
+        "contents" .Params.contents
+      ) }}
     {{ else }}
       {{ partial "pages/partials/children.html" . }}
     {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -15,9 +15,9 @@
 
     {{ if .Params.contents }}
       {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+          "context" . 
+          "contents" .Params.contents
+        ) }}
     {{ else }}
       {{ partial "pages/partials/children.html" . }}
     {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -14,7 +14,10 @@
       ) }}
 
     {{ if .Params.contents }}
-      {{ partial "contents/list.html" . }}
+      {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
     {{ else }}
       {{ partial "pages/partials/children.html" . }}
     {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,9 +18,9 @@
 
     {{- if .Params.contents }}
       {{- partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) -}}
+          "context" . 
+          "contents" .Params.contents
+        ) -}}
     {{ else }}
       {{ partial "pages/partials/children.html" . }}
     {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,7 +17,10 @@
       ) }}
 
     {{- if .Params.contents }}
-      {{- partial "contents/list.html" . -}}
+      {{- partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) -}}
     {{ else }}
       {{ partial "pages/partials/children.html" . }}
     {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -16,11 +16,11 @@
         "context" .
       ) }}
 
-    {{- if .Params.contents }}
-      {{- partial "contents/list.html" (dict 
-          "context" . 
-          "contents" .Params.contents
-        ) -}}
+    {{ if .Params.contents }}
+      {{ partial "contents/list.html" (dict
+        "context" .
+        "contents" .Params.contents
+      ) }}
     {{ else }}
       {{ partial "pages/partials/children.html" . }}
     {{ end }}

--- a/layouts/pages/sitemap.html
+++ b/layouts/pages/sitemap.html
@@ -19,10 +19,10 @@
       "block_wrapped" true
       ) }}
 
-    {{ partial "contents/list.html" (dict 
-        "context" . 
-        "contents" .Params.contents
-      ) }}
+    {{ partial "contents/list.html" (dict
+      "context" .
+      "contents" .Params.contents
+    ) }}
 
     <div class="block block-sitemap" id="pages">
       <div class="container">

--- a/layouts/pages/sitemap.html
+++ b/layouts/pages/sitemap.html
@@ -20,9 +20,9 @@
       ) }}
 
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
 
     <div class="block block-sitemap" id="pages">
       <div class="container">

--- a/layouts/pages/sitemap.html
+++ b/layouts/pages/sitemap.html
@@ -19,7 +19,10 @@
       "block_wrapped" true
       ) }}
 
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
     <div class="block block-sitemap" id="pages">
       <div class="container">

--- a/layouts/partials/administrators/section.html
+++ b/layouts/partials/administrators/section.html
@@ -9,9 +9,9 @@
 
   {{ if (partial "IsFirstPage" .) }}
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/administrators/section.html
+++ b/layouts/partials/administrators/section.html
@@ -8,10 +8,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" (dict 
-        "context" . 
-        "contents" .Params.contents
-      ) }}
+    {{ partial "contents/list.html" (dict
+      "context" .
+      "contents" .Params.contents
+    ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/administrators/section.html
+++ b/layouts/partials/administrators/section.html
@@ -8,7 +8,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/authors/section.html
+++ b/layouts/partials/authors/section.html
@@ -7,10 +7,10 @@
       "context" .
     ) }}
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
   <div class="container">
     {{ partial "persons/partials/list-by-role.html" . }}

--- a/layouts/partials/authors/section.html
+++ b/layouts/partials/authors/section.html
@@ -8,9 +8,9 @@
     ) }}
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
   <div class="container">
     {{ partial "persons/partials/list-by-role.html" . }}

--- a/layouts/partials/authors/section.html
+++ b/layouts/partials/authors/section.html
@@ -7,7 +7,10 @@
       "context" .
     ) }}
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
   <div class="container">
     {{ partial "persons/partials/list-by-role.html" . }}

--- a/layouts/partials/categories/section.html
+++ b/layouts/partials/categories/section.html
@@ -13,9 +13,9 @@
 
   {{ if (partial "IsFirstPage" .) }}
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/categories/section.html
+++ b/layouts/partials/categories/section.html
@@ -12,10 +12,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" (dict 
-        "context" . 
-        "contents" .Params.contents
-      ) }}
+    {{ partial "contents/list.html" (dict
+      "context" .
+      "contents" .Params.contents
+    ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/categories/section.html
+++ b/layouts/partials/categories/section.html
@@ -12,7 +12,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/categories/single.html
+++ b/layouts/partials/categories/single.html
@@ -11,10 +11,10 @@
     "block_wrapped" true
   ) }}
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
   {{ with .Params.children }}
     {{ partial "categories/single/categories.html" . }}

--- a/layouts/partials/categories/single.html
+++ b/layouts/partials/categories/single.html
@@ -11,7 +11,10 @@
     "block_wrapped" true
   ) }}
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
   {{ with .Params.children }}
     {{ partial "categories/single/categories.html" . }}

--- a/layouts/partials/categories/single.html
+++ b/layouts/partials/categories/single.html
@@ -12,9 +12,9 @@
   ) }}
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
   {{ with .Params.children }}
     {{ partial "categories/single/categories.html" . }}

--- a/layouts/partials/contents/list.html
+++ b/layouts/partials/contents/list.html
@@ -1,5 +1,6 @@
 {{ $context := .context }}
 {{ $contents := .contents }}
+{{ $index_offset := .index_offset | default 0 }}
 
 {{- if $contents -}}
 
@@ -8,6 +9,7 @@
 
   <div class="blocks">
     {{- range $index, $content := $contents -}}
+      {{ $index = add $index $index_offset }}
       {{ if and (eq .kind "block") (not (in site.Params.blocks.ignored .html_class) ) }}
         {{ $is_last_content := eq (add $index 1) (len $contents) }}
         {{ $is_title := eq .template "title" }}

--- a/layouts/partials/contents/list.html
+++ b/layouts/partials/contents/list.html
@@ -1,5 +1,5 @@
-{{ $context := . }}
-{{ $contents := .Params.contents }}
+{{ $context := .context }}
+{{ $contents := .contents }}
 
 {{- if $contents -}}
 
@@ -7,35 +7,35 @@
   {{ $is_last_content := false }}
 
   <div class="blocks">
-  {{- range $index, $content := .Params.contents -}}
-    {{ if and (eq .kind "block") (not (in site.Params.blocks.ignored .html_class) ) }}
-      {{ $is_last_content := eq (add $index 1) (len $contents) }}
-      {{ $is_title := eq .template "title" }}
-      {{ $is_layout_collapsed := eq .data.layout "collapsed" }}
-      {{ $template := printf "blocks/templates/%s.html" .template }}
+    {{- range $index, $content := $contents -}}
+      {{ if and (eq .kind "block") (not (in site.Params.blocks.ignored .html_class) ) }}
+        {{ $is_last_content := eq (add $index 1) (len $contents) }}
+        {{ $is_title := eq .template "title" }}
+        {{ $is_layout_collapsed := eq .data.layout "collapsed" }}
+        {{ $template := printf "blocks/templates/%s.html" .template }}
 
-      {{ if and $is_title $collapsed_started }}
-        {{ $collapsed_started = false }}
-        </div>
-      {{ end }}
+        {{ if and $is_title $collapsed_started }}
+          {{ $collapsed_started = false }}
+          </div>
+        {{ end }}
 
-      {{ if templates.Exists ( printf "partials/%s" $template ) }}
-        {{ partial $template (dict
-            "block" $content
-            "context" $context
-            "index" $index
-          )}}
-      {{ end }}
+        {{ if templates.Exists ( printf "partials/%s" $template ) }}
+          {{ partial $template (dict
+              "block" $content
+              "context" $context
+              "index" $index
+            )}}
+        {{ end }}
 
-      {{ if and $is_title $is_layout_collapsed }}
-        {{ $collapsed_started = true }}
-        <div class="collapse" id="collapse-{{- .slug -}}">
-      {{ end }}
+        {{ if and $is_title $is_layout_collapsed }}
+          {{ $collapsed_started = true }}
+          <div class="collapse" id="collapse-{{- .slug -}}">
+        {{ end }}
 
-      {{ if and $collapsed_started $is_last_content }}
-        </div>
+        {{ if and $collapsed_started $is_last_content }}
+          </div>
+        {{ end }}
       {{ end }}
-    {{ end }}
-  {{- end -}}
+    {{- end -}}
   </div>
 {{- end -}}

--- a/layouts/partials/diplomas/section.html
+++ b/layouts/partials/diplomas/section.html
@@ -9,9 +9,9 @@
 
   {{ if (partial "IsFirstPage" .) }}
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/diplomas/section.html
+++ b/layouts/partials/diplomas/section.html
@@ -8,10 +8,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" (dict 
-        "context" . 
-        "contents" .Params.contents
-      ) }}
+    {{ partial "contents/list.html" (dict
+      "context" .
+      "contents" .Params.contents
+    ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/diplomas/section.html
+++ b/layouts/partials/diplomas/section.html
@@ -8,7 +8,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/diplomas/single.html
+++ b/layouts/partials/diplomas/single.html
@@ -6,10 +6,12 @@
       "context" .
       "block_wrapped" true
     ) }}
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
+
   <div class="container">
     {{ $programs_options := site.Params.diplomas.single.programs.options }}
     <ol class="programs {{ if eq $programs_options false }}programs--default{{ end }}">

--- a/layouts/partials/diplomas/single.html
+++ b/layouts/partials/diplomas/single.html
@@ -6,7 +6,10 @@
       "context" .
       "block_wrapped" true
     ) }}
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   <div class="container">
     {{ $programs_options := site.Params.diplomas.single.programs.options }}
     <ol class="programs {{ if eq $programs_options false }}programs--default{{ end }}">

--- a/layouts/partials/diplomas/single.html
+++ b/layouts/partials/diplomas/single.html
@@ -7,9 +7,9 @@
       "block_wrapped" true
     ) }}
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
   <div class="container">
     {{ $programs_options := site.Params.diplomas.single.programs.options }}
     <ol class="programs {{ if eq $programs_options false }}programs--default{{ end }}">

--- a/layouts/partials/events/section-month.html
+++ b/layouts/partials/events/section-month.html
@@ -7,7 +7,10 @@
 
   {{ partial "events/section/calendar.html" . }}
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
   <div class="container events-programme" id="events-programme">
     {{ $events := .Pages }}

--- a/layouts/partials/events/section-month.html
+++ b/layouts/partials/events/section-month.html
@@ -7,10 +7,10 @@
 
   {{ partial "events/section/calendar.html" . }}
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
   <div class="container events-programme" id="events-programme">
     {{ $events := .Pages }}

--- a/layouts/partials/events/section-month.html
+++ b/layouts/partials/events/section-month.html
@@ -8,9 +8,9 @@
   {{ partial "events/section/calendar.html" . }}
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
   <div class="container events-programme" id="events-programme">
     {{ $events := .Pages }}

--- a/layouts/partials/events/section-year.html
+++ b/layouts/partials/events/section-year.html
@@ -18,7 +18,10 @@
     </div>
   {{ end }}
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
   <div class="container events-programme" id="events-programme">
     {{ partial "events/partials/events.html" (dict

--- a/layouts/partials/events/section-year.html
+++ b/layouts/partials/events/section-year.html
@@ -19,9 +19,9 @@
   {{ end }}
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
   <div class="container events-programme" id="events-programme">
     {{ partial "events/partials/events.html" (dict

--- a/layouts/partials/events/section-year.html
+++ b/layouts/partials/events/section-year.html
@@ -18,10 +18,10 @@
     </div>
   {{ end }}
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
   <div class="container events-programme" id="events-programme">
     {{ partial "events/partials/events.html" (dict

--- a/layouts/partials/events/section.html
+++ b/layouts/partials/events/section.html
@@ -13,9 +13,9 @@
   {{ partial "events/section/filters.html" . }}
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
   <div class="container events-programme" id="events-programme">
     {{ $per_page := site.Params.events.index.per_page }}

--- a/layouts/partials/events/section.html
+++ b/layouts/partials/events/section.html
@@ -12,10 +12,10 @@
 
   {{ partial "events/section/filters.html" . }}
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
   <div class="container events-programme" id="events-programme">
     {{ $per_page := site.Params.events.index.per_page }}

--- a/layouts/partials/events/section.html
+++ b/layouts/partials/events/section.html
@@ -12,7 +12,10 @@
 
   {{ partial "events/section/filters.html" . }}
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
   <div class="container events-programme" id="events-programme">
     {{ $per_page := site.Params.events.index.per_page }}

--- a/layouts/partials/events/single.html
+++ b/layouts/partials/events/single.html
@@ -19,9 +19,9 @@
       ) }}
 
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
     {{ if site.Params.events.single.navigation.active }}
       {{ partial "commons/siblings-navigation.html" (dict

--- a/layouts/partials/events/single.html
+++ b/layouts/partials/events/single.html
@@ -18,8 +18,8 @@
         "block_wrapped" true
       ) }}
 
-    {{ partial "contents/list.html" (dict 
-      "context" . 
+    {{ partial "contents/list.html" (dict
+      "context" .
       "contents" .Params.contents
     ) }}
 

--- a/layouts/partials/events/single.html
+++ b/layouts/partials/events/single.html
@@ -18,7 +18,10 @@
         "block_wrapped" true
       ) }}
 
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
     {{ if site.Params.events.single.navigation.active }}
       {{ partial "commons/siblings-navigation.html" (dict

--- a/layouts/partials/events_categories/single.html
+++ b/layouts/partials/events_categories/single.html
@@ -5,7 +5,10 @@
       "context" .
     ) }}
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
   {{ partial "taxonomies/section-list-container.html" . }}
 

--- a/layouts/partials/events_categories/single.html
+++ b/layouts/partials/events_categories/single.html
@@ -6,9 +6,9 @@
     ) }}
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
   {{ partial "taxonomies/section-list-container.html" . }}
 

--- a/layouts/partials/events_categories/single.html
+++ b/layouts/partials/events_categories/single.html
@@ -5,10 +5,10 @@
       "context" .
     ) }}
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
   {{ partial "taxonomies/section-list-container.html" . }}
 

--- a/layouts/partials/exhibitions/section.html
+++ b/layouts/partials/exhibitions/section.html
@@ -7,9 +7,9 @@
 
   {{ if (partial "IsFirstPage" .) }}
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
   {{ end }}
 
   {{ partial "taxonomies/section-list-container.html" . }}

--- a/layouts/partials/exhibitions/section.html
+++ b/layouts/partials/exhibitions/section.html
@@ -6,7 +6,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   {{ end }}
 
   {{ partial "taxonomies/section-list-container.html" . }}

--- a/layouts/partials/exhibitions/section.html
+++ b/layouts/partials/exhibitions/section.html
@@ -6,8 +6,8 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" (dict 
-      "context" . 
+    {{ partial "contents/list.html" (dict
+      "context" .
       "contents" .Params.contents
     ) }}
   {{ end }}

--- a/layouts/partials/exhibitions/single.html
+++ b/layouts/partials/exhibitions/single.html
@@ -15,9 +15,9 @@
       ) }}
   
     {{ partial "contents/list.html" (dict
-    "context" .
-    "contents" .Params.contents
-  ) }}
+      "context" .
+      "contents" .Params.contents
+    ) }}
 
     {{ if site.Params.events.single.navigation.active }}
       {{ partial "commons/siblings-navigation.html" (dict

--- a/layouts/partials/exhibitions/single.html
+++ b/layouts/partials/exhibitions/single.html
@@ -14,10 +14,10 @@
         "block_wrapped" true
       ) }}
   
-    {{ partial "contents/list.html" (dict 
-        "context" . 
-        "contents" .Params.contents
-      ) }}
+    {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
     {{ if site.Params.events.single.navigation.active }}
       {{ partial "commons/siblings-navigation.html" (dict

--- a/layouts/partials/exhibitions/single.html
+++ b/layouts/partials/exhibitions/single.html
@@ -15,9 +15,9 @@
       ) }}
   
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
 
     {{ if site.Params.events.single.navigation.active }}
       {{ partial "commons/siblings-navigation.html" (dict

--- a/layouts/partials/exhibitions/single.html
+++ b/layouts/partials/exhibitions/single.html
@@ -14,7 +14,10 @@
         "block_wrapped" true
       ) }}
   
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
     {{ if site.Params.events.single.navigation.active }}
       {{ partial "commons/siblings-navigation.html" (dict

--- a/layouts/partials/footer/contents.html
+++ b/layouts/partials/footer/contents.html
@@ -1,15 +1,15 @@
 {{ $contents := index site.Data.website site.Language.Lang "contents" }}
 {{ $index_offset := 0 }}
-{{ if .Params.contents }}
-  {{ $index_offset = len .Params.contents }}
+{{ with .Params.contents }}
+  {{ $index_offset = len . }}
 {{ end }}
 
 {{ if $contents }}
   <div class="footer-contents contents-full-width">
     {{ partial "contents/list.html" (dict
-        "context" .
-        "contents" $contents
-        "index_offset" $index_offset
-      ) }}
+      "context" .
+      "contents" $contents
+      "index_offset" $index_offset
+    ) }}
   </div>
 {{ end }}

--- a/layouts/partials/footer/contents.html
+++ b/layouts/partials/footer/contents.html
@@ -1,10 +1,15 @@
 {{ $contents := index site.Data.website site.Language.Lang "contents" }}
+{{ $index_offset := 0 }}
+{{ if .Params.contents }}
+  {{ $index_offset = len .Params.contents }}
+{{ end }}
 
 {{ if $contents }}
   <div class="footer-contents contents-full-width">
     {{ partial "contents/list.html" (dict 
         "context" .
         "contents" $contents
+        "index_offset" $index_offset
       ) }}
   </div>
 {{ end }}

--- a/layouts/partials/footer/contents.html
+++ b/layouts/partials/footer/contents.html
@@ -1,0 +1,10 @@
+{{ $contents := index site.Data.website site.Language.Lang "contents" }}
+
+{{ if $contents }}
+  <div class="footer-blocks">
+    {{ partial "contents/list.html" (dict 
+        "context" .
+        "contents" $contents
+      ) }}
+  </div>
+{{ end }}

--- a/layouts/partials/footer/contents.html
+++ b/layouts/partials/footer/contents.html
@@ -1,7 +1,7 @@
 {{ $contents := index site.Data.website site.Language.Lang "contents" }}
 
 {{ if $contents }}
-  <div class="footer-blocks">
+  <div class="footer-contents contents-full-width">
     {{ partial "contents/list.html" (dict 
         "context" .
         "contents" $contents

--- a/layouts/partials/footer/contents.html
+++ b/layouts/partials/footer/contents.html
@@ -6,7 +6,7 @@
 
 {{ if $contents }}
   <div class="footer-contents contents-full-width">
-    {{ partial "contents/list.html" (dict 
+    {{ partial "contents/list.html" (dict
         "context" .
         "contents" $contents
         "index_offset" $index_offset

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -1,3 +1,5 @@
+{{ partial "footer/contents.html" . }}
+
 <footer id="document-footer" role="contentinfo">
   {{ partial "footer/footer-simple.html" . }}
 </footer>

--- a/layouts/partials/footer/js.html
+++ b/layouts/partials/footer/js.html
@@ -1,27 +1,4 @@
-{{ $isLeafletNeeded := false }}
-
-{{ if .Params.contents }}
-  {{ range .Params.contents }}
-    {{ if or (eq .template "locations") (eq .template "organizations") }}
-      {{ with .data }}
-        {{ if eq .layout "map" }}
-          {{ $isLeafletNeeded = true }}
-        {{ end }}
-      {{ end }}
-    {{ end }}
-  {{ end }}
-{{ end }}
-{{ if and (eq .Kind "taxonomy") (eq .Section "locations") }}
-  {{ $isLeafletNeeded = true }}
-{{ end }}
-
-
-<!-- check if map needed  -->
-{{ if .Params.contact_details.postal_address.geolocation }} 
-  {{ $isLeafletNeeded = true }}
-{{ end }}
-
-{{ if $isLeafletNeeded }}
+{{ if partial "isInteractiveMapPresent" . }}
   <!-- CSS -->
   {{- $cssOpts := (dict
     "targetPath" "assets/css/leaflet.css"

--- a/layouts/partials/isInteractiveMapPresent
+++ b/layouts/partials/isInteractiveMapPresent
@@ -1,33 +1,23 @@
 {{ $is_interactive_map_present := false }}
-{{ $page_content := .Params.contents }}
+{{ $page_contents := .Params.contents }}
 {{ $website_content := index site.Data.website site.Language.Lang "contents" }}
 
-{{ range .Params.contents }}
-  {{ if or (eq .template "locations") (eq .template "organizations") }}
-    {{ with .data }}
-      {{ if eq .layout "map" }}
-        {{ $is_interactive_map_present = true }}
+{{ range slice $page_contents $website_content }}
+  {{ range . }}
+    {{ if or (eq .template "locations") (eq .template "organizations") }}
+      {{ with .data }}
+        {{ if eq .layout "map" }}
+          {{ $is_interactive_map_present = true }}
+        {{ end }}
       {{ end }}
     {{ end }}
   {{ end }}
 {{ end }}
-
-{{ range $website_content }}
-  {{ if or (eq .template "locations") (eq .template "organizations") }}
-    {{ with .data }}
-      {{ if eq .layout "map" }}
-        {{ $is_interactive_map_present = true }}
-      {{ end }}
-    {{ end }}
-  {{ end }}
-{{ end }}
-
 
 {{ if and (eq .Kind "taxonomy") (eq .Section "locations") }}
   {{ $is_interactive_map_present = true }}
 {{ end }}
 
-<!-- check if map needed  -->
 {{ if .Params.contact_details.postal_address.geolocation }} 
   {{ $is_interactive_map_present = true }}
 {{ end }}

--- a/layouts/partials/isInteractiveMapPresent
+++ b/layouts/partials/isInteractiveMapPresent
@@ -1,0 +1,35 @@
+{{ $is_interactive_map_present := false }}
+{{ $page_content := .Params.contents }}
+{{ $website_content := index site.Data.website site.Language.Lang "contents" }}
+
+{{ range .Params.contents }}
+  {{ if or (eq .template "locations") (eq .template "organizations") }}
+    {{ with .data }}
+      {{ if eq .layout "map" }}
+        {{ $is_interactive_map_present = true }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ range $website_content }}
+  {{ if or (eq .template "locations") (eq .template "organizations") }}
+    {{ with .data }}
+      {{ if eq .layout "map" }}
+        {{ $is_interactive_map_present = true }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+
+{{ if and (eq .Kind "taxonomy") (eq .Section "locations") }}
+  {{ $is_interactive_map_present = true }}
+{{ end }}
+
+<!-- check if map needed  -->
+{{ if .Params.contact_details.postal_address.geolocation }} 
+  {{ $is_interactive_map_present = true }}
+{{ end }}
+
+{{ return $is_interactive_map_present }}

--- a/layouts/partials/jobs/section.html
+++ b/layouts/partials/jobs/section.html
@@ -6,7 +6,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   {{ end }}
 
   {{ partial "taxonomies/section-list-container.html" . }}

--- a/layouts/partials/jobs/section.html
+++ b/layouts/partials/jobs/section.html
@@ -6,10 +6,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" (dict 
-        "context" . 
-        "contents" .Params.contents
-      ) }}
+    {{ partial "contents/list.html" (dict
+      "context" .
+      "contents" .Params.contents
+    ) }}
   {{ end }}
 
   {{ partial "taxonomies/section-list-container.html" . }}

--- a/layouts/partials/jobs/section.html
+++ b/layouts/partials/jobs/section.html
@@ -7,9 +7,9 @@
 
   {{ if (partial "IsFirstPage" .) }}
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
   {{ end }}
 
   {{ partial "taxonomies/section-list-container.html" . }}

--- a/layouts/partials/jobs/single.html
+++ b/layouts/partials/jobs/single.html
@@ -19,7 +19,10 @@
       "block_wrapped" true
     ) }}
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
   {{ partial "commons/siblings-navigation.html" (dict
     "context" .

--- a/layouts/partials/jobs/single.html
+++ b/layouts/partials/jobs/single.html
@@ -19,10 +19,10 @@
       "block_wrapped" true
     ) }}
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
   {{ partial "commons/siblings-navigation.html" (dict
     "context" .

--- a/layouts/partials/jobs/single.html
+++ b/layouts/partials/jobs/single.html
@@ -20,9 +20,9 @@
     ) }}
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
   {{ partial "commons/siblings-navigation.html" (dict
     "context" .

--- a/layouts/partials/journals/section.html
+++ b/layouts/partials/journals/section.html
@@ -7,9 +7,9 @@
 
   {{ if (partial "IsFirstPage" .) }}
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/journals/section.html
+++ b/layouts/partials/journals/section.html
@@ -6,10 +6,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" (dict 
-        "context" . 
-        "contents" .Params.contents
-      ) }}
+    {{ partial "contents/list.html" (dict
+      "context" .
+      "contents" .Params.contents
+    ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/journals/section.html
+++ b/layouts/partials/journals/section.html
@@ -6,7 +6,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/journals/single.html
+++ b/layouts/partials/journals/single.html
@@ -10,7 +10,10 @@
       "block_wrapped" true
     ) }}
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
   {{ partial "hooks/before-document-content-end.html" . }}
 </div>

--- a/layouts/partials/journals/single.html
+++ b/layouts/partials/journals/single.html
@@ -10,10 +10,10 @@
       "block_wrapped" true
     ) }}
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
   {{ partial "hooks/before-document-content-end.html" . }}
 </div>

--- a/layouts/partials/journals/single.html
+++ b/layouts/partials/journals/single.html
@@ -11,9 +11,9 @@
     ) }}
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
   {{ partial "hooks/before-document-content-end.html" . }}
 </div>

--- a/layouts/partials/laboratories/section.html
+++ b/layouts/partials/laboratories/section.html
@@ -7,9 +7,9 @@
 
   {{ if (partial "IsFirstPage" .) }}
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/laboratories/section.html
+++ b/layouts/partials/laboratories/section.html
@@ -6,10 +6,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" (dict 
-        "context" . 
-        "contents" .Params.contents
-      ) }}
+    {{ partial "contents/list.html" (dict
+      "context" .
+      "contents" .Params.contents
+    ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/laboratories/section.html
+++ b/layouts/partials/laboratories/section.html
@@ -6,7 +6,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/laboratories/single.html
+++ b/layouts/partials/laboratories/single.html
@@ -15,9 +15,9 @@
   </div>
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
   {{ partial "hooks/before-document-content-end.html" . }}
 </div>

--- a/layouts/partials/laboratories/single.html
+++ b/layouts/partials/laboratories/single.html
@@ -14,10 +14,10 @@
     {{ partial "commons/contact-details.html" (dict "subject" .) }}
   </div>
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
   {{ partial "hooks/before-document-content-end.html" . }}
 </div>

--- a/layouts/partials/laboratories/single.html
+++ b/layouts/partials/laboratories/single.html
@@ -14,7 +14,10 @@
     {{ partial "commons/contact-details.html" (dict "subject" .) }}
   </div>
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
   {{ partial "hooks/before-document-content-end.html" . }}
 </div>

--- a/layouts/partials/locations/section.html
+++ b/layouts/partials/locations/section.html
@@ -8,9 +8,9 @@
 
   {{ if (partial "IsFirstPage" .) }}
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/locations/section.html
+++ b/layouts/partials/locations/section.html
@@ -7,7 +7,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/locations/section.html
+++ b/layouts/partials/locations/section.html
@@ -7,10 +7,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" (dict 
-        "context" . 
-        "contents" .Params.contents
-      ) }}
+    {{ partial "contents/list.html" (dict
+      "context" .
+      "contents" .Params.contents
+    ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/locations/single.html
+++ b/layouts/partials/locations/single.html
@@ -10,7 +10,10 @@
       "block_wrapped" true
     ) }}
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   {{ partial "locations/single/diplomas.html" . }}
 </div>
 {{ $address_geolocation := .Params.contact_details.postal_address.geolocation }}

--- a/layouts/partials/locations/single.html
+++ b/layouts/partials/locations/single.html
@@ -11,9 +11,9 @@
     ) }}
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
   {{ partial "locations/single/diplomas.html" . }}
 </div>
 {{ $address_geolocation := .Params.contact_details.postal_address.geolocation }}

--- a/layouts/partials/locations/single.html
+++ b/layouts/partials/locations/single.html
@@ -10,10 +10,11 @@
       "block_wrapped" true
     ) }}
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
+
   {{ partial "locations/single/diplomas.html" . }}
 </div>
 {{ $address_geolocation := .Params.contact_details.postal_address.geolocation }}

--- a/layouts/partials/organizations/section.html
+++ b/layouts/partials/organizations/section.html
@@ -20,10 +20,10 @@
         "context" .
       ) }}
     {{ partial "taxonomies/section-list-container.html" . }}
-    {{ partial "contents/list.html" (dict 
-        "context" . 
-        "contents" .Params.contents
-      ) }}
+    {{ partial "contents/list.html" (dict
+      "context" .
+      "contents" .Params.contents
+    ) }}
   {{ end }}
 
   {{- if not $is_organizations_block_present -}}

--- a/layouts/partials/organizations/section.html
+++ b/layouts/partials/organizations/section.html
@@ -21,9 +21,9 @@
       ) }}
     {{ partial "taxonomies/section-list-container.html" . }}
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
   {{ end }}
 
   {{- if not $is_organizations_block_present -}}

--- a/layouts/partials/organizations/section.html
+++ b/layouts/partials/organizations/section.html
@@ -20,7 +20,10 @@
         "context" .
       ) }}
     {{ partial "taxonomies/section-list-container.html" . }}
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   {{ end }}
 
   {{- if not $is_organizations_block_present -}}

--- a/layouts/partials/organizations/single.html
+++ b/layouts/partials/organizations/single.html
@@ -28,9 +28,9 @@
     {{ partial "organizations/partials/logo.html" . }}
   </div>
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
   {{ if site.Params.organizations.single.backlinks }}
     {{ partial "contents/backlinks.html" . }}

--- a/layouts/partials/organizations/single.html
+++ b/layouts/partials/organizations/single.html
@@ -27,7 +27,10 @@
 
     {{ partial "organizations/partials/logo.html" . }}
   </div>
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
   {{ if site.Params.organizations.single.backlinks }}
     {{ partial "contents/backlinks.html" . }}

--- a/layouts/partials/organizations/single.html
+++ b/layouts/partials/organizations/single.html
@@ -27,10 +27,11 @@
 
     {{ partial "organizations/partials/logo.html" . }}
   </div>
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
   {{ if site.Params.organizations.single.backlinks }}
     {{ partial "contents/backlinks.html" . }}

--- a/layouts/partials/pages/single.html
+++ b/layouts/partials/pages/single.html
@@ -19,7 +19,10 @@
   {{ end }}
 
   {{ if .Params.contents }}
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   {{ else }}
     {{ partial "pages/partials/children.html" . }}
   {{ end }}

--- a/layouts/partials/pages/single.html
+++ b/layouts/partials/pages/single.html
@@ -19,10 +19,10 @@
   {{ end }}
 
   {{ if .Params.contents }}
-    {{ partial "contents/list.html" (dict 
-        "context" . 
-        "contents" .Params.contents
-      ) }}
+    {{ partial "contents/list.html" (dict
+      "context" .
+      "contents" .Params.contents
+    ) }}
   {{ else }}
     {{ partial "pages/partials/children.html" . }}
   {{ end }}

--- a/layouts/partials/pages/single.html
+++ b/layouts/partials/pages/single.html
@@ -20,9 +20,9 @@
 
   {{ if .Params.contents }}
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
   {{ else }}
     {{ partial "pages/partials/children.html" . }}
   {{ end }}

--- a/layouts/partials/papers/section.html
+++ b/layouts/partials/papers/section.html
@@ -12,8 +12,8 @@
     {{ partial "commons/pagination.html" . }}
   </div>
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 </div>

--- a/layouts/partials/papers/section.html
+++ b/layouts/partials/papers/section.html
@@ -13,7 +13,7 @@
   </div>
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 </div>

--- a/layouts/partials/papers/section.html
+++ b/layouts/partials/papers/section.html
@@ -12,5 +12,8 @@
     {{ partial "commons/pagination.html" . }}
   </div>
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 </div>

--- a/layouts/partials/papers/single.html
+++ b/layouts/partials/papers/single.html
@@ -13,10 +13,10 @@
     </div>
   </div>
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
   <div class="container">
     <div class="content">

--- a/layouts/partials/papers/single.html
+++ b/layouts/partials/papers/single.html
@@ -13,7 +13,10 @@
     </div>
   </div>
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
   <div class="container">
     <div class="content">

--- a/layouts/partials/papers/single.html
+++ b/layouts/partials/papers/single.html
@@ -14,9 +14,9 @@
   </div>
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
   <div class="container">
     <div class="content">

--- a/layouts/partials/persons/section.html
+++ b/layouts/partials/persons/section.html
@@ -30,10 +30,10 @@
   {{ partial "taxonomies/section-list-container.html" . }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" (dict 
-        "context" . 
-        "contents" .Params.contents
-      ) }}
+    {{ partial "contents/list.html" (dict
+      "context" .
+      "contents" .Params.contents
+    ) }}
   {{ end }}
 
   {{- if not $is_block_persons_present -}}

--- a/layouts/partials/persons/section.html
+++ b/layouts/partials/persons/section.html
@@ -31,9 +31,9 @@
 
   {{ if (partial "IsFirstPage" .) }}
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
   {{ end }}
 
   {{- if not $is_block_persons_present -}}

--- a/layouts/partials/persons/section.html
+++ b/layouts/partials/persons/section.html
@@ -30,7 +30,10 @@
   {{ partial "taxonomies/section-list-container.html" . }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   {{ end }}
 
   {{- if not $is_block_persons_present -}}

--- a/layouts/partials/persons/single.html
+++ b/layouts/partials/persons/single.html
@@ -79,10 +79,10 @@
     {{ partial "commons/contact-details.html" (dict "subject" .) }}
   </div>
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
   <div class="container person-objects">
     {{ if $programsForTeacher }}

--- a/layouts/partials/persons/single.html
+++ b/layouts/partials/persons/single.html
@@ -79,7 +79,10 @@
     {{ partial "commons/contact-details.html" (dict "subject" .) }}
   </div>
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
   <div class="container person-objects">
     {{ if $programsForTeacher }}

--- a/layouts/partials/persons/single.html
+++ b/layouts/partials/persons/single.html
@@ -80,9 +80,9 @@
   </div>
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
   <div class="container person-objects">
     {{ if $programsForTeacher }}

--- a/layouts/partials/posts/section.html
+++ b/layouts/partials/posts/section.html
@@ -8,10 +8,10 @@
   {{ partial "taxonomies/section-list-container.html" . }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" (dict 
-        "context" . 
-        "contents" .Params.contents
-      ) }}
+    {{ partial "contents/list.html" (dict
+      "context" .
+      "contents" .Params.contents
+    ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/posts/section.html
+++ b/layouts/partials/posts/section.html
@@ -9,9 +9,9 @@
 
   {{ if (partial "IsFirstPage" .) }}
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/posts/section.html
+++ b/layouts/partials/posts/section.html
@@ -8,7 +8,10 @@
   {{ partial "taxonomies/section-list-container.html" . }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/posts/single.html
+++ b/layouts/partials/posts/single.html
@@ -13,7 +13,10 @@
       "block_wrapped" true
     ) }}
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
   {{ partial "posts/single/after-contents.html" . }}
 

--- a/layouts/partials/posts/single.html
+++ b/layouts/partials/posts/single.html
@@ -13,10 +13,10 @@
       "block_wrapped" true
     ) }}
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
   {{ partial "posts/single/after-contents.html" . }}
 

--- a/layouts/partials/posts/single.html
+++ b/layouts/partials/posts/single.html
@@ -14,9 +14,9 @@
     ) }}
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
   {{ partial "posts/single/after-contents.html" . }}
 

--- a/layouts/partials/programs/section.html
+++ b/layouts/partials/programs/section.html
@@ -11,9 +11,9 @@
       "context" .
     ) }}
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
   {{ partial "taxonomies/section-list-container.html" . }}
 

--- a/layouts/partials/programs/section.html
+++ b/layouts/partials/programs/section.html
@@ -10,7 +10,10 @@
       "with_container" true
       "context" .
     ) }}
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
   {{ partial "taxonomies/section-list-container.html" . }}
 

--- a/layouts/partials/programs/section.html
+++ b/layouts/partials/programs/section.html
@@ -6,14 +6,16 @@
           "context" .
       )
     }}
+
   {{ partial "programs/section/summary.html" (dict
       "with_container" true
       "context" .
     ) }}
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
   {{ partial "taxonomies/section-list-container.html" . }}
 

--- a/layouts/partials/programs/single/presentation.html
+++ b/layouts/partials/programs/single/presentation.html
@@ -39,10 +39,10 @@
         </div>
       {{ end }}
 
-      {{- partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      {{ partial "contents/list.html" (dict
+        "context" .
+        "contents" .Params.contents
+      ) }}
 
       {{ if ( partial "HasAdministrativeInformation" . ) }}
         <div>

--- a/layouts/partials/programs/single/presentation.html
+++ b/layouts/partials/programs/single/presentation.html
@@ -39,7 +39,10 @@
         </div>
       {{ end }}
 
-      {{- partial "contents/list.html" . }}
+      {{- partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
       {{ if ( partial "HasAdministrativeInformation" . ) }}
         <div>

--- a/layouts/partials/projects/section.html
+++ b/layouts/partials/projects/section.html
@@ -9,9 +9,9 @@
 
     {{ if (partial "IsFirstPage" .) }}
       {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
     {{ end }}
   
   <div class="container">

--- a/layouts/partials/projects/section.html
+++ b/layouts/partials/projects/section.html
@@ -8,8 +8,8 @@
     {{ partial "taxonomies/section-list-container.html" . }}
 
     {{ if (partial "IsFirstPage" .) }}
-      {{ partial "contents/list.html" (dict 
-        "context" . 
+      {{ partial "contents/list.html" (dict
+        "context" .
         "contents" .Params.contents
       ) }}
     {{ end }}

--- a/layouts/partials/projects/section.html
+++ b/layouts/partials/projects/section.html
@@ -8,7 +8,10 @@
     {{ partial "taxonomies/section-list-container.html" . }}
 
     {{ if (partial "IsFirstPage" .) }}
-      {{ partial "contents/list.html" . }}
+      {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
     {{ end }}
   
   <div class="container">

--- a/layouts/partials/projects/single.html
+++ b/layouts/partials/projects/single.html
@@ -19,7 +19,10 @@
       "block_wrapped" true
     ) }}
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
   {{ partial "commons/siblings-navigation.html" (dict
     "context" .

--- a/layouts/partials/projects/single.html
+++ b/layouts/partials/projects/single.html
@@ -19,10 +19,10 @@
       "block_wrapped" true
     ) }}
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
   {{ partial "commons/siblings-navigation.html" (dict
     "context" .

--- a/layouts/partials/projects/single.html
+++ b/layouts/partials/projects/single.html
@@ -20,9 +20,9 @@
     ) }}
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
   {{ partial "commons/siblings-navigation.html" (dict
     "context" .

--- a/layouts/partials/publications/section.html
+++ b/layouts/partials/publications/section.html
@@ -2,9 +2,9 @@
 <div class="document-content">
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
   <div class="container">
     {{ $publications := partial "FilterPublications" .Pages }}

--- a/layouts/partials/publications/section.html
+++ b/layouts/partials/publications/section.html
@@ -1,10 +1,10 @@
 {{ partial "publications/section/hero.html" . }}
 <div class="document-content">
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
   <div class="container">
     {{ $publications := partial "FilterPublications" .Pages }}

--- a/layouts/partials/publications/section.html
+++ b/layouts/partials/publications/section.html
@@ -1,7 +1,10 @@
 {{ partial "publications/section/hero.html" . }}
 <div class="document-content">
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
   <div class="container">
     {{ $publications := partial "FilterPublications" .Pages }}

--- a/layouts/partials/researchers/section.html
+++ b/layouts/partials/researchers/section.html
@@ -9,9 +9,9 @@
 
   {{ if (partial "IsFirstPage" .) }}
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/researchers/section.html
+++ b/layouts/partials/researchers/section.html
@@ -8,10 +8,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" (dict 
-        "context" . 
-        "contents" .Params.contents
-      ) }}
+    {{ partial "contents/list.html" (dict
+      "context" .
+      "contents" .Params.contents
+    ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/researchers/section.html
+++ b/layouts/partials/researchers/section.html
@@ -8,7 +8,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/schools/section.html
+++ b/layouts/partials/schools/section.html
@@ -7,9 +7,9 @@
 
   {{ if (partial "IsFirstPage" .) }}
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/schools/section.html
+++ b/layouts/partials/schools/section.html
@@ -6,10 +6,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" (dict 
-        "context" . 
-        "contents" .Params.contents
-      ) }}
+    {{ partial "contents/list.html" (dict
+      "context" .
+      "contents" .Params.contents
+    ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/schools/section.html
+++ b/layouts/partials/schools/section.html
@@ -6,7 +6,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/schools/single.html
+++ b/layouts/partials/schools/single.html
@@ -15,9 +15,9 @@
   </div>
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
   {{ partial "hooks/before-document-content-end.html" . }}
 </div>

--- a/layouts/partials/schools/single.html
+++ b/layouts/partials/schools/single.html
@@ -14,10 +14,10 @@
     {{ partial "commons/contact-details.html" (dict "subject" .) }}
   </div>
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
   {{ partial "hooks/before-document-content-end.html" . }}
 </div>

--- a/layouts/partials/schools/single.html
+++ b/layouts/partials/schools/single.html
@@ -14,7 +14,10 @@
     {{ partial "commons/contact-details.html" (dict "subject" .) }}
   </div>
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
   {{ partial "hooks/before-document-content-end.html" . }}
 </div>

--- a/layouts/partials/teachers/section.html
+++ b/layouts/partials/teachers/section.html
@@ -9,9 +9,9 @@
 
   {{ if (partial "IsFirstPage" .) }}
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/teachers/section.html
+++ b/layouts/partials/teachers/section.html
@@ -8,10 +8,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" (dict 
-        "context" . 
-        "contents" .Params.contents
-      ) }}
+    {{ partial "contents/list.html" (dict
+      "context" .
+      "contents" .Params.contents
+    ) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/teachers/section.html
+++ b/layouts/partials/teachers/section.html
@@ -8,7 +8,10 @@
     ) }}
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   {{ end }}
 
   <div class="container">

--- a/layouts/partials/volumes/section.html
+++ b/layouts/partials/volumes/section.html
@@ -8,8 +8,8 @@
 
   {{ if (partial "IsFirstPage" .) }}
     {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+        "context" . 
+        "contents" .Params.contents
+      ) }}
   {{ end }}
 </div>

--- a/layouts/partials/volumes/section.html
+++ b/layouts/partials/volumes/section.html
@@ -7,6 +7,9 @@
   </div>
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" . }}
+    {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
   {{ end }}
 </div>

--- a/layouts/partials/volumes/section.html
+++ b/layouts/partials/volumes/section.html
@@ -7,9 +7,9 @@
   </div>
 
   {{ if (partial "IsFirstPage" .) }}
-    {{ partial "contents/list.html" (dict 
-        "context" . 
-        "contents" .Params.contents
-      ) }}
+    {{ partial "contents/list.html" (dict
+      "context" .
+      "contents" .Params.contents
+    ) }}
   {{ end }}
 </div>

--- a/layouts/partials/volumes/single.html
+++ b/layouts/partials/volumes/single.html
@@ -21,9 +21,9 @@
 
   </div>
 
-  {{ partial "contents/list.html" (dict 
-      "context" . 
-      "contents" .Params.contents
-    ) }}
+  {{ partial "contents/list.html" (dict
+    "context" .
+    "contents" .Params.contents
+  ) }}
 
 </div>

--- a/layouts/partials/volumes/single.html
+++ b/layouts/partials/volumes/single.html
@@ -21,6 +21,9 @@
 
   </div>
 
-  {{ partial "contents/list.html" . }}
+  {{ partial "contents/list.html" (dict 
+  "context" . 
+  "contents" .Params.contents
+) }}
 
 </div>

--- a/layouts/partials/volumes/single.html
+++ b/layouts/partials/volumes/single.html
@@ -22,8 +22,8 @@
   </div>
 
   {{ partial "contents/list.html" (dict 
-  "context" . 
-  "contents" .Params.contents
-) }}
+      "context" . 
+      "contents" .Params.contents
+    ) }}
 
 </div>


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Support des blocs de pied de page :

- [x] gestion des js à charger (par exemple : utilisation d'une carte en pied de page)
- [x] gestion de la pleine largeur / largeur partielle à ignorer dans les blocs de pied de page
- [x] vérifier le bon fonctionnement des blocs interactifs (js)

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [x] Incidence forte 😱

## Référence (ticket et/ou figma)

#1210


## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


