### PR TITLE
Amélioration de la gestion des expositions

### DIFF
--- a/layouts/partials/exhibitions/partials/exhibitions.html
+++ b/layouts/partials/exhibitions/partials/exhibitions.html
@@ -4,16 +4,20 @@
 {{ $heading_level := .heading_level | default 2 }}
 {{ $with_more := eq $layout "agenda" }}
 
-<ol class="exhibitions exhibitions--{{- $layout }}">
-  {{ range $exhibitions }}
-    <li>
-      {{ partial "exhibitions/partials/exhibition.html" (dict
-          "exhibition" .
-          "heading_level" $heading_level
-          "layout" $layout
-          "options" $options
-          "with_more" $with_more
-        )}}
-    </li>
-  {{ end }}
-</ol>
+{{ if not $exhibitions }}
+  <p class="none">{{ i18n "exhibitions.none" }}</p>
+{{ else }}
+  <ol class="exhibitions exhibitions--{{- $layout }}">
+    {{ range $exhibitions }}
+      <li>
+        {{ partial "exhibitions/partials/exhibition.html" (dict
+            "exhibition" .
+            "heading_level" $heading_level
+            "layout" $layout
+            "options" $options
+            "with_more" $with_more
+          )}}
+      </li>
+    {{ end }}
+  </ol>
+{{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

- Ajout d'un message pour signaler l'absence d'exposition en cours.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/campus-beaux-arts-de-marseille/issues/44#issuecomment-3347097046
3 points : 
- ajout d'un message quand il n'y a aucune expo en cours
- masquage des catégories quand il n'y a pas d'expo s'y référant
- uniformisation sur le modèle de l'agenda

## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site BA
`http://localhost:1314/expositions/`

## Screenshots
<img width="1514" height="598" alt="Capture d’écran 2025-09-29 à 16 32 31" src="https://github.com/user-attachments/assets/cd8db30b-aa98-4280-ad38-1083bc66c580" />
