### PR TITLE
Flux RSS : exclure certaines sections

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -39,7 +39,9 @@ params:
     title:
       separator: "|"
     head_no_referrer: true # see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referer
-
+  rss:
+    ignore:
+      - files
   # DESIGN SYSTEM
   logo:
     header: "/assets/images/logo.svg"

--- a/layouts/_partials/rss/helpers/GetPages.html
+++ b/layouts/_partials/rss/helpers/GetPages.html
@@ -10,7 +10,7 @@
 {{ end }}
 
 {{/*  Section filtering  */}}
-{{ $pages = where $pages "Section" "not in" site.Params.rss.ignore  }}
+{{ $pages = where $pages "Section" "not in" site.Params.rss.ignore }}
 
 {{ $limit := .Site.Config.Services.RSS.Limit }}
 {{ if ge $limit 1 }}

--- a/layouts/_partials/rss/helpers/GetPages.html
+++ b/layouts/_partials/rss/helpers/GetPages.html
@@ -8,6 +8,10 @@
 {{ else }}
   {{ $pages = $pctx.Pages }}
 {{ end }}
+
+{{/*  Section filtering  */}}
+{{ $pages = where $pages "Section" "not in" site.Params.rss.ignore  }}
+
 {{ $limit := .Site.Config.Services.RSS.Limit }}
 {{ if ge $limit 1 }}
   {{ $pages = $pages | first $limit }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Pouvoir ignorer des sections complètes du xml.

```
params: 
  rss:
    ignore:
      - files
```


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
