### PR TITLE
Actualité : ajustement des signatures

### DIFF
--- a/assets/sass/_theme/sections/posts.sass
+++ b/assets/sass/_theme/sections/posts.sass
@@ -230,6 +230,7 @@
     .document-content
         @include document-min-height(600px)
     .block-signatures
+        margin-bottom: var(--grid-gutter)
         .signatures
             border-top: var(--border-width) solid var(--color-border)
             padding-top: var(--grid-gutter)

--- a/assets/sass/_theme/sections/posts.sass
+++ b/assets/sass/_theme/sections/posts.sass
@@ -234,7 +234,7 @@
             border-top: var(--border-width) solid var(--color-border)
             padding-top: var(--grid-gutter)
             li
-                align-items: flex-start
+                align-items: center
                 display: flex
                 flex-direction: row-reverse
                 gap: var(--grid-gutter)

--- a/layouts/_partials/posts/single/signature.html
+++ b/layouts/_partials/posts/single/signature.html
@@ -6,7 +6,7 @@
           {{ $person := site.GetPage (printf "persons/%s" .Slug) }}
           <li>
             <div class="author-content">
-              <a href="{{ .Permalink }}" itemprop="url">
+              <a href="{{ $person.Permalink }}" itemprop="url">
                 <span itemprop="name">{{ safeHTML .Params.person }}</span>
               </a>
               {{ safeHTML .Params.summary }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

- changement du lien : on renvoie vers la page de la personne et non ses actualités
- alignement vertical désormais centré

Aussi, ajustement des marges, pour un pb bien visible sur CIDS :
<img width="943" height="339" alt="image" src="https://github.com/user-attachments/assets/6acc9250-aa67-4951-9d6e-861465944d2f" />

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/1598

## URL de test sur CIDS

`http://localhost:1313/about/news/2026-06-22-2025-annual-report/`

## URL de test du site jeanlatreille

`http://localhost:1313/publications/2022-02-17-une-fable-pour-lan-3000/`

## Screenshots
<img width="855" height="301" alt="Capture d’écran 2026-08-25 à 12 05 53" src="https://github.com/user-attachments/assets/a88d0711-1da9-4152-99f4-8f76533a9a3e" />
<img width="946" height="318" alt="Capture d’écran 2026-08-25 à 12 05 25" src="https://github.com/user-attachments/assets/2ccac35b-6a1e-4ad8-9a7e-69e32a7b45d9" />


