### PR TITLE
Recherche : alignement de la liste des résultats

### DIFF
--- a/assets/sass/_theme/design-system/search.sass
+++ b/assets/sass/_theme/design-system/search.sass
@@ -104,6 +104,7 @@
             @include media-breakpoint-down(desktop)
                 padding-top: $spacing-2
         &__results
+            @include list-reset
             &:empty
                 display: none
         &__result


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

La liste (ul) de pagefind ajoute un espace à gauche.
(c'est bien le cas sur example et tous les sites)

<img width="1385" height="957" alt="Capture d’écran 2025-10-06 à 15 38 44" src="https://github.com/user-attachments/assets/dcad7936-5404-420e-bdf1-b2dc2439df4e" />
<img width="1382" height="956" alt="Capture d’écran 2025-10-06 à 15 38 32" src="https://github.com/user-attachments/assets/2e7e3b93-e87a-4544-9fb9-68fde1036c92" />

Est-ce que `list-reset` est trop fort et juste un padding suffit ?
Je me suis dit qu'on est paré avec ça