### PR TITLE
Header : afficher le bouton i18n même en l'absence de menu

### DIFF
--- a/layouts/_partials/commons/menu.html
+++ b/layouts/_partials/commons/menu.html
@@ -1,6 +1,7 @@
 {{ $kind := .kind }}
 {{ $menu := partial "GetMenu" $kind }}
 {{ $level := .level | default 1 }}
+{{ $has_i18n := .has_i18n }}
 {{ $stop := .stop }}
 {{ $items := $menu.items }}
 {{ $options := index site.Params.menu $kind }}
@@ -9,8 +10,7 @@
 {{ end }}
 {{ $level_options := index $options (printf "level_%d" $level) }}
 {{ $context := .context }}
-
-{{ if $items }}
+{{ if or $items $has_i18n}}
   <ul class="{{ with $level }}nav-level-{{ . }}{{ end }} {{ .class }}">
     {{ range $items }}
       {{ partial "commons/menu/item.html" (dict

--- a/layouts/_partials/commons/menu.html
+++ b/layouts/_partials/commons/menu.html
@@ -10,7 +10,6 @@
 {{ end }}
 {{ $level_options := index $options (printf "level_%d" $level) }}
 {{ $context := .context }}
-
 {{ if or $items $has_i18n}}
   <ul class="{{ with $level }}nav-level-{{ . }}{{ end }} {{ .class }}">
     {{ range $items }}

--- a/layouts/_partials/commons/menu.html
+++ b/layouts/_partials/commons/menu.html
@@ -10,6 +10,7 @@
 {{ end }}
 {{ $level_options := index $options (printf "level_%d" $level) }}
 {{ $context := .context }}
+
 {{ if or $items $has_i18n}}
   <ul class="{{ with $level }}nav-level-{{ . }}{{ end }} {{ .class }}">
     {{ range $items }}

--- a/layouts/_partials/commons/menu/helpers/HasI18n.html
+++ b/layouts/_partials/commons/menu/helpers/HasI18n.html
@@ -1,0 +1,5 @@
+{{ $has_i18n := false }}
+
+{{ if gt (len site.Languages) 1 }}
+  {{ $has_i18n = true}}
+{{ end }}

--- a/layouts/_partials/footer/legals.html
+++ b/layouts/_partials/footer/legals.html
@@ -1,7 +1,12 @@
 {{ $menu := partial "GetMenu" "legal" }}
 {{ $class := "nav-legal" }}
+{{ $has_i18n := false }}
 
-{{ if $menu }}
+{{ if gt (len site.Languages) 1 }}
+  {{ $has_i18n = true}}
+{{ end }}
+
+{{ if or $menu $has_i18n }}
   {{ if not (in site.Params.i18n.positions "footer") }}
     {{ $class = printf "%s without-i18n" $class }}
   {{ end }}
@@ -9,5 +14,6 @@
     "kind" "legal"
     "class" $class
     "context" .
+    "has_i18n" $has_i18n
   ) }}
 {{ end }}

--- a/layouts/_partials/footer/legals.html
+++ b/layouts/_partials/footer/legals.html
@@ -1,10 +1,6 @@
 {{ $menu := partial "GetMenu" "legal" }}
 {{ $class := "nav-legal" }}
-{{ $has_i18n := false }}
-
-{{ if gt (len site.Languages) 1 }}
-  {{ $has_i18n = true}}
-{{ end }}
+{{ $has_i18n := partial "commons/menu/helpers/HasI18n" . }}
 
 {{ if or $menu $has_i18n }}
   {{ if not (in site.Params.i18n.positions "footer") }}

--- a/layouts/_partials/header/header.html
+++ b/layouts/_partials/header/header.html
@@ -19,15 +19,10 @@
   <nav class="primary-menu" aria-label="{{ i18n "commons.menu.main" }}">
     <div class="container">
       {{ partial "header/logo.html" }}
-      {{ if $primary.items }}
-        {{ partial "header/button.html" }}
-        <div class="menu" id="navigation">
-          {{ partial "commons/menu.html" (dict
-            "kind" "primary"
-            "context" .
-          ) }}
-        </div>
-      {{ end }}
+      {{ partial "header/header/menu.html" (dict
+        "context" .
+        "primary" $primary
+      )}}
       {{ partial "header/hooks/before-primary-menu-end.html" . }}
     </div>
   </nav>

--- a/layouts/_partials/header/header/menu.html
+++ b/layouts/_partials/header/header/menu.html
@@ -1,9 +1,5 @@
 {{ $primary := .primary }}
-{{ $has_i18n := false }}
-
-{{ if gt (len site.Languages) 1 }}
-  {{ $has_i18n = true}}
-{{ end }}
+{{ $has_i18n := partial "commons/menu/helpers/HasI18n" . }}
 
 {{ if or $primary.items $has_i18n }}
   {{ partial "header/button.html" }}

--- a/layouts/_partials/header/header/menu.html
+++ b/layouts/_partials/header/header/menu.html
@@ -1,0 +1,17 @@
+{{ $primary := .primary }}
+{{ $has_i18n := false }}
+
+{{ if gt (len site.Languages) 1 }}
+  {{ $has_i18n = true}}
+{{ end }}
+
+{{ if or $primary.items $has_i18n }}
+  {{ partial "header/button.html" }}
+  <div class="menu" id="navigation">
+    {{ partial "commons/menu.html" (dict
+      "kind" "primary"
+      "has_i18n" $has_i18n
+      "context" .
+    ) }}
+  </div>
+{{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Comme il n'y a pas d'item au menu primary sur la version anglaise de FUTURs, on perd le dropdown des langues :
<img width="1320" height="168" alt="Capture d’écran 2026-08-05 à 17 22 28" src="https://github.com/user-attachments/assets/a11b6fca-cc92-4949-ac81-644b6a78d3b4" />

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/641

## URL de test du site FUTURs

`http://localhost:1313/en/`

## Screenshots

<img width="1322" height="194" alt="Capture d’écran 2026-08-05 à 17 22 07" src="https://github.com/user-attachments/assets/6a079db8-e124-4caa-864b-bd4a5737a209" />