### PR TITLE
Événement : retirer le bouton de partage sur les archives

### DIFF
--- a/layouts/_partials/events/single/hero.html
+++ b/layouts/_partials/events/single/hero.html
@@ -1,6 +1,10 @@
 {{ $title := partial "header/helpers/GetTitle" . }}
 
 {{ $share := site.Params.events.share_links.enabled | default site.Params.share_links.enabled }}
+{{ if .Params.dates.archive }}
+  {{ $share = false }}
+{{ end }}
+
 {{ $sizes := "" }}
 
 {{ $image := .Params.image }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

On vérifie si l'événement est une archive ou non.
Si oui, le `share` du hero n'est pas présent.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/1601

## URL de test sur example.osuny.org

Archive : `http://localhost:1313/fr/agenda/2025/arte-concert-festival-2025/`
Normal : `http://localhost:1313/fr/agenda/2024/anne-charlotte-finel-respiro/`

## Screenshots

<img width="1918" height="897" alt="Capture d’écran 2026-08-31 à 12 13 42" src="https://github.com/user-attachments/assets/3b853d05-b6ee-4718-ba24-ffa120d5f5bb" />