### PR TITLE
Réduire la priorité du mixin `in-page-with-sidebar`

### DIFF
--- a/assets/sass/_theme/utils/sidebar.sass
+++ b/assets/sass/_theme/utils/sidebar.sass
@@ -1,6 +1,6 @@
 @mixin in-page-with-sidebar
     @include media-breakpoint-up(desktop)
-        body:not(.full-width) main &
+        body:not(.full-width) *:where:not(.contents-full-width) &
             @content
 
 @mixin in-page-without-sidebar


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Le sélecteur du mixin `in-page-with-sidebar` était trop précis et donc prioritaire par rapport a l'usage d'une bodyclass comme `.toc-offcanvas`.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱



