### PR TITLE
Sitemap : enlever les liens de section non publiée

### DIFF
--- a/layouts/pages/sitemap.html
+++ b/layouts/pages/sitemap.html
@@ -46,7 +46,11 @@
           <div class="container">
             <div class="block-content">
               <h2 class="heading" id="#{{ .Type }}">
+                {{ if .Permalink }}
                 <a href="{{ $permalink }}">{{ safeHTML .Title }}</a>
+                {{ else }}
+                  {{ safeHTML .Title }}
+                {{ end }}
               </h2>
               {{ $ignore_children := partial "GetSiteParamWithDefault" (dict
                   "param" (printf "%s.sitemap.ignore_children" .Type)

--- a/layouts/pages/sitemap.html
+++ b/layouts/pages/sitemap.html
@@ -47,7 +47,7 @@
             <div class="block-content">
               <h2 class="heading" id="#{{ .Type }}">
                 {{ if .Permalink }}
-                <a href="{{ $permalink }}">{{ safeHTML .Title }}</a>
+                  <a href="{{ $permalink }}">{{ safeHTML .Title }}</a>
                 {{ else }}
                   {{ safeHTML .Title }}
                 {{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Ajustement du plan du site pour ne pas afficher de lien pour des index de sections non publiés.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)


https://github.com/osunyorg/admin/pull/3444

