### PR TITLE
Gestion de l'affichage du cta dans la version "large" des listes de personnes

### DIFF
--- a/layouts/partials/persons/partials/person.html
+++ b/layouts/partials/persons/partials/person.html
@@ -34,7 +34,7 @@
           "with_labels" site.Params.persons.contact_details.with_labels
         ) }}
     {{ end }}
-    {{ if eq $layout "large" }}
+    {{ if and $options.link (eq $layout "large") }}
       <p class="more meta" aria-hidden="true">{{- i18n "commons.more" -}}</p>
     {{ end }}
     {{ if $options.cohorts }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

L'affichage du lien "read more" doit prendre en compte l'option `link`, et non uniquement le layout.

## URL de test sur example.osuny.org

https://example.osuny.org/fr/blocks/blocs-de-liste/organigramme/#layout-grand (enlever l'option)

## URL de test du site IDN

http://localhost:1313/news/2025-10-01-communicating-degrowth-a-personal-blog-from-idn-volunteer-kanika-prajapat/

## Screenshots
<img width="1252" height="460" alt="Capture d’écran 2025-10-01 à 12 47 56" src="https://github.com/user-attachments/assets/5e1ef53b-dc4f-452d-82f3-d6a630adf266" />