### PR TITLE
Titre et sous-titre override

### DIFF
--- a/layouts/_partials/commons/item/heading.html
+++ b/layouts/_partials/commons/item/heading.html
@@ -2,7 +2,8 @@
 {{ $level := .level }}
 {{ $type := .type | default $item.Type | default "page" }}
 {{ $type = $type | singularize }}
-{{ $subtitle := $item.Params.subtitle }}
+{{ $title := .title | default $item.Title }}
+{{ $subtitle := .subtitle | default $item.Params.subtitle }}
 {{ $options := .options }}
 {{ $itemprop := .itemprop }}
 
@@ -23,7 +24,7 @@
 {{ $heading_tag.open }}
   {{ $permalink := partial "commons/item/helpers/GetPermalink" $item }}
   <a href="{{ $permalink }}" title="{{ $link_title }}" {{ if $itemprop }} itemprop="url" {{ end }} >
-    {{ $item.Title }}
+    {{ $title }}
   </a>
 {{ $heading_tag.close }}
 {{ if and $options.subtitle $subtitle }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Possibilité de modifier les titres et sous-titres en override.

Par exemple, j'ai besoin d'ajouter le mot "Référence avant le sous-titre des projets. Dans `_partials/projects/partials/project/core/heading.html` : 


```
{{ partial "commons/item/heading.html" (dict
  "item" .item
  "level" .level
  "options" .options
  "subtitle" (prinft "Référence : %s" $subtitle)
) }}
```

## Niveau d'incidence

- [x] Incidence nulle 😌
- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
