### PR TITLE
Plan du site : Ajout d'une option pour ignorer une section complète

### DIFF
--- a/layouts/pages/sitemap.html
+++ b/layouts/pages/sitemap.html
@@ -40,36 +40,43 @@
     </div>
 
     {{ range .Site.Sections }}
+      
       {{ if and (ne .Type "sitemap") (ne .Type "pages") }}
-        {{ $permalink := .Permalink }}
-        <div class="block block-sitemap" id="{{ .Type }}">
-          <div class="container">
-            <div class="block-content">
-              <h2 class="heading" id="#{{ .Type }}">
-                {{ if .Permalink }}
-                  <a href="{{ $permalink }}">{{ safeHTML .Title }}</a>
-                {{ else }}
-                  {{ safeHTML .Title }}
-                {{ end }}
-              </h2>
-              {{ $ignore_children := partial "GetSiteParamWithDefault" (dict
-                  "param" (printf "%s.sitemap.ignore_children" .Type)
-                  "default" "default.sitemap.ignore_children"
-                ) }}
-              {{ if not $ignore_children }}
-                <ul>
-                  {{ range where .Site.Pages "Section" .Type }}
-                    {{ if not .Params.ignore.in_sitemap }}
-                      {{ if ne $permalink .Permalink }}
-                        <li><a href="{{ .Permalink }}">{{ safeHTML .Title }}</a></li>
+        {{ $ignore_section := partial "GetSiteParamWithDefault" (dict
+            "param" (printf "%s.sitemap.ignore" .Type)
+            "default" "default.sitemap.ignore"
+          ) }}
+        {{ if not $ignore_section }}
+          {{ $permalink := .Permalink }}
+          <div class="block block-sitemap" id="{{ .Type }}">
+            <div class="container">
+              <div class="block-content">
+                <h2 class="heading" id="#{{ .Type }}">
+                  {{ if .Permalink }}
+                    <a href="{{ $permalink }}">{{ safeHTML .Title }}</a>
+                  {{ else }}
+                    {{ safeHTML .Title }}
+                  {{ end }}
+                </h2>
+                {{ $ignore_children := partial "GetSiteParamWithDefault" (dict
+                    "param" (printf "%s.sitemap.ignore_children" .Type)
+                    "default" "default.sitemap.ignore_children"
+                  ) }}
+                {{ if not $ignore_children }}
+                  <ul>
+                    {{ range where .Site.Pages "Section" .Type }}
+                      {{ if not .Params.ignore.in_sitemap }}
+                        {{ if ne $permalink .Permalink }}
+                          <li><a href="{{ .Permalink }}">{{ safeHTML .Title }}</a></li>
+                        {{ end }}
                       {{ end }}
                     {{ end }}
-                  {{ end }}
-                </ul>
-              {{ end }}
+                  </ul>
+                {{ end }}
+              </div>
             </div>
           </div>
-        </div>
+        {{ end }}
       {{ end }}
     {{ end }}
 

--- a/layouts/pages/sitemap.html
+++ b/layouts/pages/sitemap.html
@@ -40,43 +40,40 @@
     </div>
 
     {{ range .Site.Sections }}
-      
-      {{ if and (ne .Type "sitemap") (ne .Type "pages") }}
-        {{ $ignore_section := partial "GetSiteParamWithDefault" (dict
-            "param" (printf "%s.sitemap.ignore" .Type)
-            "default" "default.sitemap.ignore"
-          ) }}
-        {{ if not $ignore_section }}
-          {{ $permalink := .Permalink }}
-          <div class="block block-sitemap" id="{{ .Type }}">
-            <div class="container">
-              <div class="block-content">
-                <h2 class="heading" id="#{{ .Type }}">
-                  {{ if .Permalink }}
-                    <a href="{{ $permalink }}">{{ safeHTML .Title }}</a>
-                  {{ else }}
-                    {{ safeHTML .Title }}
-                  {{ end }}
-                </h2>
-                {{ $ignore_children := partial "GetSiteParamWithDefault" (dict
-                    "param" (printf "%s.sitemap.ignore_children" .Type)
-                    "default" "default.sitemap.ignore_children"
-                  ) }}
-                {{ if not $ignore_children }}
-                  <ul>
-                    {{ range where .Site.Pages "Section" .Type }}
-                      {{ if not .Params.ignore.in_sitemap }}
-                        {{ if ne $permalink .Permalink }}
-                          <li><a href="{{ .Permalink }}">{{ safeHTML .Title }}</a></li>
-                        {{ end }}
+      {{ $ignore_section := partial "GetSiteParamWithDefault" (dict
+          "param" (printf "%s.sitemap.ignore" .Type)
+          "default" "default.sitemap.ignore"
+        ) }}
+      {{ if and (ne .Type "sitemap") (ne .Type "pages") (not $ignore_section) }}
+        {{ $permalink := .Permalink }}
+        <div class="block block-sitemap" id="{{ .Type }}">
+          <div class="container">
+            <div class="block-content">
+              <h2 class="heading" id="#{{ .Type }}">
+                {{ if .Permalink }}
+                  <a href="{{ $permalink }}">{{ safeHTML .Title }}</a>
+                {{ else }}
+                  {{ safeHTML .Title }}
+                {{ end }}
+              </h2>
+              {{ $ignore_children := partial "GetSiteParamWithDefault" (dict
+                  "param" (printf "%s.sitemap.ignore_children" .Type)
+                  "default" "default.sitemap.ignore_children"
+                ) }}
+              {{ if not $ignore_children }}
+                <ul>
+                  {{ range where .Site.Pages "Section" .Type }}
+                    {{ if not .Params.ignore.in_sitemap }}
+                      {{ if ne $permalink .Permalink }}
+                        <li><a href="{{ .Permalink }}">{{ safeHTML .Title }}</a></li>
                       {{ end }}
                     {{ end }}
-                  </ul>
-                {{ end }}
-              </div>
+                  {{ end }}
+                </ul>
+              {{ end }}
             </div>
           </div>
-        {{ end }}
+        </div>
       {{ end }}
     {{ end }}
 

--- a/layouts/partials/sitemap/toc.html
+++ b/layouts/partials/sitemap/toc.html
@@ -8,9 +8,15 @@
     </li>
     {{ range site.Sections }}
       {{ if and (ne .Type "sitemap") (ne .Type "pages") }}
-        <li>
-          <a href="#{{ .Type }}">{{ safeHTML .Title }}</a>
-        </li>
+        {{ $ignore_section := partial "GetSiteParamWithDefault" (dict
+          "param" (printf "%s.sitemap.ignore" .Type)
+          "default" "default.sitemap.ignore"
+        ) }}
+        {{ if not $ignore_section }}
+          <li>
+            <a href="#{{ .Type }}">{{ safeHTML .Title }}</a>
+          </li>
+        {{ end }}
       {{ end }}
     {{ end }}
   </ol>


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Permet d'enlever de masquer des sections complètes dans le plan du site.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
