### PR TITLE
Bloc vidéo : Ajout d'une balise `span` autour du texte du bouton

### DIFF
--- a/layouts/partials/blocks/templates/video.html
+++ b/layouts/partials/blocks/templates/video.html
@@ -24,7 +24,7 @@
             <button class="btn"
               id="play-{{ $video_id }}"
               data-lightbox="{{ $options | encoding.Jsonify }}">
-                {{ i18n "blocks.video.play" }}
+                <span>{{ i18n "blocks.video.play" }}</span>
             </button>
           {{ end }}
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Afin de manipuler le style du bouton plus simplement, on ajoute un `span` autour du texte.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
