### PR TITLE
Bloc organisations : ajustement de la typo des titres

### DIFF
--- a/assets/sass/_theme/sections/organizations.sass
+++ b/assets/sass/_theme/sections/organizations.sass
@@ -1,12 +1,11 @@
 .organization
     &-title
+        @include body-text
         a
             @include stretched-link(before)
             text-decoration: none
             display: block
-    .organizations:not(.with-summaries) &
-        .organization-title
-            @include meta
+
     .media
         background: $organization-background-color
         margin-bottom: $spacing-2
@@ -33,7 +32,6 @@
                 padding-bottom: 100%
     .organization-categories
         @include item-categories-list
-
 
 .organizations
     article
@@ -68,8 +66,6 @@
                 width: 100%
                 .organization-content
                     flex: 1
-                    .organization-title
-                        @include body-text
                     .organization-summary
                         @include small
                 .media
@@ -111,6 +107,10 @@
     &--list
         @include layout-list
 
+        @include media-breakpoint-down(desktop)
+            .organization-title
+                @include h3
+
 .organizations__section
     .organizations
         margin-top: $spacing-4
@@ -140,12 +140,14 @@
                 margin-top: 0
             &:not(:first-child)
                 margin-top: $spacing-5
+
     @include media-breakpoint-down(md)
         .document-content
             .organization-logo
                 margin-top: $spacing-5
                 display: flex
                 justify-content: space-between
+
     @include media-breakpoint-up(md)
         &:not(.full-width)
             .organization-presentation-container


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Dans un bloc en layout liste, on stipule une typo h4 pour la largeur partielle, h3 pour la pleine largeur, mais aucune pour le mobile.
Héritant du style défini pour tous les titres, il prend le style meta et devient tout petit. On lui ajoute donc ici le style du h3, mais peut-être faut-il plutôt utiliser le h4 pour correspondre au style de la semi largeur ?

Le style meta est dû à une différentiation sur le figma entre avec et sans résumé, mais ça donne une bizarrerie (à voir si on la garde, j'ai harmonisé ici).

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

Les overrides sont plus précis au niveau des sélecteurs.

## URL de test sur example.osuny.org

`http://localhost:1314/fr/blocks/blocs-de-liste/organisations-1/`

## URL de test du site noesya

`http://localhost:1313/clients/`

## Screenshots
<img width="372" height="665" alt="Capture d’écran 2026-09-10 à 18 01 29" src="https://github.com/user-attachments/assets/d10de0c9-92e0-426e-9fed-1ec24a5fd080" /><img width="369" height="655" alt="Capture d’écran 2026-09-10 à 18 01 57" src="https://github.com/user-attachments/assets/0349d52f-8b8a-45ec-8fa9-acbd7591ca17" />
