### PR TITLE
Plan du site : trier les événements par mois ? 

### DIFF
--- a/layouts/_partials/sitemap/sections/events.html
+++ b/layouts/_partials/sitemap/sections/events.html
@@ -4,16 +4,24 @@
     <li>
       <a href="{{ .Permalink }}">{{ .Title }}</a>
       {{ $events := where .RegularPagesRecursive "Params.dates.archive" false }}
+      {{ $months := $events.GroupByDate "January" "asc" }}
 
-      {{/*  Group by slug to avoid duplication of recurring events and parents events with multiple dates  */}}
-      {{ range $events.GroupByParam "slug" }}
-        {{/*  Get only the first event of the group as the group contains duplicated events */}}
-        {{ $event := .Pages | first 1 }}
-        {{ partial "sitemap/sections/children.html" (dict 
-          "items" $event
-          "type" "events"
-        ) }}
-      {{ end }}
+      <ul>
+        {{ range $months }}
+          <li>
+            <span>{{ .Key | strings.FirstUpper | safeHTML }}</span>
+            {{/*  Group by slug to avoid duplication of recurring events and parents events with multiple dates  */}}
+            {{ range .Pages.GroupByParam "slug" }}
+              {{/*  Get only the first event of the group as the group contains duplicated events */}}
+              {{ $event := .Pages | first 1 }}
+              {{ partial "sitemap/sections/children.html" (dict 
+                "items" $event
+                "type" "events"
+              ) }}
+            {{ end }}
+          </li>
+        {{ end }}
+      </ul>
     </li>
   {{ end }}
 </ul>

--- a/layouts/_partials/sitemap/sections/events.html
+++ b/layouts/_partials/sitemap/sections/events.html
@@ -4,8 +4,20 @@
     <li>
       <a href="{{ .Permalink }}">{{ .Title }}</a>
       {{ $events := where .RegularPagesRecursive "Params.dates.archive" false }}
+
+      {{ $events_slugs := slice }}
+      {{ $unique_events := slice }}
+
+      {{ range $events }}
+        {{ $slug := .Params.slug }}
+        {{ if not (in $events_slugs $slug) }}
+          {{ $events_slugs = $events_slugs | append $slug }}
+          {{ $unique_events = $unique_events | append . }}
+        {{ end }}
+      {{ end }}
+
       {{ partial "sitemap/sections/children.html" (dict 
-        "items" $events
+        "items" $unique_events
         "type" "events"
       ) }}
     </li>

--- a/layouts/_partials/sitemap/sections/events.html
+++ b/layouts/_partials/sitemap/sections/events.html
@@ -9,9 +9,9 @@
       {{ $unique_events := slice }}
 
       {{ range $events }}
-        {{ $slug := .Params.slug }}
-        {{ if not (in $events_slugs $slug) }}
-          {{ $events_slugs = $events_slugs | append $slug }}
+        {{ $event_slug := .Params.slug }}
+        {{ if not (in $events_slugs $event_slug) }}
+          {{ $events_slugs = $events_slugs | append $event_slug }}
           {{ $unique_events = $unique_events | append . }}
         {{ end }}
       {{ end }}

--- a/layouts/_partials/sitemap/sections/events.html
+++ b/layouts/_partials/sitemap/sections/events.html
@@ -5,21 +5,15 @@
       <a href="{{ .Permalink }}">{{ .Title }}</a>
       {{ $events := where .RegularPagesRecursive "Params.dates.archive" false }}
 
-      {{ $events_slugs := slice }}
-      {{ $unique_events := slice }}
-
-      {{ range $events }}
-        {{ $event_slug := .Params.slug }}
-        {{ if not (in $events_slugs $event_slug) }}
-          {{ $events_slugs = $events_slugs | append $event_slug }}
-          {{ $unique_events = $unique_events | append . }}
-        {{ end }}
+      {{/*  Group by slug to avoid duplication of recurring events and parents events with multiple dates  */}}
+      {{ range $events.GroupByParam "slug" }}
+        {{/*  Get only the first event of the group as the group contains duplicated events */}}
+        {{ $event := .Pages | first 1 }}
+        {{ partial "sitemap/sections/children.html" (dict 
+          "items" $event
+          "type" "events"
+        ) }}
       {{ end }}
-
-      {{ partial "sitemap/sections/children.html" (dict 
-        "items" $unique_events
-        "type" "events"
-      ) }}
     </li>
   {{ end }}
 </ul>


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Proposition ouverte sur le fait de trier ou non les événements par mois dans le plan du site.



## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


## Screenshots


<img width="1515" height="982" alt="image" src="https://github.com/user-attachments/assets/43e60534-a869-4646-8791-81bf18dd0d35" />
