### PR TITLE
Ajustements dûs aux changements de priorités dans le style

### DIFF
--- a/assets/sass/_theme/blocks/base.sass
+++ b/assets/sass/_theme/blocks/base.sass
@@ -20,14 +20,15 @@
 
 // Specific
 $backgrounded_blocks: ".block-call_to_action--accent_background, .block-chapter--accent_background, .block-chapter--alt_background, .block-timeline--horizontal, .block-pages--cards"
-.blocks
-    .block:first-child
-        margin-top: 0
-        &:not(#{$backgrounded_blocks})
-            padding-top: 0
-    .block:last-child
-        &:is(#{$backgrounded_blocks})
-            margin-bottom: 0
+main
+    .blocks
+        .block:first-child
+            margin-top: 0
+            &:not(#{$backgrounded_blocks})
+                padding-top: 0
+        .block:last-child
+            &:is(#{$backgrounded_blocks})
+                margin-bottom: 0
 
 // Following chapters
 .block-chapter

--- a/assets/sass/_theme/blocks/key_figures.sass
+++ b/assets/sass/_theme/blocks/key_figures.sass
@@ -4,12 +4,11 @@
     ul
         @include list-reset
         @include grid(2, md)
-        @include in-page-with-sidebar
-            @include grid(2)
-        &.even-items
-            @include grid(4, desktop)
         &.odd-items
             @include grid(3, desktop)
+        @include in-page-without-sidebar
+            &.even-items
+                @include grid(4, desktop)
     .top + ul
         margin-top: $spacing-4
         align-items: baseline


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Suite de https://github.com/osunyorg/theme/pull/1217 (blocs de pied de page)

- Bloc chiffre clé : on fait une modif via le `without-sidebar` plutôt
- cas des premiers blocs sans padding/margin top : on scope dans main (attention niveau de priorité, ex: Diapason)

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱