### PR TITLE
Menu mobile : ajout d'un titre "fermer"

### DIFF
--- a/assets/sass/_theme/design-system/header.sass
+++ b/assets/sass/_theme/design-system/header.sass
@@ -246,20 +246,30 @@ header#document-header
                 outline-offset: 5px
                 outline-style: dashed
                 outline-width: 1px
-            @include media-breakpoint-down(desktop)
-                display: flex
-                align-items: center
-            span:first-of-type
+            .button-title
                 @include meta
                 font-size: pxToRem(14)
                 text-transform: uppercase
+                &--close
+                    display: none
+
             span:last-of-type
-                background: none
                 @include icon-block(menu-line, before)
-                    vertical-align: baseline
                     margin-right: $icon-burger-margin-right
+                    vertical-align: baseline
+                background: none
+
             &[aria-expanded="true"]
+                .button-title
+                    &--open
+                        display: none
+                    &--close
+                        display: block
                 span:last-of-type
                     &::before
                         content: map-get($icons, "close-line")
                         margin-right: $icon-close-margin-right
+
+            @include media-breakpoint-down(desktop)
+                align-items: center
+                display: flex

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -195,7 +195,9 @@ commons:
     main: Main menu
     secondary: Secondary menu
     social: Socials networks menu
-    title: Menu
+    title: 
+      open: Menu
+      close: Close
     upper: Menu d'accès rapide
   more: Read more
   more_aria: Read more about “{{ .Title }}”

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -196,7 +196,9 @@ commons:
     main: Menu principal
     secondary: Menu secondaire
     social: Menu réseaux sociaux
-    title: Menu
+    title: 
+      open: Menu
+      close: Fermer
     upper: Menu d'accès rapide
   more: En savoir plus
   more_aria: En savoir plus sur “{{ .Title }}“

--- a/i18n/pt.yml
+++ b/i18n/pt.yml
@@ -176,7 +176,9 @@ commons:
     main: Menu principal
     secondary: Menu secundário
     social: Menu de redes sociais
-    title: Menu
+    title:
+      open: Menu
+      close: Fechar
     upper: Menu de acesso rápido
   more: Saiba mais
   more_aria: Saiba mais sobre “{{ .Title }}“

--- a/layouts/_partials/header/button.html
+++ b/layouts/_partials/header/button.html
@@ -3,7 +3,8 @@
     aria-expanded="false"
     aria-label="{{ i18n "commons.menu.label" }}"
     class="header-button">
-  <span>{{ i18n "commons.menu.title" }}</span>
+  <span class="button-title button-title--open">{{ i18n "commons.menu.title.open" }}</span>
+  <span class="button-title button-title--close">{{ i18n "commons.menu.title.close" }}</span>
   {{/*  djlint:off  */}}
   <span></span>
   {{/*  djlint:on  */}}


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout du titre "fermer" au bouton de menu mobile, lorsqu'il est ouvert.
Plus un peu de rangement dans le style, très léger

## Niveau d'incidence

- [ ] Incidence faible 😌
- [X] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/992

## Impact
On utilise span:not(:first-child) à de nombreux endroits pour masquer le texte du bouton : https://github.com/search?q=org%3Aosunyorg%20header-button&type=code, il faut donc appliquer ce fonctionnement aux deux premiers span

## URL de test sur example.osuny.org

`http://localhost:1313/fr/`

## Screenshots
<img width="373" height="98" alt="Capture d’écran 2026-07-22 à 11 03 15" src="https://github.com/user-attachments/assets/22b9d6e0-8e43-4ffe-98cc-80a23412d7bc" />
<img width="373" height="478" alt="Capture d’écran 2026-07-22 à 11 03 09" src="https://github.com/user-attachments/assets/cca10074-653c-42b8-a275-85c7027788f7" />